### PR TITLE
Fix Variable Sharing Error in execute_and_retry.sh Script

### DIFF
--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -180,8 +180,8 @@ jobs:
               ${{ env.SAMPLE_APP_NAMESPACE }} && \
               aws eks update-kubeconfig --name ${{ inputs.test-cluster-name }} --region ${{ inputs.aws-region }}"
           
-              execute_and_retry 1 "kubectl delete pods --all -n ${{ env.SAMPLE_APP_NAMESPACE }}"
-              execute_and_retry 1 "kubectl wait --for=condition=Ready --request-timeout '5m' pod --all -n ${{ env.SAMPLE_APP_NAMESPACE }}"
+              execute_and_retry 2 "kubectl delete pods --all -n ${{ env.SAMPLE_APP_NAMESPACE }}"
+              execute_and_retry 2 "kubectl wait --for=condition=Ready --request-timeout '5m' pod --all -n ${{ env.SAMPLE_APP_NAMESPACE }}"
           
               echo "Attempting to connect to the main sample app endpoint"
               main_sample_app_endpoint=http://$(terraform output sample_app_endpoint)

--- a/.github/workflows/util/execute_and_retry.sh
+++ b/.github/workflows/util/execute_and_retry.sh
@@ -5,23 +5,23 @@
 # $2: Command to execute
 # $3: (Optional) Command for cleaning up resources if $2 fails
 execute_and_retry () {
-  retry_counter=0
-  max_retry=$1
+  execute_retry_counter=0
+  max_execute_retry=$1
   command=$2
   cleanup=$3
-  while [ $retry_counter -lt $max_retry ]; do
+  while [ $execute_retry_counter -lt $max_execute_retry ]; do
    attempt_failed=0
    eval "$command" || attempt_failed=$?
 
    if [ $attempt_failed -ne 0 ]; then
      eval "$cleanup"
-     retry_counter=$(($retry_counter+1))
+     execute_retry_counter=$(($execute_retry_counter+1))
      sleep 5
    else
      break
    fi
 
-   if [ $retry_counter -eq $max_retry ]; then
+   if [ $execute_retry_counter -eq $max_execute_retry ]; then
      echo "Max retry reached, command failed to execute properly. Exiting code"
      exit 1
    fi

--- a/.github/workflows/util/execute_and_retry.sh
+++ b/.github/workflows/util/execute_and_retry.sh
@@ -5,6 +5,8 @@
 # $2: Command to execute
 # $3: (Optional) Command for cleaning up resources if $2 fails
 execute_and_retry () {
+  # Warning: The variables called in this function are not local and will be shared with the calling function.
+  # Make sure that the variable names do not conflict
   execute_retry_counter=0
   max_execute_retry=$1
   command=$2


### PR DESCRIPTION
*Issue #, if available:*
Some of the variable names used by the `execute_and_retry.sh` script are the same as the variables used in the `Deploy sample app via terraform and wait for the endpoint to come online` step. This is causing the variables to be overwritten when the `execute_and_retry.sh` script is run. 

*Description of changes:*
Update the variables affected in `execute_and_retry.sh`
- retry_counter -> execute_retry_counter
- max_retry ->  max_execute_retry

Also updating the max_retry value from 1 -> 2 for the `kubectl delete pods` and `kubectl wait pods` commands, as these should be attempted at least twice rather than once. 

Test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8348075360

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

