### PR TITLE
[Python E2E Sample App] Update healthcheck API naming

### DIFF
--- a/sample-apps/python/django_frontend_service/frontend_service_app/views.py
+++ b/sample-apps/python/django_frontend_service/frontend_service_app/views.py
@@ -1,12 +1,13 @@
 ## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 ## SPDX-License-Identifier: Apache-2.0
-from django.http import HttpResponse, JsonResponse
-import boto3
 import logging
+import threading
+import time
+
+import boto3
 import requests
 import schedule
-import time
-import threading
+from django.http import HttpResponse, JsonResponse
 from opentelemetry import trace
 from opentelemetry.trace.span import format_trace_id
 
@@ -75,7 +76,7 @@ def http_call(request):
 def downstream_service(request):
     ip = request.GET.get('ip', '')
     ip = ip.replace("/", "")
-    url = f"http://{ip}:8001/health-check"
+    url = f"http://{ip}:8001/healthcheck"
     try:
         response = requests.get(url)
         status_code = response.status_code

--- a/sample-apps/python/django_remote_service/django_remote_service/urls.py
+++ b/sample-apps/python/django_remote_service/django_remote_service/urls.py
@@ -4,5 +4,5 @@ from django.urls import path
 from remote_service_app import views
 
 urlpatterns = [
-    path('health-check', views.healthcheck),
+    path('healthcheck', views.healthcheck),
 ]


### PR DESCRIPTION
*Issue #, if available:*
Make healthcheck API url and API call consistent with Java Sample App. This will make help allow the E2E python tests use the existing validations.

*Description of changes:*
`health-check` -> `healthcheck`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

