### PR TITLE
Change cw-agent.rpm to point to latest

### DIFF
--- a/.github/workflows/appsignals-e2e-ec2-test.yml
+++ b/.github/workflows/appsignals-e2e-ec2-test.yml
@@ -31,7 +31,7 @@ env:
   LOG_GROUP_NAME: /aws/appsignals/generic
   TEST: ${{ inputs.test }}
   GET_ADOT_JAR_COMMAND: "wget -O adot.jar https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar"
-  GET_CW_AGENT_RPM_COMMAND: "wget -O cw-agent.rpm https://amazoncloudwatch-agent-${{ inputs.aws-region }}.s3.${{ inputs.aws-region }}.amazonaws.com/amazon_linux/amd64/1.300031.0b313/amazon-cloudwatch-agent.rpm"
+  GET_CW_AGENT_RPM_COMMAND: "wget -O cw-agent.rpm https://amazoncloudwatch-agent-${{ inputs.aws-region }}.s3.${{ inputs.aws-region }}.amazonaws.com/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm"
   TEST_RESOURCES_FOLDER: /home/runner/work/aws-application-signals-test-framework/aws-application-signals-test-framework
 
 

--- a/validator/src/main/resources/expected-data-template/ec2/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/ec2/aws-sdk-call-trace.mustache
@@ -13,9 +13,9 @@
     "account_id": "^{{accountId}}$"
   },
   "annotations": {
-    "aws_local_service": "^{{serviceName}}$",
-    "HostedIn_Environment": "^EC2$",
-    "aws_local_operation": "^GET /aws-sdk-call$"
+    "aws.local.service": "^{{serviceName}}$",
+    "HostedIn.Environment": "^EC2$",
+    "aws.local.operation": "^GET /aws-sdk-call$"
   },
   "metadata": {
     "default": {
@@ -37,12 +37,12 @@
             }
           },
           "annotations": {
-            "HostedIn_Environment": "^EC2$",
-            "aws_local_service": "^{{serviceName}}$",
-            "aws_local_operation": "^GET /aws-sdk-call$",
-            "aws_remote_service": "^AWS\\.SDK\\.S3$",
-            "aws_remote_operation": "^GetBucketLocation$",
-            "aws_remote_target": "^::s3:::e2e-test-bucket-name$"
+            "HostedIn.Environment": "^EC2$",
+            "aws.local.service": "^{{serviceName}}$",
+            "aws.local.operation": "^GET /aws-sdk-call$",
+            "aws.remote.service": "^AWS\\.SDK\\.S3$",
+            "aws.remote.operation": "^GetBucketLocation$",
+            "aws.remote.target": "^::s3:::e2e-test-bucket-name$"
           },
           "metadata": {
             "default": {

--- a/validator/src/main/resources/expected-data-template/ec2/client-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/ec2/client-call-trace.mustache
@@ -1,9 +1,9 @@
 [{
   "name": "^{{serviceName}}$",
   "annotations": {
-    "aws_local_service": "^{{serviceName}}$",
-    "HostedIn_Environment": "^EC2$",
-    "aws_local_operation": "^InternalOperation$"
+    "aws.local.service": "^{{serviceName}}$",
+    "HostedIn.Environment": "^EC2$",
+    "aws.local.operation": "^InternalOperation$"
   },
   "metadata": {
     "default": {
@@ -23,11 +23,11 @@
           }
       },
       "annotations": {
-        "HostedIn_Environment": "^EC2$",
-        "aws_local_service": "^{{serviceName}}$",
-        "aws_local_operation": "^InternalOperation$",
-        "aws_remote_service": "^local-root-client-call$",
-        "aws_remote_operation": "GET /"
+        "HostedIn.Environment": "^EC2$",
+        "aws.local.service": "^{{serviceName}}$",
+        "aws.local.operation": "^InternalOperation$",
+        "aws.remote.service": "^local-root-client-call$",
+        "aws.remote.operation": "GET /"
       },
       "metadata": {
         "default": {
@@ -37,20 +37,4 @@
       "namespace": "^remote$"
     }
   ]
-},
-{
-    "name": "^local-root-client-call$",
-    "http": {
-        "request": {
-            "url": "^http://local-root-client-call$",
-            "method": "^GET$"
-        },
-        "response": {
-            "content_length": 0
-        }
-    },
-    "annotations": {
-        "aws_local_service": "^local-root-client-call$",
-        "aws_local_operation": "^GET /$"
-    }
 }]

--- a/validator/src/main/resources/expected-data-template/ec2/outgoing-http-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/ec2/outgoing-http-call-trace.mustache
@@ -13,9 +13,9 @@
     "account_id": "^{{accountId}}$"
   },
   "annotations": {
-    "aws_local_service": "^{{serviceName}}$",
-    "HostedIn_Environment": "^EC2$",
-    "aws_local_operation": "^GET /outgoing-http-call$"
+    "aws.local.service": "^{{serviceName}}$",
+    "HostedIn.Environment": "^EC2$",
+    "aws.local.operation": "^GET /outgoing-http-call$"
   },
   "metadata": {
       "default": {
@@ -37,11 +37,11 @@
             }
           },
           "annotations": {
-            "HostedIn_Environment": "^EC2$",
-            "aws_local_service": "^{{serviceName}}$",
-            "aws_local_operation": "^GET /outgoing-http-call$",
-            "aws_remote_service": "^www.amazon.com$",
-            "aws_remote_operation": "^GET /$"
+            "HostedIn.Environment": "^EC2$",
+            "aws.local.service": "^{{serviceName}}$",
+            "aws.local.operation": "^GET /outgoing-http-call$",
+            "aws.remote.service": "^www.amazon.com$",
+            "aws.remote.operation": "^GET /$"
           },
           "metadata": {
             "default": {

--- a/validator/src/main/resources/expected-data-template/ec2/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/ec2/remote-service-trace.mustache
@@ -13,9 +13,9 @@
     "account_id": "^{{accountId}}$"
   },
   "annotations": {
-    "aws_local_service": "^{{serviceName}}$",
-    "HostedIn_Environment": "^EC2$",
-    "aws_local_operation": "^GET /remote-service$"
+    "aws.local.service": "^{{serviceName}}$",
+    "HostedIn.Environment": "^EC2$",
+    "aws.local.operation": "^GET /remote-service$"
   },
   "metadata": {
       "default": {
@@ -37,10 +37,10 @@
             }
           },
           "annotations": {
-            "aws_local_service": "^{{serviceName}}$",
-            "aws_local_operation": "^GET /remote-service$",
-            "aws_remote_service": "^{{remoteServiceDeploymentName}}$",
-            "aws_remote_operation": "^GET /healthcheck$"
+            "aws.local.service": "^{{serviceName}}$",
+            "aws.local.operation": "^GET /remote-service$",
+            "aws.remote.service": "^{{remoteServiceDeploymentName}}$",
+            "aws.remote.operation": "^GET /healthcheck$"
           },
           "metadata": {
               "default": {
@@ -62,9 +62,9 @@
     }
   },
   "annotations": {
-    "HostedIn_Environment": "^EC2$",
-    "aws_local_service": "^{{remoteServiceName}}$",
-    "aws_local_operation": "^GET /healthcheck$"
+    "HostedIn.Environment": "^EC2$",
+    "aws.local.service": "^{{remoteServiceName}}$",
+    "aws.local.operation": "^GET /healthcheck$"
   },
   "metadata": {
       "default": {
@@ -78,8 +78,8 @@
     {
       "name": "^RemoteServiceController.healthcheck$",
       "annotations": {
-        "HostedIn_Environment": "^EC2$",
-        "aws_local_operation": "^GET /healthcheck$"
+        "HostedIn.Environment": "^EC2$",
+        "aws.local.operation": "^GET /healthcheck$"
       }
     }
   ]


### PR DESCRIPTION
*Issue #, if available:*
The current cw-agent.rpm is pointing to an older version. Update it to point to the latest branch.

Also update the validation template to reflect the latest changes

Test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8395798849

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

