### PR TITLE
Revert "Increase Terraform Deployment Retry"

### DIFF
--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -180,7 +180,7 @@ jobs:
               echo "Attempting to connect to the main sample app endpoint"
               main_sample_app_endpoint=http://$(terraform output sample_app_endpoint)
               attempt_counter=0
-              max_attempts=60
+              max_attempts=30
               until $(curl --output /dev/null --silent --head --fail $(echo "$main_sample_app_endpoint" | tr -d '"')); do
                 if [ ${attempt_counter} -eq ${max_attempts} ];then
                   echo "Failed to connect to endpoint. Will attempt to redeploy sample app."


### PR DESCRIPTION
Reverts aws-observability/aws-application-signals-test-framework#23

Canary is failing: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8396794594