### PR TITLE
Update clean-app-signals.sh location

### DIFF
--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -222,7 +222,7 @@ jobs:
             # resources created from terraform and try again.
             if [ $deployment_failed -eq 1 ]; then
               echo "Cleaning up App Signal"
-              ./clean-app-signals.sh \
+              ${{ env.TEST_RESOURCES_FOLDER }}/enablement-script/scripts/eks/appsignals/clean-app-signals.sh \
               ${{ inputs.test-cluster-name }} \
               ${{ inputs.aws-region }} \
               ${{ env.SAMPLE_APP_NAMESPACE }}


### PR DESCRIPTION
*Issue #, if available:*
The retry mechanism on deploy sample app for eks is currently failing due to the location of clean-app-signals.sh being outdated
*Description of changes:*
Update the script location

Test run with no fails: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8180355427/job/22368214659

Test run with fail: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8180295607/job/22368039068#step:18:1509

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

