### PR TITLE
Java/EKS: Fix RemoteTarget in Metrics and Traces based on AppSignals Add-on 1.3.0

### DIFF
--- a/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-metric.mustache
@@ -113,7 +113,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Latency
@@ -136,7 +136,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Error
@@ -253,7 +253,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Error
@@ -276,7 +276,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Fault
@@ -393,7 +393,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Fault
@@ -416,4 +416,4 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name

--- a/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-trace.mustache
@@ -44,7 +44,7 @@
             "aws_local_operation": "^GET /aws-sdk-call$",
             "aws_remote_service": "^AWS\\.SDK\\.S3$",
             "aws_remote_operation": "GetBucketLocation",
-            "aws_remote_target": "e2e-test-bucket-name"
+            "aws_remote_target": "^::s3:::e2e-test-bucket-name$"
           },
           "metadata": {
             "default": {


### PR DESCRIPTION
Update: Added the changes in this [PR](https://github.com/aws-observability/aws-application-signals-test-framework/pull/18)

According to the latest changes in ADOT, the RemoteTarget will be the ARN of the S3 bucket instead of the name of the S3 bucket for AWS SDK call.

Updating the EKS validations accordingly. 

Based on this PR: https://github.com/aws-observability/aws-application-signals-test-framework/pull/1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

