### PR TITLE
Increase metric validation wait time to ~15 minutes

### DIFF
--- a/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/CWMetricValidator.java
@@ -40,7 +40,7 @@ import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 public class CWMetricValidator implements IValidator {
-  private static int DEFAULT_MAX_RETRY_COUNT = 30;
+  private static int DEFAULT_MAX_RETRY_COUNT = 80;
 
   private MustacheHelper mustacheHelper = new MustacheHelper();
   private ICaller caller;


### PR DESCRIPTION
*Issue #, if available:*
The eu-central-2 eks canary frequently fails due to missing metric during the metric validation phase. Previously, the metric validation retry time was increased from ~2 minutes to ~6 minutes, but the validation issue persisted. 

Testing shows that the missing metrics takes time to appear and it takes up to around ~12 minutes.
- https://github.com/harrryr/aws-application-signals-test-framework/actions/runs/8323061826/job/22771967236
- https://github.com/harrryr/aws-application-signals-test-framework/actions/runs/8319180758/job/22762076946
- https://github.com/harrryr/aws-application-signals-test-framework/actions/runs/8318353455/job/22760197332


*Description of changes:*
Increase the retry time during the metric validation phase to ~15 minutes. This will very likely cause the canary to frequently be delayed by ~5 minutes, but since usual runs are around ~9 minute and this error occurs around once a day, it should be able to catch back up to schedule.

Test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8324877527/job/22777377535

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

