### PR TITLE
Java/EC2: Fix RemoteTarget in Metrics and Traces based on 1.32.1 release

### DIFF
--- a/validator/src/main/resources/expected-data-template/ec2/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/ec2/aws-sdk-call-metric.mustache
@@ -95,7 +95,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Latency
@@ -115,7 +115,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Error
@@ -214,7 +214,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Error
@@ -234,7 +234,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Fault
@@ -333,7 +333,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Fault
@@ -353,6 +353,6 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 

--- a/validator/src/main/resources/expected-data-template/ec2/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/ec2/aws-sdk-call-trace.mustache
@@ -42,7 +42,7 @@
             "aws_local_operation": "^GET /aws-sdk-call$",
             "aws_remote_service": "^AWS\\.SDK\\.S3$",
             "aws_remote_operation": "^GetBucketLocation$",
-            "aws_remote_target": "^e2e-test-bucket-name$"
+            "aws_remote_target": "^::s3:::e2e-test-bucket-name$"
           },
           "metadata": {
             "default": {


### PR DESCRIPTION
ADOT team performed the release of 1.32.1 which updates the RemoteTarget to be the ARN of the S3 bucket instead of the name of the S3 bucket for AWS SDK call.

Updating the EC2 validations accordingly as the new ADOT Jar has been released. Will coordinate with ADOT team on the schedule of the release for EKS so we can update the EKS test as well.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

