### PR TITLE
Update E2E Test Validation for EKS Add-on v1.3.1 version 2

### DIFF
--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -54,12 +54,6 @@ jobs:
           cleanup: "rm -f enable-app-signals.sh && rm -f clean-app-signals.sh"
           post-command: "chmod +x enable-app-signals.sh && chmod +x clean-app-signals.sh"
 
-      # TODO: remove this step next Monday and update validator with appropriate changes
-      - name: Temporary override addon version
-        working-directory: enablement-script
-        run: |
-          sed -i '\#--addon-name amazon-cloudwatch-observability \\#a--addon-version v1.2.2-eksbuild.1 \\' enable-app-signals.sh
-
       - name: Remove log group deletion command
         if: always()
         working-directory: enablement-script

--- a/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-metric.mustache
@@ -113,7 +113,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Latency
@@ -136,7 +136,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Error
@@ -253,7 +253,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Error
@@ -276,7 +276,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Fault
@@ -393,7 +393,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name
 
 -
   metricName: Fault
@@ -416,4 +416,4 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name

--- a/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-trace.mustache
@@ -13,10 +13,10 @@
     "account_id": "^{{accountId}}$"
   },
   "annotations": {
-    "aws_local_service": "^{{serviceName}}$",
-    "HostedIn_K8s_Namespace": "^{{appNamespace}}$",
-    "HostedIn_EKS_Cluster": "^{{platformInfo}}$",
-    "aws_local_operation": "^GET /aws-sdk-call$"
+    "aws.local.service": "^{{serviceName}}$",
+    "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+    "HostedIn.EKS.Cluster": "^{{platformInfo}}$",
+    "aws.local.operation": "^GET /aws-sdk-call$"
   },
   "metadata": {
     "default": {
@@ -38,13 +38,13 @@
             }
           },
           "annotations": {
-            "HostedIn_K8s_Namespace": "^{{appNamespace}}$",
-            "HostedIn_EKS_Cluster": "^{{platformInfo}}$",
-            "aws_local_service": "^{{serviceName}}$",
-            "aws_local_operation": "^GET /aws-sdk-call$",
-            "aws_remote_service": "^AWS\\.SDK\\.S3$",
-            "aws_remote_operation": "GetBucketLocation",
-            "aws_remote_target": "e2e-test-bucket-name"
+            "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+            "HostedIn.EKS.Cluster": "^{{platformInfo}}$",
+            "aws.local.service": "^{{serviceName}}$",
+            "aws.local.operation": "^GET /aws-sdk-call$",
+            "aws.remote.service": "^AWS\\.SDK\\.S3$",
+            "aws.remote.operation": "GetBucketLocation",
+            "aws.remote.target": "^::s3:::e2e-test-bucket-name$"
           },
           "metadata": {
             "default": {

--- a/validator/src/main/resources/expected-data-template/eks/client-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/eks/client-call-trace.mustache
@@ -1,10 +1,10 @@
 [{
   "name": "^{{serviceName}}$",
   "annotations": {
-    "aws_local_service": "^{{serviceName}}$",
-    "HostedIn_K8s_Namespace": "^{{appNamespace}}$",
-    "HostedIn_EKS_Cluster": "^{{platformInfo}}$",
-    "aws_local_operation": "^InternalOperation$"
+    "aws.local.service": "^{{serviceName}}$",
+    "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+    "HostedIn.EKS.Cluster": "^{{platformInfo}}$",
+    "aws.local.operation": "^InternalOperation$"
   },
   "metadata": {
     "default": {
@@ -23,12 +23,12 @@
           }
       },
       "annotations": {
-        "HostedIn_K8s_Namespace": "^{{appNamespace}}$",
-        "HostedIn_EKS_Cluster": "^{{platformInfo}}$",
-        "aws_local_service": "^{{serviceName}}$",
-        "aws_local_operation": "^InternalOperation$",
-        "aws_remote_service": "^local-root-client-call$",
-        "aws_remote_operation": "GET /"
+        "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+        "HostedIn.EKS.Cluster": "^{{platformInfo}}$",
+        "aws.local.service": "^{{serviceName}}$",
+        "aws.local.operation": "^InternalOperation$",
+        "aws.remote.service": "^local-root-client-call$",
+        "aws.remote.operation": "GET /"
       },
       "metadata": {
         "default": {
@@ -38,20 +38,4 @@
       "namespace": "^remote$"
     }
   ]
-},
-{
-    "name": "^local-root-client-call$",
-    "http": {
-        "request": {
-            "url": "^http://local-root-client-call$",
-            "method": "^GET$"
-        },
-        "response": {
-            "content_length": 0
-        }
-    },
-    "annotations": {
-        "aws_local_service": "^local-root-client-call$",
-        "aws_local_operation": "^GET /$"
-    }
 }]

--- a/validator/src/main/resources/expected-data-template/eks/outgoing-http-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/eks/outgoing-http-call-trace.mustache
@@ -13,10 +13,10 @@
     "account_id": "^{{accountId}}$"
   },
   "annotations": {
-    "aws_local_service": "^{{serviceName}}$",
-    "HostedIn_K8s_Namespace": "^{{appNamespace}}$",
-    "HostedIn_EKS_Cluster": "^{{platformInfo}}$",
-    "aws_local_operation": "^GET /outgoing-http-call$"
+    "aws.local.service": "^{{serviceName}}$",
+    "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+    "HostedIn.EKS.Cluster": "^{{platformInfo}}$",
+    "aws.local.operation": "^GET /outgoing-http-call$"
   },
   "metadata": {
       "default": {
@@ -38,12 +38,12 @@
             }
           },
           "annotations": {
-            "HostedIn_K8s_Namespace": "^{{appNamespace}}$",
-            "HostedIn_EKS_Cluster": "^{{platformInfo}}$",
-            "aws_local_service": "^{{serviceName}}$",
-            "aws_local_operation": "^GET /outgoing-http-call$",
-            "aws_remote_service": "^www.amazon.com$",
-            "aws_remote_operation": "^GET /$"
+            "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+            "HostedIn.EKS.Cluster": "^{{platformInfo}}$",
+            "aws.local.service": "^{{serviceName}}$",
+            "aws.local.operation": "^GET /outgoing-http-call$",
+            "aws.remote.service": "^www.amazon.com$",
+            "aws.remote.operation": "^GET /$"
           },
           "metadata": {
             "default": {

--- a/validator/src/main/resources/expected-data-template/eks/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/eks/remote-service-trace.mustache
@@ -13,10 +13,10 @@
     "account_id": "^{{accountId}}$"
   },
   "annotations": {
-    "aws_local_service": "^{{serviceName}}$",
-    "HostedIn_K8s_Namespace": "^{{appNamespace}}$",
-    "HostedIn_EKS_Cluster": "^{{platformInfo}}$",
-    "aws_local_operation": "^GET /remote-service$"
+    "aws.local.service": "^{{serviceName}}$",
+    "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+    "HostedIn.EKS.Cluster": "^{{platformInfo}}$",
+    "aws.local.operation": "^GET /remote-service$"
   },
   "metadata": {
       "default": {
@@ -38,10 +38,10 @@
             }
           },
           "annotations": {
-            "aws_local_service": "^{{serviceName}}$",
-            "aws_local_operation": "^GET /remote-service$",
-            "aws_remote_service": "^{{remoteServiceDeploymentName}}$",
-            "aws_remote_operation": "^GET /healthcheck$"
+            "aws.local.service": "^{{serviceName}}$",
+            "aws.local.operation": "^GET /remote-service$",
+            "aws.remote.service": "^{{remoteServiceDeploymentName}}$",
+            "aws.remote.operation": "^GET /healthcheck$"
           },
           "metadata": {
               "default": {
@@ -63,10 +63,10 @@
     }
   },
   "annotations": {
-    "aws_local_service": "^{{remoteServiceDeploymentName}}$",
-    "HostedIn_K8s_Namespace": "^{{appNamespace}}$",
-    "HostedIn_EKS_Cluster": "^{{platformInfo}}$",
-    "aws_local_operation": "^GET /healthcheck$"
+    "aws.local.service": "^{{remoteServiceDeploymentName}}$",
+    "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+    "HostedIn.EKS.Cluster": "^{{platformInfo}}$",
+    "aws.local.operation": "^GET /healthcheck$"
   },
   "metadata": {
       "default": {
@@ -80,9 +80,9 @@
     {
       "name": "^RemoteServiceController.healthcheck$",
       "annotations": {
-        "HostedIn_K8s_Namespace": "^sample-app-namespace$",
-        "HostedIn_EKS_Cluster": "^{{platformInfo}}$",
-        "aws_local_operation": "^GET /healthcheck$"
+        "HostedIn.K8s.Namespace": "^sample-app-namespace$",
+        "HostedIn.EKS.Cluster": "^{{platformInfo}}$",
+        "aws.local.operation": "^GET /healthcheck$"
       }
     }
   ]


### PR DESCRIPTION
*Issue #, if available:*
Follow up on this [PR](https://github.com/aws-observability/aws-application-signals-test-framework/pull/27) after having to revert due to failures in the canary. 

*Description of changes:*
Same changes, but also removing the client call trace validation step.

Test run: 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

