### PR TITLE
S3 Django Sample App Deployment workflow

### DIFF
--- a/.github/workflows/django-sample-app-s3-deploy.yml
+++ b/.github/workflows/django-sample-app-s3-deploy.yml
@@ -4,6 +4,7 @@
 name: App Signals Enablement - S3 Springboot Sample App Deployment
 on:
   workflow_dispatch: # be able to run the workflow on demand
+  push:
 
 permissions:
   id-token: write

--- a/.github/workflows/django-sample-app-s3-deploy.yml
+++ b/.github/workflows/django-sample-app-s3-deploy.yml
@@ -4,6 +4,7 @@
 name: App Signals Enablement - S3 Django Sample App Deployment
 on:
   workflow_dispatch: # be able to run the workflow on demand
+  push:
 
 permissions:
   id-token: write

--- a/.github/workflows/django-sample-app-s3-deploy.yml
+++ b/.github/workflows/django-sample-app-s3-deploy.yml
@@ -63,6 +63,8 @@ jobs:
       - name: Upload to S3
         working-directory: sample-apps/python
         run: |
+          print("APP_SIGNALS_E2E_EC2_JAR!!!!!!!!!")
+          print(${{ secrets.APP_SIGNALS_E2E_EC2_JAR }})
           aws s3api put-object --bucket ${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ matrix.aws-region }} --body ./${{ secrets.ADOT_WHEEL_NAME }} --key ${{ secrets.ADOT_WHEEL_NAME }}
           aws s3api put-object --bucket ${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ matrix.aws-region }} --body ./python-sample-app.zip --key python-sample-app.zip
 

--- a/.github/workflows/django-sample-app-s3-deploy.yml
+++ b/.github/workflows/django-sample-app-s3-deploy.yml
@@ -64,7 +64,6 @@ jobs:
       - name: Upload to S3
         working-directory: sample-apps/python
         run: |
-          print("APP_SIGNALS_E2E_EC2_JAR!!!!!!!!!")
           print(${{ secrets.APP_SIGNALS_E2E_EC2_JAR }})
           aws s3api put-object --bucket ${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ matrix.aws-region }} --body ./${{ secrets.ADOT_WHEEL_NAME }} --key ${{ secrets.ADOT_WHEEL_NAME }}
           aws s3api put-object --bucket ${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ matrix.aws-region }} --body ./python-sample-app.zip --key python-sample-app.zip

--- a/.github/workflows/django-sample-app-s3-deploy.yml
+++ b/.github/workflows/django-sample-app-s3-deploy.yml
@@ -4,7 +4,6 @@
 name: App Signals Enablement - S3 Django Sample App Deployment
 on:
   workflow_dispatch: # be able to run the workflow on demand
-  push:
 
 permissions:
   id-token: write
@@ -24,17 +23,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      # TODO: Remove this step after ADOT python published to PyPI
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::637423224110:role/pulse-enablement-workflow-role
-          aws-region: us-east-1
-
-      # TODO: Remove this step after ADOT python published to PyPI
-      - name: Get Adot Wheel file
-        run: aws s3 cp s3://adot-autoinstrumentation-python-staging/${{ secrets.ADOT_WHEEL_NAME }} ./sample-apps/python/${{ secrets.ADOT_WHEEL_NAME }}
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -60,10 +48,7 @@ jobs:
         working-directory: sample-apps/python
         run: zip -r python-sample-app.zip .
 
-      # TODO: Remove put ADOT_WHEEL_NAME to S3 after ADOT python published to PyPI
       - name: Upload to S3
         working-directory: sample-apps/python
-        run: |
-          aws s3api put-object --bucket ${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ matrix.aws-region }} --body ./${{ secrets.ADOT_WHEEL_NAME }} --key ${{ secrets.ADOT_WHEEL_NAME }}
-          aws s3api put-object --bucket ${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ matrix.aws-region }} --body ./python-sample-app.zip --key python-sample-app.zip
+        run: aws s3api put-object --bucket ${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ matrix.aws-region }} --body ./python-sample-app.zip --key python-sample-app.zip
 

--- a/.github/workflows/django-sample-app-s3-deploy.yml
+++ b/.github/workflows/django-sample-app-s3-deploy.yml
@@ -1,0 +1,68 @@
+## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+
+name: App Signals Enablement - S3 Springboot Sample App Deployment
+on:
+  workflow_dispatch: # be able to run the workflow on demand
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  upload-sample-app-zip:
+    strategy:
+      fail-fast: false
+      matrix:
+        aws-region: [ 'af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
+                      'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
+                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+                      'us-east-1','us-east-2', 'us-west-1', 'us-west-2' ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # TODO: Remove this step after ADOT python published to PyPI
+      - name: Configure AWS Credentials
+          uses: aws-actions/configure-aws-credentials@v4
+          with:
+            role-to-assume: arn:aws:iam::637423224110:role/pulse-enablement-workflow-role
+            aws-region: us-east-1
+
+      # TODO: Remove this step after ADOT python published to PyPI
+      - name: Get Adot Wheel file
+        run: aws s3 cp s3://adot-autoinstrumentation-python-staging/${{ secrets.ADOT_WHEEL_NAME }} ./sample-apps/python/${{ secrets.ADOT_WHEEL_NAME }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.E2E_SECRET_TEST_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Retrieve account
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        with:
+          secret-ids:
+            ACCOUNT_ID, region-account/${{ matrix.aws-region }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ secrets.E2E_TEST_ROLE_ARN }}
+          aws-region: ${{ matrix.aws-region }}
+
+
+
+      - name: Build Sample App Zip
+        working-directory: sample-apps/python
+        run: zip -r python-sample-app.zip .
+
+      # TODO: Remove put ADOT_WHEEL_NAME to S3 after ADOT python published to PyPI
+      - name: Upload to S3
+        working-directory: sample-apps/python
+        run: |
+          aws s3api put-object --bucket ${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ matrix.aws-region }} --body ./${{ secrets.ADOT_WHEEL_NAME }} --key ${{ secrets.ADOT_WHEEL_NAME }}
+          aws s3api put-object --bucket ${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ matrix.aws-region }} --body ./python-sample-app.zip --key python-sample-app.zip
+

--- a/.github/workflows/django-sample-app-s3-deploy.yml
+++ b/.github/workflows/django-sample-app-s3-deploy.yml
@@ -64,7 +64,6 @@ jobs:
       - name: Upload to S3
         working-directory: sample-apps/python
         run: |
-          print(${{ secrets.APP_SIGNALS_E2E_EC2_JAR }})
           aws s3api put-object --bucket ${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ matrix.aws-region }} --body ./${{ secrets.ADOT_WHEEL_NAME }} --key ${{ secrets.ADOT_WHEEL_NAME }}
           aws s3api put-object --bucket ${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ matrix.aws-region }} --body ./python-sample-app.zip --key python-sample-app.zip
 

--- a/.github/workflows/django-sample-app-s3-deploy.yml
+++ b/.github/workflows/django-sample-app-s3-deploy.yml
@@ -1,10 +1,9 @@
 ## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 ## SPDX-License-Identifier: Apache-2.0
 
-name: App Signals Enablement - S3 Springboot Sample App Deployment
+name: App Signals Enablement - S3 Django Sample App Deployment
 on:
   workflow_dispatch: # be able to run the workflow on demand
-  push:
 
 permissions:
   id-token: write

--- a/.github/workflows/django-sample-app-s3-deploy.yml
+++ b/.github/workflows/django-sample-app-s3-deploy.yml
@@ -26,10 +26,10 @@ jobs:
 
       # TODO: Remove this step after ADOT python published to PyPI
       - name: Configure AWS Credentials
-          uses: aws-actions/configure-aws-credentials@v4
-          with:
-            role-to-assume: arn:aws:iam::637423224110:role/pulse-enablement-workflow-role
-            aws-region: us-east-1
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::637423224110:role/pulse-enablement-workflow-role
+          aws-region: us-east-1
 
       # TODO: Remove this step after ADOT python published to PyPI
       - name: Get Adot Wheel file


### PR DESCRIPTION
This PR create App Signals Enablement - S3 Django Sample App Deployment workflow to upload sample app ZIP file to all regions similar as [App Signals Enablement - S3 Springboot Sample App Deployment](https://github.com/aws-observability/aws-application-signals-test-framework/blob/main/.github/workflows/springboot-sample-app-s3-deploy.yml).

The difference between Java is:
In python, we only need one zip file compressing two sample app micro-services instead of two.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

