### PR TITLE
Fix S3 aws.region to be us-east-1.

### DIFF
--- a/validator/src/main/resources/expected-data-template/python/ec2/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/aws-sdk-call-trace.mustache
@@ -34,7 +34,7 @@
         }
       },
       "aws": {
-        "region": "{{region}}",
+        "region": "us-east-1",
         "operation": "^GetBucketLocation$"
       },
       "annotations": {


### PR DESCRIPTION
*Issue #, if available:*
 No matter which region use to sample app to receive the client call, the` aws.region` is always us-east-1 in the span for S3 related call. So, this PR hard code it for python E2E test.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

