### PR TITLE
Update Sample Apps aws-sdk-call API to optionally uniquely name S3 Buckets

### DIFF
--- a/sample-apps/python/django_frontend_service/frontend_service_app/views.py
+++ b/sample-apps/python/django_frontend_service/frontend_service_app/views.py
@@ -47,8 +47,12 @@ def healthcheck(request):
 
 def aws_sdk_call(request):
     bucket_name = "e2e-test-bucket-name"
-    s3_client = boto3.client("s3")
 
+    # Add an (pod) ID to bucketname to associate buckets to specific test runs
+    ip = request.GET.get('ip', None)
+    if ip is not None:
+        bucket_name += "-" + ip
+    s3_client = boto3.client("s3")
     try:
         s3_client.get_bucket_location(
             Bucket=bucket_name,

--- a/sample-apps/springboot/src/main/java/com/amazon/sampleapp/FrontendServiceController.java
+++ b/sample-apps/springboot/src/main/java/com/amazon/sampleapp/FrontendServiceController.java
@@ -80,9 +80,14 @@ public class FrontendServiceController {
   // test aws calls instrumentation
   @GetMapping("/aws-sdk-call")
   @ResponseBody
-  public String awssdkCall() {
+  public String awssdkCall(@RequestParam(name = "ip", required = false) String ip) {
+    String bucketName = "e2e-test-bucket-name";
+    // Add an (pod) ID to bucketname to associate buckets to specific test runs
+    if (ip != null) {
+      bucketName += "-" + ip;
+    }
     GetBucketLocationRequest bucketLocationRequest =
-        GetBucketLocationRequest.builder().bucket("e2e-test-bucket-name").build();
+        GetBucketLocationRequest.builder().bucket(bucketName).build();
     try {
       s3.getBucketLocation(bucketLocationRequest);
     } catch (Exception e) {


### PR DESCRIPTION
*Issue #, if available:*
Blocker for metric rollup test cases - https://github.com/aws-observability/aws-otel-java-instrumentation/pull/729
Context: We want to update the aws-sdk-call api to take in an identifier (like Pod_IP) and use that in the bucket name (e.g. e2e-test-bucket-name-<Pod_IP>). Then the tests will need to specify this ID in queries that include RemoteTarget dimension.

*Description of changes:*
- Allow aws-sdk-call api to take in an optional ID to add to bucketname to associate buckets to specific test runs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*Testing*:
Build and run app locally. Ensured that IP is optional field and previous logic still works.
