### PR TITLE
Update Sample Apps aws-sdk-call param name to indicate Test ID

### DIFF
--- a/sample-apps/python/django_frontend_service/frontend_service_app/views.py
+++ b/sample-apps/python/django_frontend_service/frontend_service_app/views.py
@@ -50,9 +50,9 @@ def aws_sdk_call(request):
     bucket_name = "e2e-test-bucket-name"
 
     # Add an (pod) ID to bucketname to associate buckets to specific test runs
-    ip = request.GET.get('ip', None)
-    if ip is not None:
-        bucket_name += "-" + ip
+    bucket_id = request.GET.get('id', None)
+    if bucket_id is not None:
+        bucket_name += "-" + bucket_id
     s3_client = boto3.client("s3")
     try:
         s3_client.get_bucket_location(

--- a/sample-apps/python/django_frontend_service/frontend_service_app/views.py
+++ b/sample-apps/python/django_frontend_service/frontend_service_app/views.py
@@ -49,16 +49,18 @@ def healthcheck(request):
 def aws_sdk_call(request):
     bucket_name = "e2e-test-bucket-name"
 
-    # Add an (pod) ID to bucketname to associate buckets to specific test runs
-    bucket_id = request.GET.get('id', None)
-    if bucket_id is not None:
-        bucket_name += "-" + bucket_id
+    # Add a unique test ID to bucketname to associate buckets to specific test runs
+    testing_id = request.GET.get('testingId', None)
+    if testing_id is not None:
+        bucket_name += "-" + testing_id
     s3_client = boto3.client("s3")
     try:
         s3_client.get_bucket_location(
             Bucket=bucket_name,
         )
     except Exception as e:
+        # bucket_name does not exist, so this is expected.
+        logger.error("Error occurred when trying to get bucket location of: " + bucket_name)
         logger.error("Could not retrieve http request:" + str(e))
 
     return get_xray_trace_id()

--- a/sample-apps/springboot/src/main/java/com/amazon/sampleapp/FrontendServiceController.java
+++ b/sample-apps/springboot/src/main/java/com/amazon/sampleapp/FrontendServiceController.java
@@ -80,11 +80,11 @@ public class FrontendServiceController {
   // test aws calls instrumentation
   @GetMapping("/aws-sdk-call")
   @ResponseBody
-  public String awssdkCall(@RequestParam(name = "ip", required = false) String ip) {
+  public String awssdkCall(@RequestParam(name = "id", required = false) String id) {
     String bucketName = "e2e-test-bucket-name";
     // Add an (pod) ID to bucketname to associate buckets to specific test runs
-    if (ip != null) {
-      bucketName += "-" + ip;
+    if (id != null) {
+      bucketName += "-" + id;
     }
     GetBucketLocationRequest bucketLocationRequest =
         GetBucketLocationRequest.builder().bucket(bucketName).build();

--- a/sample-apps/springboot/src/main/java/com/amazon/sampleapp/FrontendServiceController.java
+++ b/sample-apps/springboot/src/main/java/com/amazon/sampleapp/FrontendServiceController.java
@@ -80,18 +80,19 @@ public class FrontendServiceController {
   // test aws calls instrumentation
   @GetMapping("/aws-sdk-call")
   @ResponseBody
-  public String awssdkCall(@RequestParam(name = "id", required = false) String id) {
+  public String awssdkCall(@RequestParam(name = "testingId", required = false) String testingId) {
     String bucketName = "e2e-test-bucket-name";
-    // Add an (pod) ID to bucketname to associate buckets to specific test runs
-    if (id != null) {
-      bucketName += "-" + id;
+    // Add a unique test ID to bucketname to associate buckets to specific test runs
+    if (testingId != null) {
+      bucketName += "-" + testingId;
     }
     GetBucketLocationRequest bucketLocationRequest =
         GetBucketLocationRequest.builder().bucket(bucketName).build();
     try {
       s3.getBucketLocation(bucketLocationRequest);
     } catch (Exception e) {
-      // e2e-test-bucket-name does not exist, so this is expected.
+      // bucketName does not exist, so this is expected.
+      logger.error("Error occurred when trying to get bucket location of: " + bucketName);
       logger.error("Could not retrieve http request:" + e.getLocalizedMessage());
     }
     return getXrayTraceId();


### PR DESCRIPTION
*Issue #, if available:*
Followup on https://github.com/aws-observability/aws-application-signals-test-framework/pull/7
In the future, when new metric rollup tests are added for `aws-sdk-call`, the S3 bucket name will have the workflow `Testing ID` appended to it, not the IP.

*Description of changes:*
Rename parameter `ip` to `testingId` for `aws-sdk-call` endpoint in each sample app

*Testing:*
Python and Java updated sample apps were uploaded to personal AWS account's S3 and ECR to be used in the following test runs:

IAD - EKS Java - https://github.com/jj22ee/aws-application-signals-test-framework/actions/runs/8303126176
IAD - EC2 Java - https://github.com/jj22ee/aws-application-signals-test-framework/actions/runs/8303094447
IAD - EKS Python - https://github.com/jj22ee/aws-application-signals-test-framework/actions/runs/8303096750
IAD - EC2 Python - https://github.com/jj22ee/aws-application-signals-test-framework/actions/runs/8303095306
 
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

