### PR TITLE
Add Temporary Addon Version

### DIFF
--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Temporary override addon version
         working-directory: enablement-script/scripts/eks/appsignals
         run: |
-          sed -i '61 a--addon-version v1.2.2-eksbuild.1 \\' enable-app-signals.sh
+          sed -i '\#--addon-name amazon-cloudwatch-observability \\#a--addon-version v1.2.2-eksbuild.1 \\' enable-app-signals.sh
 
       - name: Remove log group deletion command
         if: always()

--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -56,6 +56,12 @@ jobs:
             scripts/eks/appsignals/clean-app-signals.sh
           sparse-checkout-cone-mode: false
 
+      # TODO: remove this step next Monday and update validator with appropriate changes
+      - name: Temporary override addon version
+        working-directory: enablement-script/scripts/eks/appsignals
+        run: |
+          sed -i '61 a--addon-version v1.2.2-eksbuild.1 \\' enable-app-signals.sh
+
       - name: Remove log group deletion command
         if: always()
         working-directory: enablement-script/scripts/eks/appsignals


### PR DESCRIPTION
*Issue #, if available:*
The add-on will be updated in the near future, which will cause failures in the canary. Temporarily use the current version rather than the latest to allow time to make changes in the validators

*Description of changes:*
Add an argument in the enablement script to use version 1.2.2

Test run with v1.2.0: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8179952573/job/22367041619#step:17:485
Test run with v1.2.2: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8180038601/job/22367286009#step:17:485

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

