### PR TITLE
Add extra fixes for E2E canary transient errors

### DIFF
--- a/.github/workflows/actions/execute_and_retry/action.yml
+++ b/.github/workflows/actions/execute_and_retry/action.yml
@@ -27,41 +27,34 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Run pre-command
-      shell: bash
-      env:
-        PRE_COMMAND: ${{ inputs.pre-command }}
-      run: |
-        $PRE_COMMAND
-
     - name: Run command
       shell: bash
       env:
+        PRE_COMMAND: ${{ inputs.pre-command }}
         MAX_RETRY: ${{ inputs.max_retry }}
         COMMAND: ${{ inputs.command }}
         CLEANUP: ${{ inputs.cleanup }}
+        POST_COMMAND: ${{ inputs.post-command }}
       run: |
+        eval "$PRE_COMMAND"
+        
         retry_counter=0
         while [ $retry_counter -lt $MAX_RETRY ]; do
-        attempt_failed=0
-        eval "$COMMAND" || attempt_failed=$?
-
-        if [ $attempt_failed -ne 0 ]; then
-          eval "$CLEANUP"
-          retry_counter=$(($retry_counter+1))
-          sleep 5
-        else
-          break
-        fi
-
-        if [ $retry_counter -eq $max_retry ]; then
-          echo "Max retry reached, command failed to execute properly. Exiting code"
-          exit 1
-        fi
+          attempt_failed=0
+          eval "$COMMAND" || attempt_failed=$?
+  
+          if [ $attempt_failed -ne 0 ]; then
+            eval "$CLEANUP"
+            retry_counter=$(($retry_counter+1))
+            sleep 5
+          else
+            break
+          fi
+  
+          if [ $retry_counter -eq $max_retry ]; then
+            echo "Max retry reached, command failed to execute properly. Exiting code"
+            exit 1
+          fi
         done
-
-    - name: Run post command
-      shell: bash
-      env:
-        POST_COMMAND: ${{ inputs.post-command }}
-      run: $POST_COMMAND
+        
+        eval "$POST_COMMAND"

--- a/.github/workflows/appsignals-e2e-ec2-test.yml
+++ b/.github/workflows/appsignals-e2e-ec2-test.yml
@@ -68,8 +68,8 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         with:
           command: "wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg"
-          post-command: 'echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list \
-          sudo apt update && sudo apt install terraform'
+          post-command: 'echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          && sudo apt update && sudo apt install terraform'
 
       - name: Initiate Terraform
         uses: ./.github/workflows/actions/execute_and_retry
@@ -180,8 +180,9 @@ jobs:
       - name: Build Gradlew
         uses: ./.github/workflows/actions/execute_and_retry
         with:
-          max_retry: 4
+          max_retry: 2
           command: "./gradlew"
+          cleanup: "./gradlew clean"
 
       # Validation for pulse telemetry data
       - name: Validate generated EMF logs

--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -46,25 +46,23 @@ jobs:
           fetch-depth: 0
 
       - name: Download enablement script
-        uses: actions/checkout@v4
+        uses: ./.github/workflows/actions/execute_and_retry
         with:
-          repository: aws-observability/application-signals-demo
-          ref: main
-          path: enablement-script
-          sparse-checkout: |
-            scripts/eks/appsignals/enable-app-signals.sh
-            scripts/eks/appsignals/clean-app-signals.sh
-          sparse-checkout-cone-mode: false
+          pre-command: "mkdir enablement-script && cd enablement-script"
+          command: "wget https://raw.githubusercontent.com/aws-observability/application-signals-demo/main/scripts/eks/appsignals/enable-app-signals.sh 
+          && wget https://raw.githubusercontent.com/aws-observability/application-signals-demo/main/scripts/eks/appsignals/clean-app-signals.sh"
+          cleanup: "rm -f enable-app-signals.sh && rm -f clean-app-signals.sh"
+          post-command: "chmod +x enable-app-signals.sh && chmod +x clean-app-signals.sh"
 
       # TODO: remove this step next Monday and update validator with appropriate changes
       - name: Temporary override addon version
-        working-directory: enablement-script/scripts/eks/appsignals
+        working-directory: enablement-script
         run: |
           sed -i '\#--addon-name amazon-cloudwatch-observability \\#a--addon-version v1.2.2-eksbuild.1 \\' enable-app-signals.sh
 
       - name: Remove log group deletion command
         if: always()
-        working-directory: enablement-script/scripts/eks/appsignals
+        working-directory: enablement-script
         run: |
           delete_log_group="aws logs delete-log-group --log-group-name '${{ env.LOG_GROUP_NAME }}' --region \$REGION"
           sed -i "s#$delete_log_group##g" clean-app-signals.sh
@@ -100,15 +98,16 @@ jobs:
       - name: Set up kubeconfig
         run: aws eks update-kubeconfig --name ${{ inputs.test-cluster-name }} --region ${{ inputs.aws-region }}
 
-      - name: Download eksctl
+      - name: Download and install eksctl
         uses: ./.github/workflows/actions/execute_and_retry
         with:
           pre-command: 'mkdir ${{ github.workspace }}/eksctl'
-          command: 'curl -sLO "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_Linux_amd64.tar.gz"'
+          command: 'curl -sLO "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_Linux_amd64.tar.gz" 
+          && tar -xzf eksctl_Linux_amd64.tar.gz -C ${{ github.workspace }}/eksctl && rm eksctl_Linux_amd64.tar.gz'
+          cleanup: 'rm -f eksctl_Linux_amd64.tar.gz'
 
-      - name: Install eksctl
+      - name: Add eksctl to Github Path
         run: |
-          tar -xzf eksctl_Linux_amd64.tar.gz -C ${{ github.workspace }}/eksctl && rm eksctl_Linux_amd64.tar.gz
           echo "${{ github.workspace }}/eksctl" >> $GITHUB_PATH
 
       - name: Create role for AWS access from the sample app
@@ -128,8 +127,8 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         with:
           command: "wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg"
-          post-command: 'echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list \
-          sudo apt update && sudo apt install terraform'
+          post-command: 'echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          && sudo apt update && sudo apt install terraform'
 
       - name: Initiate Terraform
         uses: ./.github/workflows/actions/execute_and_retry
@@ -171,18 +170,18 @@ jobs:
             if [ $deployment_failed -eq 0 ]; then
               source ${{ env.TEST_RESOURCES_FOLDER }}/.github/workflows/util/execute_and_retry.sh
               execute_and_retry 2 \
-              "${{ env.TEST_RESOURCES_FOLDER }}/enablement-script/scripts/eks/appsignals/enable-app-signals.sh \
+              "${{ env.TEST_RESOURCES_FOLDER }}/enablement-script/enable-app-signals.sh \
               ${{ inputs.test-cluster-name }} \
               ${{ inputs.aws-region }} \
               ${{ env.SAMPLE_APP_NAMESPACE }}" \
-              "${{ env.TEST_RESOURCES_FOLDER }}/enablement-script/scripts/eks/appsignals/clean-app-signals.sh \
+              "${{ env.TEST_RESOURCES_FOLDER }}/enablement-script/clean-app-signals.sh \
               ${{ inputs.test-cluster-name }} \
               ${{ inputs.aws-region }} \
               ${{ env.SAMPLE_APP_NAMESPACE }} && \
               aws eks update-kubeconfig --name ${{ inputs.test-cluster-name }} --region ${{ inputs.aws-region }}"
           
-              kubectl delete pods --all -n ${{ env.SAMPLE_APP_NAMESPACE }}
-              kubectl wait --for=condition=Ready pod --all -n ${{ env.SAMPLE_APP_NAMESPACE }}
+              execute_and_retry 1 "kubectl delete pods --all -n ${{ env.SAMPLE_APP_NAMESPACE }}"
+              execute_and_retry 1 "kubectl wait --for=condition=Ready pod --all -n ${{ env.SAMPLE_APP_NAMESPACE }}"
           
               echo "Attempting to connect to the main sample app endpoint"
               main_sample_app_endpoint=http://$(terraform output sample_app_endpoint)
@@ -222,7 +221,7 @@ jobs:
             # resources created from terraform and try again.
             if [ $deployment_failed -eq 1 ]; then
               echo "Cleaning up App Signal"
-              ${{ env.TEST_RESOURCES_FOLDER }}/enablement-script/scripts/eks/appsignals/clean-app-signals.sh \
+              ${{ env.TEST_RESOURCES_FOLDER }}/enablement-script/clean-app-signals.sh \
               ${{ inputs.test-cluster-name }} \
               ${{ inputs.aws-region }} \
               ${{ env.SAMPLE_APP_NAMESPACE }}
@@ -283,8 +282,9 @@ jobs:
       - name: Build Gradlew
         uses: ./.github/workflows/actions/execute_and_retry
         with:
-          max_retry: 4
+          max_retry: 2
           command: "./gradlew"
+          cleanup: "./gradlew clean"
 
       # Validation for app signals telemetry data
       - name: Call endpoint and validate generated EMF logs
@@ -361,7 +361,7 @@ jobs:
       - name: Clean Up App Signals
         if: always()
         continue-on-error: true
-        working-directory: enablement-script/scripts/eks/appsignals
+        working-directory: enablement-script
         run: |
           ./clean-app-signals.sh \
           ${{ inputs.test-cluster-name }} \
@@ -372,7 +372,7 @@ jobs:
       - name: Delete all sample app resources
         if: always()
         continue-on-error: true
-        timeout-minutes: 10
+        timeout-minutes: 5
         run: kubectl delete namespace ${{ env.SAMPLE_APP_NAMESPACE }}
 
       - name: Terraform destroy

--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -181,7 +181,7 @@ jobs:
               aws eks update-kubeconfig --name ${{ inputs.test-cluster-name }} --region ${{ inputs.aws-region }}"
           
               execute_and_retry 1 "kubectl delete pods --all -n ${{ env.SAMPLE_APP_NAMESPACE }}"
-              execute_and_retry 1 "kubectl wait --for=condition=Ready pod --all -n ${{ env.SAMPLE_APP_NAMESPACE }}"
+              execute_and_retry 1 "kubectl wait --for=condition=Ready --request-timeout '5m' pod --all -n ${{ env.SAMPLE_APP_NAMESPACE }}"
           
               echo "Attempting to connect to the main sample app endpoint"
               main_sample_app_endpoint=http://$(terraform output sample_app_endpoint)


### PR DESCRIPTION
*Issue #, if available:*
Several transient issues have occurred after the recent PR to add retries. This PR will add more retries to steps and also edit cleanup commands for retries that failed due to inadequate cleanup procedures. 

*Description of changes:*
- Modify the retry action
- Add retries to enablement script download and kubectl wait
- Modify Gradlew cleanup command
- Reduce namespace deletion timeout to 5 minutes
- Combine eksctl setup steps

Test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8332990028
Test run after adding timeout: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8334985940

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

