### PR TITLE
Increase Terraform Deployment Retry

### DIFF
--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -186,7 +186,7 @@ jobs:
               echo "Attempting to connect to the main sample app endpoint"
               main_sample_app_endpoint=http://$(terraform output sample_app_endpoint)
               attempt_counter=0
-              max_attempts=30
+              max_attempts=60
               until $(curl --output /dev/null --silent --head --fail $(echo "$main_sample_app_endpoint" | tr -d '"')); do
                 if [ ${attempt_counter} -eq ${max_attempts} ];then
                   echo "Failed to connect to endpoint. Will attempt to redeploy sample app."


### PR DESCRIPTION
*Issue #, if available:*
The sample app main service endpoint is frequently unavailable
Example: 
- https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8360267882/job/22886092870
- https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8360036563/job/22885200876

Before a bug was patched in this [PR](https://github.com/aws-observability/aws-application-signals-test-framework/pull/22), the terraform deployment was retrying indefinitely until success, and the endpoint issue was recovering itself after ~30 minutes
Example:
- https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8319148159/job/22762001323

Upon doing some research, this error began to occur frequently after this [PR](https://github.com/aws-observability/aws-application-signals-test-framework/pull/9/files) was merged. Suspecting that the wait attempt duration for endpoint is currently not sufficient.


*Description of changes:*
Increase the endpoint connection attempt counter back to 60

Test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8379454872

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

