### PR TITLE
[Native K8s]: E2E test implementation in IAD

### DIFF
--- a/.github/workflows/appsignals-e2e-ec2-test.yml
+++ b/.github/workflows/appsignals-e2e-ec2-test.yml
@@ -29,7 +29,6 @@ env:
   APP_SIGNALS_ADOT_JAR: "https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar"
   METRIC_NAMESPACE: AppSignals
   LOG_GROUP_NAME: /aws/appsignals/generic
-  TEST: ${{ inputs.test }}
   GET_ADOT_JAR_COMMAND: "wget -O adot.jar https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar"
   GET_CW_AGENT_RPM_COMMAND: "wget -O cw-agent.rpm https://amazoncloudwatch-agent-${{ inputs.aws-region }}.s3.${{ inputs.aws-region }}.amazonaws.com/amazon_linux/amd64/1.300031.0b313/amazon-cloudwatch-agent.rpm"
   TEST_RESOURCES_FOLDER: /home/runner/work/aws-application-signals-test-framework/aws-application-signals-test-framework

--- a/.github/workflows/appsignals-e2e-k8s-canary-test.yml
+++ b/.github/workflows/appsignals-e2e-k8s-canary-test.yml
@@ -1,0 +1,30 @@
+## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+
+## This workflow aims to run the Application Signals end-to-end tests as a canary to
+## test the artifacts for App Signals enablement. It will deploy the CloudWatch Agent
+## Operator and our sample app and remote service onto a native K8s cluster, call the
+## APIs, and validate the generated telemetry, including logs, metrics, and traces.
+## It will then clean up the cluster and EC2 instance it runs on for the next test run.
+name:  App Signals Enablement - E2E K8s Canary Testing
+on:
+  schedule:
+    - cron: '*/15 * * * *' # run the workflow every 15 minutes
+  workflow_dispatch: # be able to run the workflow on demand
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  e2e-k8s-test:
+    uses: ./.github/workflows/appsignals-e2e-k8s-test.yml
+    secrets: inherit
+    with:
+      # To run in more regions, a cluster must be provisioned manually on EC2 instances in that region
+      aws-region: 'us-east-1'
+      caller-workflow-name: 'appsignals-e2e-k8s-canary-test'

--- a/.github/workflows/appsignals-e2e-k8s-canary-test.yml
+++ b/.github/workflows/appsignals-e2e-k8s-canary-test.yml
@@ -12,10 +12,6 @@ on:
     - cron: '*/15 * * * *' # run the workflow every 15 minutes
   workflow_dispatch: # be able to run the workflow on demand
 
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
-
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/appsignals-e2e-k8s-test.yml
+++ b/.github/workflows/appsignals-e2e-k8s-test.yml
@@ -1,0 +1,220 @@
+## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+
+# This is a reusable workflow for running the E2E test for App Signals.
+# It is meant to be called from another workflow.
+# Read more about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview
+name: App Signals Enablement E2E Testing - K8s on EC2 Use Case
+on:
+  workflow_call:
+    inputs:
+      aws-region:
+        required: true
+        type: string
+      caller-workflow-name:
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  # The presence of this env var is required for use by terraform and AWS CLI commands
+  # It is not redundant
+  AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
+  TEST_ACCOUNT: ${{ secrets.APP_SIGNALS_E2E_TEST_ACC }}
+  METRIC_NAMESPACE: AppSignals
+  LOG_GROUP_NAME: /aws/appsignals/k8s
+  TEST_RESOURCES_FOLDER: /home/runner/work/aws-application-signals-test-framework/aws-application-signals-test-framework
+  MASTER_NODE_SSH_KEY: ${{ secrets.APP_SIGNALS_E2E_K8S_SSH_KEY_IAD }}
+  MAIN_SERVICE_ENDPOINT: ${{ secrets.APP_SIGNALS_E2E_K8S_MASTER_NODE_ENDPOINT }}
+  SAMPLE_APP_NAMESPACE: sample-app-namespace
+
+
+jobs:
+  e2e-k8s-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate testing id
+        run: echo TESTING_ID="${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.E2E_SECRET_TEST_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Retrieve account
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        with:
+          secret-ids:
+            ACCOUNT_ID, region-account/${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ secrets.E2E_TEST_ROLE_ARN }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+
+      - name: Prepare and upload sample app deployment files
+        working-directory: terraform/k8s/deploy/resources
+        run: |
+          sed -i 's#\${TESTING_ID}#${{ env.TESTING_ID }}#' frontend-service-depl.yaml
+          sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_DEFAULT_REGION }}.amazonaws.com/${{ secrets.APP_SIGNALS_E2E_FE_SA_IMG }}#' frontend-service-depl.yaml
+          sed -i 's#\${TESTING_ID}#${{ env.TESTING_ID }}#' remote-service-depl.yaml
+          sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_DEFAULT_REGION }}.amazonaws.com/${{ secrets.APP_SIGNALS_E2E_RE_SA_IMG }}#' remote-service-depl.yaml
+          aws s3api put-object --bucket ${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ env.AWS_DEFAULT_REGION }} --key frontend-service-depl.yaml --body frontend-service-depl.yaml
+          aws s3api put-object --bucket ${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ env.AWS_DEFAULT_REGION }} --key remote-service-depl.yaml --body remote-service-depl.yaml
+          
+
+      - name: Set up terraform
+        uses: ./.github/workflows/actions/execute_and_retry
+        with:
+          command: "wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg"
+          post-command: 'echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          && sudo apt update && sudo apt install terraform'
+
+      - name: Initiate Terraform for Deployment
+        uses: ./.github/workflows/actions/execute_and_retry
+        with:
+          command: "cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/k8s/deploy && terraform init && terraform validate"
+          cleanup: "rm -rf .terraform && rm -rf .terraform.lock.hcl"
+
+      - name: Deploy Operator and Sample App using Terraform
+        working-directory: terraform/k8s/deploy
+        run: |
+          terraform apply -auto-approve \
+            -var="aws_region=${{ env.AWS_DEFAULT_REGION }}" \
+            -var="test_id=${{ env.TESTING_ID }}" \
+            -var="ssh_key=${{ env.MASTER_NODE_SSH_KEY }}" \
+            -var="host=${{ env.MAIN_SERVICE_ENDPOINT }}"
+
+      - name: Get Remote Service IP
+        run: |
+          echo REMOTE_SERVICE_IP="$(aws ssm get-parameter --region ${{ env.AWS_DEFAULT_REGION }} --name remote-service-ip | jq -r '.Parameter.Value')" >> $GITHUB_ENV
+
+      - name: Build Gradlew
+        uses: ./.github/workflows/actions/execute_and_retry
+        with:
+          max_retry: 2
+          command: "./gradlew"
+          cleanup: "./gradlew clean"
+
+      # This steps increases the speed of the validation by creating the telemetry data in advance
+      # It is run after the gradle build to give the app time to initialize after the pods become ready
+      - name: Call all test APIs
+        continue-on-error: true
+        run: |
+          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/outgoing-http-call/
+          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/aws-sdk-call/
+          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/remote-service?ip=${{ env.REMOTE_SERVICE_IP }}/
+          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/client-call/
+
+      # Validation for pulse telemetry data
+      - name: Validate generated EMF logs
+        id: log-validation
+        run: ./gradlew validator:run --args='-c k8s/log-validation.yml
+          --testing-id ${{ env.TESTING_ID }}
+          --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100
+          --region ${{ env.AWS_DEFAULT_REGION }}
+          --account-id ${{ env.ACCOUNT_ID }}
+          --metric-namespace ${{ env.METRIC_NAMESPACE }}
+          --log-group ${{ env.LOG_GROUP_NAME }}
+          --platform-info k8s-cluster-${{ env.TESTING_ID }}
+          --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
+          --service-name sample-application-${{ env.TESTING_ID }}
+          --remote-service-name sample-r-app-deployment-${{ env.TESTING_ID }}
+          --request-body ip=${{ env.REMOTE_SERVICE_IP }}
+          --rollup'
+
+      - name: Validate generated metrics
+        id: metric-validation
+        if: (success() || steps.log-validation.outcome == 'failure') && !cancelled()
+        run: ./gradlew validator:run --args='-c k8s/metric-validation.yml
+          --testing-id ${{ env.TESTING_ID }}
+          --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100
+          --region ${{ env.AWS_DEFAULT_REGION }}
+          --account-id ${{ env.ACCOUNT_ID }}
+          --metric-namespace ${{ env.METRIC_NAMESPACE }}
+          --log-group ${{ env.LOG_GROUP_NAME }}
+          --platform-info k8s-cluster-${{ env.TESTING_ID }}
+          --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
+          --service-name sample-application-${{ env.TESTING_ID }}
+          --remote-service-name sample-r-app-deployment-${{ env.TESTING_ID }}
+          --remote-service-deployment-name sample-r-app-deployment-${{ env.TESTING_ID }}
+          --request-body ip=${{ env.REMOTE_SERVICE_IP }}
+          --rollup'
+
+      - name: Validate generated traces
+        id: trace-validation
+        if: (success() || steps.log-validation.outcome == 'failure' || steps.metric-validation.outcome == 'failure') && !cancelled()
+        run: ./gradlew validator:run --args='-c k8s/trace-validation.yml
+          --testing-id ${{ env.TESTING_ID }}
+          --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100
+          --region ${{ env.AWS_DEFAULT_REGION }}
+          --account-id ${{ env.ACCOUNT_ID }}
+          --metric-namespace ${{ env.METRIC_NAMESPACE }}
+          --log-group ${{ env.LOG_GROUP_NAME }}
+          --platform-info k8s-cluster-${{ env.TESTING_ID }}
+          --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
+          --service-name sample-application-${{ env.TESTING_ID }}
+          --remote-service-name sample-r-app-deployment-${{ env.TESTING_ID }}
+          --remote-service-deployment-name sample-r-app-deployment-${{ env.TESTING_ID }}
+          --request-body ip=${{ env.REMOTE_SERVICE_IP }}
+          --rollup'
+
+      - name: Publish metric on test result
+        if: always()
+        run: |
+          if [[ "${{ steps.log-validation.outcome }}" == "success" && "${{ steps.metric-validation.outcome }}" == "success" && "${{ steps.trace-validation.outcome }}" == "success" ]]; then
+            aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
+            --metric-name Failure \
+            --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=${{ inputs.caller-workflow-name }} \
+            --value 0.0 \
+            --region ${{ env.AWS_DEFAULT_REGION }}
+          else
+            aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
+            --metric-name Failure \
+            --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=${{ inputs.caller-workflow-name }} \
+            --value 1.0 \
+            --region ${{ env.AWS_DEFAULT_REGION }}
+          fi
+
+      # Clean up Procedures
+      - name: Initiate Terraform for Cleanup
+        if: always()
+        uses: ./.github/workflows/actions/execute_and_retry
+        with:
+          command: "cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/k8s/cleanup && terraform init && terraform validate"
+          cleanup: "rm -rf .terraform && rm -rf .terraform.lock.hcl"
+
+      - name: Clean Up Operator and Sample App using Terraform
+        if: always()
+        working-directory: terraform/k8s/cleanup
+        run: |
+          terraform apply -auto-approve \
+            -var="aws_region=${{ inputs.aws-region }}" \
+            -var="test_id=${{ env.TESTING_ID }}" \
+            -var="ssh_key=${{ env.MASTER_NODE_SSH_KEY }}" \
+            -var="host=${{ env.MAIN_SERVICE_ENDPOINT }}"
+
+      - name: Terraform destroy - deployment
+        if: always()
+        continue-on-error: true
+        working-directory: terraform/k8s/deploy
+        run: |
+          terraform destroy -auto-approve \
+            -var="test_id=${{ env.TESTING_ID }}"
+
+      - name: Terraform destroy - cleanup
+        if: always()
+        continue-on-error: true
+        working-directory: terraform/k8s/cleanup
+        run: |
+          terraform destroy -auto-approve \
+            -var="test_id=${{ env.TESTING_ID }}"

--- a/.github/workflows/appsignals-e2e-k8s-test.yml
+++ b/.github/workflows/appsignals-e2e-k8s-test.yml
@@ -15,6 +15,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: '${{ github.workflow }} @ ${{ inputs.aws-region }}'
+  cancel-in-progress: false
+
 permissions:
   id-token: write
   contents: read
@@ -26,22 +30,23 @@ env:
   TEST_ACCOUNT: ${{ secrets.APP_SIGNALS_E2E_TEST_ACC }}
   METRIC_NAMESPACE: AppSignals
   LOG_GROUP_NAME: /aws/appsignals/k8s
-  TEST_RESOURCES_FOLDER: /home/runner/work/aws-application-signals-test-framework/aws-application-signals-test-framework
   MASTER_NODE_SSH_KEY: ${{ secrets.APP_SIGNALS_E2E_K8S_SSH_KEY_IAD }}
   MAIN_SERVICE_ENDPOINT: ${{ secrets.APP_SIGNALS_E2E_K8S_MASTER_NODE_ENDPOINT }}
   SAMPLE_APP_NAMESPACE: sample-app-namespace
-
+  TEST_RESOURCES_FOLDER: /__w/aws-application-signals-test-framework/aws-application-signals-test-framework
 
 jobs:
   e2e-k8s-test:
     runs-on: ubuntu-latest
+    container:
+      image: public.ecr.aws/h6o3z5z9/aws-application-signals-test-framework-workflow-container:latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Generate testing id
-        run: echo TESTING_ID="${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
+        run: echo TESTING_ID="${{ env.AWS_DEFAULT_REGION }}-${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -70,16 +75,8 @@ jobs:
           sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_DEFAULT_REGION }}.amazonaws.com/${{ secrets.APP_SIGNALS_E2E_RE_SA_IMG }}#' remote-service-depl.yaml
           aws s3api put-object --bucket ${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ env.AWS_DEFAULT_REGION }} --key frontend-service-depl.yaml --body frontend-service-depl.yaml
           aws s3api put-object --bucket ${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ env.AWS_DEFAULT_REGION }} --key remote-service-depl.yaml --body remote-service-depl.yaml
-          
 
-      - name: Set up terraform
-        uses: ./.github/workflows/actions/execute_and_retry
-        with:
-          command: "wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg"
-          post-command: 'echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          && sudo apt update && sudo apt install terraform'
-
-      - name: Initiate Terraform for Deployment
+      - name: Initiate Terraform
         uses: ./.github/workflows/actions/execute_and_retry
         with:
           command: "cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/k8s/deploy && terraform init && terraform validate"
@@ -98,22 +95,15 @@ jobs:
         run: |
           echo REMOTE_SERVICE_IP="$(aws ssm get-parameter --region ${{ env.AWS_DEFAULT_REGION }} --name remote-service-ip | jq -r '.Parameter.Value')" >> $GITHUB_ENV
 
-      - name: Build Gradlew
-        uses: ./.github/workflows/actions/execute_and_retry
-        with:
-          max_retry: 2
-          command: "./gradlew"
-          cleanup: "./gradlew clean"
-
       # This steps increases the speed of the validation by creating the telemetry data in advance
       # It is run after the gradle build to give the app time to initialize after the pods become ready
       - name: Call all test APIs
         continue-on-error: true
         run: |
-          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/outgoing-http-call/
-          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/aws-sdk-call/
-          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/remote-service?ip=${{ env.REMOTE_SERVICE_IP }}/
-          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/client-call/
+          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/outgoing-http-call/; echo
+          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/aws-sdk-call/; echo
+          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/remote-service?ip=${{ env.REMOTE_SERVICE_IP }}/; echo
+          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/client-call/; echo
 
       # Validation for pulse telemetry data
       - name: Validate generated EMF logs
@@ -171,7 +161,7 @@ jobs:
       - name: Publish metric on test result
         if: always()
         run: |
-          if [[ "${{ steps.log-validation.outcome }}" == "success" && "${{ steps.metric-validation.outcome }}" == "success" && "${{ steps.trace-validation.outcome }}" == "success" ]]; then
+          if [ "${{ steps.log-validation.outcome }}" = "success" ] && [ "${{ steps.metric-validation.outcome }}" = "success" ] && [ "${{ steps.trace-validation.outcome }}" = "success" ]; then
             aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
             --metric-name Failure \
             --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=${{ inputs.caller-workflow-name }} \
@@ -198,7 +188,7 @@ jobs:
         working-directory: terraform/k8s/cleanup
         run: |
           terraform apply -auto-approve \
-            -var="aws_region=${{ inputs.aws-region }}" \
+            -var="aws_region=${{ env.AWS_DEFAULT_REGION }}" \
             -var="test_id=${{ env.TESTING_ID }}" \
             -var="ssh_key=${{ env.MASTER_NODE_SSH_KEY }}" \
             -var="host=${{ env.MAIN_SERVICE_ENDPOINT }}"

--- a/terraform/k8s/cleanup/main.tf
+++ b/terraform/k8s/cleanup/main.tf
@@ -1,0 +1,35 @@
+
+
+resource "null_resource" "cleanup" {
+  connection {
+    type        = "ssh"
+    user        = var.user
+    private_key = var.ssh_key
+    host        = var.host
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      # Allow terraform to fail any of the following steps without exiting
+      "set +e",
+
+      # Uninstall the operator and remove the repo from the EC2 instance
+      "echo \"LOG: Uninstalling CloudWatch Agent Operator\"",
+      "helm uninstall --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator --ignore-not-found",
+      "echo \"LOG: Deleting CloudWatch Agent Operator repo from environment\"",
+      "[ ! -e amazon-cloudwatch-agent-operator ] || sudo rm -r amazon-cloudwatch-agent-operator",
+
+      # Delete sample app resources
+      "echo \"LOG: Deleting sample app namespace\"",
+      "kubectl delete namespace sample-app-namespace",
+      "echo \"LOG: Deleting sample app deployment files\"",
+      "[ ! -e frontend-service-depl.yaml ] || rm frontend-service-depl.yaml",
+      "[ ! -e remote-service-depl.yaml ] || rm remote-service-depl.yaml",
+      "sleep 10",
+
+      # Print cluster state when done clean up procedures
+      "echo \"LOG: Printing cluster state after cleanup\"",
+      "kubectl get pods -A",
+    ]
+  }
+}

--- a/terraform/k8s/cleanup/main.tf
+++ b/terraform/k8s/cleanup/main.tf
@@ -10,26 +10,28 @@ resource "null_resource" "cleanup" {
 
   provisioner "remote-exec" {
     inline = [
+      <<-EOF
       # Allow terraform to fail any of the following steps without exiting
-      "set +e",
+      set +e
 
       # Uninstall the operator and remove the repo from the EC2 instance
-      "echo \"LOG: Uninstalling CloudWatch Agent Operator\"",
-      "helm uninstall --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator --ignore-not-found",
-      "echo \"LOG: Deleting CloudWatch Agent Operator repo from environment\"",
-      "[ ! -e amazon-cloudwatch-agent-operator ] || sudo rm -r amazon-cloudwatch-agent-operator",
+      echo "LOG: Uninstalling CloudWatch Agent Operator"
+      helm uninstall --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator --ignore-not-found
+      echo "LOG: Deleting CloudWatch Agent Operator repo from environment"
+      [ ! -e amazon-cloudwatch-agent-operator ] || sudo rm -r amazon-cloudwatch-agent-operator
 
       # Delete sample app resources
-      "echo \"LOG: Deleting sample app namespace\"",
-      "kubectl delete namespace sample-app-namespace",
-      "echo \"LOG: Deleting sample app deployment files\"",
-      "[ ! -e frontend-service-depl.yaml ] || rm frontend-service-depl.yaml",
-      "[ ! -e remote-service-depl.yaml ] || rm remote-service-depl.yaml",
-      "sleep 10",
+      echo "LOG: Deleting sample app namespace"
+      kubectl delete namespace sample-app-namespace
+      echo "LOG: Deleting sample app deployment files"
+      [ ! -e frontend-service-depl.yaml ] || rm frontend-service-depl.yaml
+      [ ! -e remote-service-depl.yaml ] || rm remote-service-depl.yaml
+      sleep 10
 
       # Print cluster state when done clean up procedures
-      "echo \"LOG: Printing cluster state after cleanup\"",
-      "kubectl get pods -A",
+      echo "LOG: Printing cluster state after cleanup"
+      kubectl get pods -A
+      EOF
     ]
   }
 }

--- a/terraform/k8s/cleanup/variables.tf
+++ b/terraform/k8s/cleanup/variables.tf
@@ -1,0 +1,36 @@
+# ------------------------------------------------------------------------
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+# -------------------------------------------------------------------------
+
+variable "test_id" {
+  default = "dummy-123"
+}
+
+variable "aws_region" {
+  default = "<aws-region>"
+}
+
+variable "user" {
+  default = "ec2-user"
+}
+
+variable "ssh_key" {
+  default = "<MASTER_NODE_SSH_KEY>"
+  description = "This variable is responsible for providing the SSH key of the master node to allow terraform to interact with the cluster"
+}
+
+variable "host" {
+  default = "<HOST_IP_OR_DNS>"
+  description = "This variable is responsible for defining which host (ec2 instance) we connect to for the K8s-on-EC2 test"
+}

--- a/terraform/k8s/deploy/main.tf
+++ b/terraform/k8s/deploy/main.tf
@@ -23,66 +23,72 @@ resource "null_resource" "deploy" {
 
   provisioner "remote-exec" {
     inline = [
+      <<-EOF
       # Make the Terraform fail if any step throws an error
-      "set -e",
+      set -e
 
       # Ensure environment is clean
-      "echo \"LOG: Rerunning cleanup commands in case of cleanup failure in previous run\"",
-      "helm uninstall --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator --ignore-not-found",
-      "kubectl delete namespace sample-app-namespace --ignore-not-found=true",
-      "[ ! -e amazon-cloudwatch-agent-operator ] || sudo rm -r amazon-cloudwatch-agent-operator",
-      "[ ! -e frontend-service-depl.yaml ] || rm frontend-service-depl.yaml",
-      "[ ! -e remote-service-depl.yaml ] || rm remote-service-depl.yaml",
+      echo "LOG: Rerunning cleanup commands in case of cleanup failure in previous run"
+      helm uninstall --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator --ignore-not-found
+      kubectl delete namespace sample-app-namespace --ignore-not-found=true
+      [ ! -e amazon-cloudwatch-agent-operator ] || sudo rm -r amazon-cloudwatch-agent-operator
+      [ ! -e frontend-service-depl.yaml ] || rm frontend-service-depl.yaml
+      [ ! -e remote-service-depl.yaml ] || rm remote-service-depl.yaml
 
       # Clone and install operator onto cluster
-      "echo \"LOG: Cloning operator repo\"",
-      "git clone https://github.com/aws/amazon-cloudwatch-agent-operator -q",
-      "cd amazon-cloudwatch-agent-operator/helm/",
-      "echo \"LOG: Installing CloudWatch Agent Operator using Helm\"",
-      "helm upgrade --install --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator ./ --create-namespace --set region=us-east-1 --set clusterName=k8s-cluster-${var.test_id}",
+      echo "LOG: Cloning operator repo"
+      git clone https://github.com/aws/amazon-cloudwatch-agent-operator -q
+      cd amazon-cloudwatch-agent-operator/helm/
+      echo "LOG: Installing CloudWatch Agent Operator using Helm"
+      helm upgrade --install --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator ./ --create-namespace --set region=us-east-1 --set clusterName=k8s-cluster-${var.test_id}
 
-      "sleep 60", # wait for pods to exist before checking if they're ready
-      "kubectl wait --for=condition=Ready pods --all --selector=app.kubernetes.io/name=amazon-cloudwatch-observability -n amazon-cloudwatch --timeout=60s",
-      "kubectl wait --for=condition=Ready pods --all --selector=app.kubernetes.io/name=cloudwatch-agent -n amazon-cloudwatch --timeout=60s",
+      # Wait for pods to exist before checking if they're ready
+      sleep 60
+      kubectl wait --for=condition=Ready pods --all --selector=app.kubernetes.io/name=amazon-cloudwatch-observability -n amazon-cloudwatch --timeout=60s
+      kubectl wait --for=condition=Ready pods --all --selector=app.kubernetes.io/name=cloudwatch-agent -n amazon-cloudwatch --timeout=60s
 
       # Create sample app namespace
-      "echo \"LOG: Creating sample app namespace\"",
-      "kubectl create namespace sample-app-namespace",
+      echo "LOG: Creating sample app namespace"
+      kubectl create namespace sample-app-namespace
 
       # Set up secret to pull image with
-      "echo \"LOG: Creating secret \"",
-      "ACCOUNT=$(aws sts get-caller-identity --query 'Account' --output text)",
-      "SECRET_NAME=ecr-secret",
-      "TOKEN=`aws ecr --region=${var.aws_region} get-authorization-token --output text --query authorizationData[].authorizationToken | base64 -d | cut -d: -f2`",
+      echo "LOG: Creating secret to access ECR images"
+      ACCOUNT=$(aws sts get-caller-identity --query 'Account' --output text)
+      SECRET_NAME=ecr-secret
+      TOKEN=`aws ecr --region=${var.aws_region} get-authorization-token --output text --query authorizationData[].authorizationToken | base64 -d | cut -d: -f2`
 
-      "echo \"LOG: Deleting secret if it exists\"",
-      "kubectl delete secret -n sample-app-namespace --ignore-not-found $SECRET_NAME",
-      "echo \"LOG: Creating secret for pulling sample app ECR\"",
-      "kubectl create secret -n sample-app-namespace docker-registry $SECRET_NAME \\",
-      "--docker-server=https://$ACCOUNT.dkr.ecr.${var.aws_region}.amazonaws.com \\",
-      "--docker-username=AWS \\",
-      "--docker-password=\"$${TOKEN}\"",
+      echo "LOG: Deleting secret if it exists"
+      kubectl delete secret -n sample-app-namespace --ignore-not-found $SECRET_NAME
+      echo "LOG: Creating secret for pulling sample app ECR"
+      kubectl create secret -n sample-app-namespace docker-registry $SECRET_NAME \
+      --docker-server=https://$ACCOUNT.dkr.ecr.${var.aws_region}.amazonaws.com \
+      --docker-username=AWS \
+      --docker-password="$${TOKEN}"
 
       # Deploy sample app
-      "echo \"LOG: Pulling sample app deployment files\"",
-      "cd ~", # To ensure everything is downloaded into root directory so cleanup is easy
-      "aws s3api get-object --bucket aws-appsignals-sample-app-prod-us-east-1 --key frontend-service-depl.yaml frontend-service-depl.yaml",
-      "aws s3api get-object --bucket aws-appsignals-sample-app-prod-us-east-1 --key remote-service-depl.yaml remote-service-depl.yaml",
-      "echo \"LOG: Applying sample app deployment files\"",
-      "kubectl apply -f frontend-service-depl.yaml",
-      "kubectl apply -f remote-service-depl.yaml",
+      echo "LOG: Pulling sample app deployment files"
+
+      # cd to ensure everything is downloaded into root directory so cleanup is each
+      cd ~
+      aws s3api get-object --bucket aws-appsignals-sample-app-prod-us-east-1 --key frontend-service-depl.yaml frontend-service-depl.yaml
+      aws s3api get-object --bucket aws-appsignals-sample-app-prod-us-east-1 --key remote-service-depl.yaml remote-service-depl.yaml
+      echo "LOG: Applying sample app deployment files"
+      kubectl apply -f frontend-service-depl.yaml
+      kubectl apply -f remote-service-depl.yaml
 
       # Expose sample app on port 30100
-      "echo \"LOG: Exposing main sample app on port 30100\"",
-      "kubectl expose deployment sample-app-deployment-${var.test_id} -n sample-app-namespace --type=\"NodePort\" --port 8080",
-      "kubectl patch service sample-app-deployment-${var.test_id} -n sample-app-namespace --type='json' --patch='[{\"op\": \"replace\", \"path\": \"/spec/ports/0/nodePort\", \"value\":30100}]'",
+      echo "LOG: Exposing main sample app on port 30100"
+      kubectl expose deployment sample-app-deployment-${var.test_id} -n sample-app-namespace --type="NodePort" --port 8080
+      kubectl patch service sample-app-deployment-${var.test_id} -n sample-app-namespace --type='json' --patch='[{"op": "replace", "path": "/spec/ports/0/nodePort", "value":30100}]'
 
       # Wait for sample app to be reach ready state
-      "kubectl wait --for=condition=Ready --request-timeout '5m' pod --all -n sample-app-namespace",
+      kubectl wait --for=condition=Ready --request-timeout '5m' pod --all -n sample-app-namespace
 
       # Emit remote service pod IP
-      "echo \"LOG: Outputting remote service pod IP to SSM using put-parameter API\"",
-      "aws ssm put-parameter --region ${var.aws_region} --name remote-service-ip --type String --overwrite --value $(kubectl get pod --selector=app=remote-app -n sample-app-namespace -o jsonpath='{.items[0].status.podIP}')",
+      echo "LOG: Outputting remote service pod IP to SSM using put-parameter API"
+      aws ssm put-parameter --region ${var.aws_region} --name remote-service-ip --type String --overwrite --value $(kubectl get pod --selector=app=remote-app -n sample-app-namespace -o jsonpath='{.items[0].status.podIP}')
+
+      EOF
     ]
   }
 }

--- a/terraform/k8s/deploy/main.tf
+++ b/terraform/k8s/deploy/main.tf
@@ -1,0 +1,88 @@
+# ------------------------------------------------------------------------
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+# -------------------------------------------------------------------------
+
+resource "null_resource" "deploy" {
+  connection {
+    type        = "ssh"
+    user        = var.user
+    private_key = var.ssh_key
+    host        = var.host
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      # Make the Terraform fail if any step throws an error
+      "set -e",
+
+      # Ensure environment is clean
+      "echo \"LOG: Rerunning cleanup commands in case of cleanup failure in previous run\"",
+      "helm uninstall --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator --ignore-not-found",
+      "kubectl delete namespace sample-app-namespace --ignore-not-found=true",
+      "[ ! -e amazon-cloudwatch-agent-operator ] || sudo rm -r amazon-cloudwatch-agent-operator",
+      "[ ! -e frontend-service-depl.yaml ] || rm frontend-service-depl.yaml",
+      "[ ! -e remote-service-depl.yaml ] || rm remote-service-depl.yaml",
+
+      # Clone and install operator onto cluster
+      "echo \"LOG: Cloning operator repo\"",
+      "git clone https://github.com/aws/amazon-cloudwatch-agent-operator -q",
+      "cd amazon-cloudwatch-agent-operator/helm/",
+      "echo \"LOG: Installing CloudWatch Agent Operator using Helm\"",
+      "helm upgrade --install --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator ./ --create-namespace --set region=us-east-1 --set clusterName=k8s-cluster-${var.test_id}",
+
+      "sleep 60", # wait for pods to exist before checking if they're ready
+      "kubectl wait --for=condition=Ready pods --all --selector=app.kubernetes.io/name=amazon-cloudwatch-observability -n amazon-cloudwatch --timeout=60s",
+      "kubectl wait --for=condition=Ready pods --all --selector=app.kubernetes.io/name=cloudwatch-agent -n amazon-cloudwatch --timeout=60s",
+
+      # Create sample app namespace
+      "echo \"LOG: Creating sample app namespace\"",
+      "kubectl create namespace sample-app-namespace",
+
+      # Set up secret to pull image with
+      "echo \"LOG: Creating secret \"",
+      "ACCOUNT=$(aws sts get-caller-identity --query 'Account' --output text)",
+      "SECRET_NAME=ecr-secret",
+      "TOKEN=`aws ecr --region=${var.aws_region} get-authorization-token --output text --query authorizationData[].authorizationToken | base64 -d | cut -d: -f2`",
+
+      "echo \"LOG: Deleting secret if it exists\"",
+      "kubectl delete secret -n sample-app-namespace --ignore-not-found $SECRET_NAME",
+      "echo \"LOG: Creating secret for pulling sample app ECR\"",
+      "kubectl create secret -n sample-app-namespace docker-registry $SECRET_NAME \\",
+      "--docker-server=https://$ACCOUNT.dkr.ecr.${var.aws_region}.amazonaws.com \\",
+      "--docker-username=AWS \\",
+      "--docker-password=\"$${TOKEN}\"",
+
+      # Deploy sample app
+      "echo \"LOG: Pulling sample app deployment files\"",
+      "cd ~", # To ensure everything is downloaded into root directory so cleanup is easy
+      "aws s3api get-object --bucket aws-appsignals-sample-app-prod-us-east-1 --key frontend-service-depl.yaml frontend-service-depl.yaml",
+      "aws s3api get-object --bucket aws-appsignals-sample-app-prod-us-east-1 --key remote-service-depl.yaml remote-service-depl.yaml",
+      "echo \"LOG: Applying sample app deployment files\"",
+      "kubectl apply -f frontend-service-depl.yaml",
+      "kubectl apply -f remote-service-depl.yaml",
+
+      # Expose sample app on port 30100
+      "echo \"LOG: Exposing main sample app on port 30100\"",
+      "kubectl expose deployment sample-app-deployment-${var.test_id} -n sample-app-namespace --type=\"NodePort\" --port 8080",
+      "kubectl patch service sample-app-deployment-${var.test_id} -n sample-app-namespace --type='json' --patch='[{\"op\": \"replace\", \"path\": \"/spec/ports/0/nodePort\", \"value\":30100}]'",
+
+      # Wait for sample app to be reach ready state
+      "kubectl wait --for=condition=Ready --request-timeout '5m' pod --all -n sample-app-namespace",
+
+      # Emit remote service pod IP
+      "echo \"LOG: Outputting remote service pod IP to SSM using put-parameter API\"",
+      "aws ssm put-parameter --region ${var.aws_region} --name remote-service-ip --type String --overwrite --value $(kubectl get pod --selector=app=remote-app -n sample-app-namespace -o jsonpath='{.items[0].status.podIP}')",
+    ]
+  }
+}

--- a/terraform/k8s/deploy/main.tf
+++ b/terraform/k8s/deploy/main.tf
@@ -40,7 +40,7 @@ resource "null_resource" "deploy" {
       git clone https://github.com/aws/amazon-cloudwatch-agent-operator -q
       cd amazon-cloudwatch-agent-operator/helm/
       echo "LOG: Installing CloudWatch Agent Operator using Helm"
-      helm upgrade --install --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator ./ --create-namespace --set region=us-east-1 --set clusterName=k8s-cluster-${var.test_id}
+      helm upgrade --install --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator ./ --create-namespace --set region=${var.aws_region} --set clusterName=k8s-cluster-${var.test_id}
 
       # Wait for pods to exist before checking if they're ready
       sleep 60

--- a/terraform/k8s/deploy/resources/frontend-service-depl.yaml
+++ b/terraform/k8s/deploy/resources/frontend-service-depl.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sample-app-deployment-${TESTING_ID}
+  namespace: sample-app-namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sample-app
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: sample-app
+      annotations:
+        instrumentation.opentelemetry.io/inject-java: "true"
+    spec:
+      containers:
+        - name: frontend
+          image: ${IMAGE}
+          ports:
+            - containerPort: 8080
+          env:
+            - name: "OTEL_SERVICE_NAME"
+              value: "sample-application-${TESTING_ID}"
+      imagePullSecrets:
+        - name: ecr-secret

--- a/terraform/k8s/deploy/resources/remote-service-depl.yaml
+++ b/terraform/k8s/deploy/resources/remote-service-depl.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sample-r-app-deployment-${TESTING_ID}
+  namespace: sample-app-namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: remote-app
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: remote-app
+      annotations:
+        instrumentation.opentelemetry.io/inject-java: "true"
+    spec:
+      containers:
+        - name: remote
+          image: ${IMAGE}
+          ports:
+            - containerPort: 8081
+      imagePullSecrets:
+        - name: ecr-secret

--- a/terraform/k8s/deploy/variables.tf
+++ b/terraform/k8s/deploy/variables.tf
@@ -1,0 +1,36 @@
+# ------------------------------------------------------------------------
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+# -------------------------------------------------------------------------
+
+variable "test_id" {
+  default = "dummy-123"
+}
+
+variable "aws_region" {
+  default = "<aws-region>"
+}
+
+variable "user" {
+  default = "ec2-user"
+}
+
+variable "ssh_key" {
+  default = "<MASTER_NODE_SSH_KEY>"
+  description = "This variable is responsible for providing the SSH key of the master node to allow terraform to interact with the cluster"
+}
+
+variable "host" {
+  default = "<HOST_IP_OR_DNS>"
+  description = "This variable is responsible for defining which host (ec2 instance) we connect to for the K8s-on-EC2 test"
+}

--- a/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
+++ b/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
@@ -22,7 +22,7 @@ import java.net.URL;
  * resources/expected-data-templates.
  */
 public enum PredefinedExpectedTemplate implements FileConfig {
-  /** EKS Test Case Validations */
+  /** Java EKS Test Case Validations */
   EKS_OUTGOING_HTTP_CALL_LOG("/expected-data-template/eks/outgoing-http-call-log.mustache"),
   EKS_OUTGOING_HTTP_CALL_METRIC("/expected-data-template/eks/outgoing-http-call-metric.mustache"),
   EKS_OUTGOING_HTTP_CALL_TRACE("/expected-data-template/eks/outgoing-http-call-trace.mustache"),
@@ -55,6 +55,23 @@ public enum PredefinedExpectedTemplate implements FileConfig {
   EC2_CLIENT_CALL_LOG("/expected-data-template/ec2/client-call-log.mustache"),
   EC2_CLIENT_CALL_METRIC("/expected-data-template/ec2/client-call-metric.mustache"),
   EC2_CLIENT_CALL_TRACE("/expected-data-template/ec2/client-call-trace.mustache"),
+
+  /** Java EC2 Test Case Validations */
+  K8S_OUTGOING_HTTP_CALL_LOG("/expected-data-template/k8s/outgoing-http-call-log.mustache"),
+  K8S_OUTGOING_HTTP_CALL_METRIC("/expected-data-template/k8s/outgoing-http-call-metric.mustache"),
+  K8S_OUTGOING_HTTP_CALL_TRACE("/expected-data-template/k8s/outgoing-http-call-trace.mustache"),
+
+  K8S_AWS_SDK_CALL_LOG("/expected-data-template/k8s/aws-sdk-call-log.mustache"),
+  K8S_AWS_SDK_CALL_METRIC("/expected-data-template/k8s/aws-sdk-call-metric.mustache"),
+  K8S_AWS_SDK_CALL_TRACE("/expected-data-template/k8s/aws-sdk-call-trace.mustache"),
+
+  K8S_REMOTE_SERVICE_LOG("/expected-data-template/k8s/remote-service-log.mustache"),
+  K8S_REMOTE_SERVICE_METRIC("/expected-data-template/k8s/remote-service-metric.mustache"),
+  K8S_REMOTE_SERVICE_TRACE("/expected-data-template/k8s/remote-service-trace.mustache"),
+
+  K8S_CLIENT_CALL_LOG("/expected-data-template/k8s/client-call-log.mustache"),
+  K8S_CLIENT_CALL_METRIC("/expected-data-template/k8s/client-call-metric.mustache"),
+  K8S_CLIENT_CALL_TRACE("/expected-data-template/k8s/client-call-trace.mustache"),
 
  /** Python EKS Test Case Validations */
   PYTHON_EKS_OUTGOING_HTTP_CALL_LOG("/expected-data-template/python/eks/outgoing-http-call-log.mustache"),

--- a/validator/src/main/resources/expected-data-template/k8s/aws-sdk-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/k8s/aws-sdk-call-log.mustache
@@ -1,0 +1,29 @@
+[{
+  "EC2.InstanceId": "^i-[A-Za-z0-9]{17}$",
+  "HostedIn.K8s.Cluster": "^{{platformInfo}}$",
+  "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+  "K8s.Node": "^i-[A-Za-z0-9]{17}$",
+  "K8s.Pod": "^sample-app-deployment-{{testingId}}(-[A-Za-z0-9]*)*$",
+  "K8s.Workload": "^sample-app-deployment-{{testingId}}$",
+  "Operation": "GET /aws-sdk-call",
+  "OTelLib": "^AwsSpanMetricsProcessor$",
+  "Version": "^1$",
+  "aws.span.kind": "^LOCAL_ROOT$",
+  "host.name": "^ip(-[0-9]{1,3}){4}\\.ec2\\.internal$"
+},
+{
+  "EC2.InstanceId": "^i-[A-Za-z0-9]{17}$",
+  "HostedIn.K8s.Cluster": "^{{platformInfo}}$",
+  "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+  "K8s.Node": "^i-[A-Za-z0-9]{17}$",
+  "K8s.Pod": "^sample-app-deployment-{{testingId}}(-[A-Za-z0-9]*)*$",
+  "K8s.Workload": "^sample-app-deployment-{{testingId}}$",
+  "Operation": "GET /aws-sdk-call",
+  "OTelLib": "^AwsSpanMetricsProcessor$",
+  "Version": "^1$",
+  "RemoteService": "AWS.SDK.S3",
+  "RemoteOperation": "GetBucketLocation",
+  "RemoteTarget": "::s3:::e2e-test-bucket-name",
+  "aws.span.kind": "^CLIENT$",
+  "host.name": "^ip(-[0-9]{1,3}){4}\\.ec2\\.internal$"
+}]

--- a/validator/src/main/resources/expected-data-template/k8s/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/k8s/aws-sdk-call-metric.mustache
@@ -1,0 +1,419 @@
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: ::s3:::e2e-test-bucket-name
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: ::s3:::e2e-test-bucket-name
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: ::s3:::e2e-test-bucket-name
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: ::s3:::e2e-test-bucket-name
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: ::s3:::e2e-test-bucket-name
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: ::s3:::e2e-test-bucket-name

--- a/validator/src/main/resources/expected-data-template/k8s/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/k8s/aws-sdk-call-trace.mustache
@@ -1,0 +1,65 @@
+[{
+  "name": "^{{serviceName}}$",
+  "http": {
+    "request": {
+      "url": "^{{endpoint}}/aws-sdk-call$",
+      "method": "^GET$"
+    },
+    "response": {
+      "status": "^200$"
+    }
+  },
+  "aws": {
+    "account_id": "^{{accountId}}$"
+  },
+  "annotations": {
+    "aws.local.service": "^{{serviceName}}$",
+    "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+    "HostedIn.K8s.Cluster": "^{{platformInfo}}$",
+    "aws.local.operation": "^GET /aws-sdk-call$"
+  },
+  "metadata": {
+    "default": {
+          "otel.resource.K8s.Workload": "^sample-app-deployment-{{testingId}}$",
+          "otel.resource.K8s.Node": "^i-[A-Za-z0-9]{17}$",
+          "otel.resource.K8s.Pod": "^sample-app-deployment-{{testingId}}(-[A-Za-z0-9]*)*$",
+        "aws.span.kind": "^LOCAL_ROOT$"
+    }
+  },
+  "subsegments": [
+    {
+      "subsegments": [
+        {
+          "name": "^S3$",
+          "http": {
+            "request": {
+              "url": "^https://e2e-test-bucket-name.s3.{{region}}.amazonaws.com\\?location$",
+              "method": "^GET$"
+            }
+          },
+          "annotations": {
+            "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+            "HostedIn.K8s.Cluster": "^{{platformInfo}}$",
+            "aws.local.service": "^{{serviceName}}$",
+            "aws.local.operation": "^GET /aws-sdk-call$",
+            "aws.remote.service": "^AWS\\.SDK\\.S3$",
+            "aws.remote.operation": "GetBucketLocation",
+            "aws.remote.target": "::s3:::e2e-test-bucket-name"
+          },
+          "metadata": {
+            "default": {
+              "aws.span.kind": "^CLIENT$"
+            }
+          },
+          "namespace": "^aws$"
+        }
+      ]
+    }
+  ]
+},
+{
+  "name": "^S3$",
+  "aws": {
+    "operation": "^GetBucketLocation$"
+  }
+}]

--- a/validator/src/main/resources/expected-data-template/k8s/client-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/k8s/client-call-log.mustache
@@ -1,0 +1,28 @@
+[{
+  "EC2.InstanceId": "^i-[A-Za-z0-9]{17}$",
+  "HostedIn.K8s.Cluster": "^{{platformInfo}}$",
+  "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+  "K8s.Node": "^i-[A-Za-z0-9]{17}$",
+  "K8s.Pod": "^sample-app-deployment-{{testingId}}(-[A-Za-z0-9]*)*$",
+  "K8s.Workload": "^sample-app-deployment-{{testingId}}$",
+  "Operation": "InternalOperation",
+  "OTelLib": "^AwsSpanMetricsProcessor$",
+  "Version": "^1$",
+  "aws.span.kind": "^LOCAL_ROOT$",
+  "host.name": "^ip(-[0-9]{1,3}){4}\\.ec2\\.internal$"
+},
+{
+  "EC2.InstanceId": "^i-[A-Za-z0-9]{17}$",
+  "HostedIn.K8s.Cluster": "^{{platformInfo}}$",
+  "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+  "K8s.Node": "^i-[A-Za-z0-9]{17}$",
+  "K8s.Pod": "^sample-app-deployment-{{testingId}}(-[A-Za-z0-9]*)*$",
+  "K8s.Workload": "^sample-app-deployment-{{testingId}}$",
+  "Operation": "InternalOperation",
+  "OTelLib": "^AwsSpanMetricsProcessor$",
+  "Version": "^1$",
+  "RemoteService": "local-root-client-call",
+  "RemoteOperation": "GET /",
+  "aws.span.kind": "^CLIENT$",
+  "host.name": "^ip(-[0-9]{1,3}){4}\\.ec2\\.internal$"
+}]

--- a/validator/src/main/resources/expected-data-template/k8s/client-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/k8s/client-call-metric.mustache
@@ -1,0 +1,323 @@
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: GET /client-call
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: local-root-client-call
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: GET /client-call
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: local-root-client-call
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: GET /client-call
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: local-root-client-call

--- a/validator/src/main/resources/expected-data-template/k8s/client-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/k8s/client-call-trace.mustache
@@ -1,0 +1,57 @@
+[{
+  "name": "^{{serviceName}}$",
+  "annotations": {
+    "aws.local.service": "^{{serviceName}}$",
+    "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+    "HostedIn.K8s.Cluster": "^{{platformInfo}}$",
+    "aws.local.operation": "^InternalOperation$"
+  },
+  "metadata": {
+    "default": {
+          "otel.resource.K8s.Workload": "^sample-app-deployment-{{testingId}}$",
+          "otel.resource.K8s.Node": "^i-[A-Za-z0-9]{17}$",
+          "otel.resource.K8s.Pod": "^sample-app-deployment-{{testingId}}(-[A-Za-z0-9]*)*$"
+    }
+  },
+  "subsegments": [
+    {
+      "name": "^local-root-client-call$",
+      "http": {
+          "request": {
+              "url": "^http://local-root-client-call$",
+              "method": "^GET$"
+          }
+      },
+      "annotations": {
+        "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+        "HostedIn.K8s.Cluster": "^{{platformInfo}}$",
+        "aws.local.service": "^{{serviceName}}$",
+        "aws.local.operation": "^InternalOperation$",
+        "aws.remote.service": "^local-root-client-call$",
+        "aws.remote.operation": "GET /"
+      },
+      "metadata": {
+        "default": {
+          "aws.span.kind": "^LOCAL_ROOT$"
+        }
+      },
+      "namespace": "^remote$"
+    }
+  ]
+},
+{
+    "name": "^local-root-client-call$",
+    "http": {
+        "request": {
+            "url": "^http://local-root-client-call$",
+            "method": "^GET$"
+        },
+        "response": {
+            "content_length": 0
+        }
+    },
+    "annotations": {
+        "aws.local.service": "^local-root-client-call$",
+        "aws.local.operation": "^GET /$"
+    }
+}]

--- a/validator/src/main/resources/expected-data-template/k8s/outgoing-http-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/k8s/outgoing-http-call-log.mustache
@@ -1,0 +1,29 @@
+[{
+  "EC2.InstanceId": "^i-[A-Za-z0-9]{17}$",
+  "HostedIn.K8s.Cluster": "^{{platformInfo}}$",
+  "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+  "K8s.Node": "^i-[A-Za-z0-9]{17}$",
+  "K8s.Pod": "^sample-app-deployment-{{testingId}}(-[A-Za-z0-9]*)*$",
+  "K8s.Workload": "^sample-app-deployment-{{testingId}}$",
+  "Operation": "GET /outgoing-http-call",
+  "OTelLib": "^AwsSpanMetricsProcessor$",
+  "Version": "^1$",
+  "aws.span.kind": "^LOCAL_ROOT$",
+  "host.name": "^ip(-[0-9]{1,3}){4}\\.ec2\\.internal$"
+},
+{
+  "EC2.InstanceId": "^i-[A-Za-z0-9]{17}$",
+  "HostedIn.K8s.Cluster": "^{{platformInfo}}$",
+  "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+  "K8s.Node": "^i-[A-Za-z0-9]{17}$",
+  "K8s.Pod": "^sample-app-deployment-{{testingId}}(-[A-Za-z0-9]*)*$",
+  "K8s.Workload": "^sample-app-deployment-{{testingId}}$",
+  "Operation": "GET /outgoing-http-call",
+  "OTelLib": "^AwsSpanMetricsProcessor$",
+  "Version": "^1$",
+  "RemoteService": "www.amazon.com",
+  "RemoteOperation": "GET /",
+  "aws.span.kind": "^CLIENT$",
+  "host.name": "^ip(-[0-9]{1,3}){4}\\.ec2\\.internal$"
+}]
+

--- a/validator/src/main/resources/expected-data-template/k8s/outgoing-http-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/k8s/outgoing-http-call-metric.mustache
@@ -1,0 +1,272 @@
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /outgoing-http-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /outgoing-http-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: www.amazon.com
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /outgoing-http-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /outgoing-http-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: www.amazon.com
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /outgoing-http-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /outgoing-http-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: www.amazon.com

--- a/validator/src/main/resources/expected-data-template/k8s/outgoing-http-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/k8s/outgoing-http-call-trace.mustache
@@ -1,0 +1,61 @@
+[{
+  "name": "^{{serviceName}}$",
+  "http": {
+    "request": {
+      "url": "^{{endpoint}}/outgoing-http-call$",
+      "method": "^GET$"
+    },
+    "response": {
+      "status": "^200$"
+    }
+  },
+  "aws": {
+    "account_id": "^{{accountId}}$"
+  },
+  "annotations": {
+    "aws.local.service": "^{{serviceName}}$",
+    "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+    "HostedIn.K8s.Cluster": "^{{platformInfo}}$",
+    "aws.local.operation": "^GET /outgoing-http-call$"
+  },
+  "metadata": {
+      "default": {
+          "otel.resource.K8s.Workload": "^sample-app-deployment-{{testingId}}$",
+          "otel.resource.K8s.Node": "^i-[A-Za-z0-9]{17}$",
+          "otel.resource.K8s.Pod": "^sample-app-deployment-{{testingId}}(-[A-Za-z0-9]*)*$",
+          "aws.span.kind": "^LOCAL_ROOT$"
+      }
+  },
+  "subsegments": [
+    {
+      "subsegments": [
+        {
+          "name": "^www.amazon.com$",
+          "http": {
+            "request": {
+              "url": "^https://www.amazon.com$",
+              "method": "^GET$"
+            }
+          },
+          "annotations": {
+            "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+            "HostedIn.K8s.Cluster": "^{{platformInfo}}$",
+            "aws.local.service": "^{{serviceName}}$",
+            "aws.local.operation": "^GET /outgoing-http-call$",
+            "aws.remote.service": "^www.amazon.com$",
+            "aws.remote.operation": "^GET /$"
+          },
+          "metadata": {
+            "default": {
+              "aws.span.kind": "^CLIENT$"
+            }
+          },
+          "namespace": "^remote$"
+        }
+      ]
+    }
+  ]
+},
+{
+  "name": "^www.amazon.com$"
+}]

--- a/validator/src/main/resources/expected-data-template/k8s/remote-service-log.mustache
+++ b/validator/src/main/resources/expected-data-template/k8s/remote-service-log.mustache
@@ -1,0 +1,28 @@
+[{
+  "EC2.InstanceId": "^i-[A-Za-z0-9]{17}$",
+  "HostedIn.K8s.Cluster": "^{{platformInfo}}$",
+  "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+  "K8s.Node": "^i-[A-Za-z0-9]{17}$",
+  "K8s.Pod": "^sample-app-deployment-{{testingId}}(-[A-Za-z0-9]*)*$",
+  "K8s.Workload": "^sample-app-deployment-{{testingId}}$",
+  "Operation": "GET /remote-service",
+  "OTelLib": "^AwsSpanMetricsProcessor$",
+  "Version": "^1$",
+  "aws.span.kind": "^LOCAL_ROOT$",
+  "host.name": "^ip(-[0-9]{1,3}){4}\\.ec2\\.internal$"
+},
+{
+  "EC2.InstanceId": "^i-[A-Za-z0-9]{17}$",
+  "HostedIn.K8s.Cluster": "^{{platformInfo}}$",
+  "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+  "K8s.Node": "^i-[A-Za-z0-9]{17}$",
+  "K8s.Pod": "^sample-app-deployment-{{testingId}}(-[A-Za-z0-9]*)*$",
+  "K8s.Workload": "^sample-app-deployment-{{testingId}}$",
+  "Operation": "GET /remote-service",
+  "OTelLib": "^AwsSpanMetricsProcessor$",
+  "Version": "^1$",
+  "RemoteService": "{{remoteServiceName}}",
+  "RemoteOperation": "GET /healthcheck",
+  "aws.span.kind": "^CLIENT$",
+  "host.name": "^ip(-[0-9]{1,3}){4}\\.ec2\\.internal$"
+}]

--- a/validator/src/main/resources/expected-data-template/k8s/remote-service-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/k8s/remote-service-metric.mustache
@@ -1,0 +1,596 @@
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceName}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: Operation
+      value: GET /healthcheck
+    -
+      name: Service
+      value: {{remoteServiceName}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{remoteServiceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: {{remoteServiceName}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceName}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: {{remoteServiceName}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: K8s.RemoteNamespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: {{remoteServiceName}}
+    -
+      name: Service
+      value: {{serviceName}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: K8s.RemoteNamespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceName}}
+    -
+      name: Service
+      value: {{serviceName}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: K8s.RemoteNamespace
+      value: {{appNamespace}}
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceName}}
+    -
+      name: Service
+      value: {{serviceName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: Operation
+      value: GET /healthcheck
+    -
+      name: Service
+      value: {{remoteServiceName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{remoteServiceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: {{remoteServiceName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: {{remoteServiceName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: K8s.RemoteNamespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: {{remoteServiceName}}
+    -
+      name: Service
+      value: {{serviceName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: K8s.RemoteNamespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceName}}
+    -
+      name: Service
+      value: {{serviceName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: K8s.RemoteNamespace
+      value: {{appNamespace}}
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceName}}
+    -
+      name: Service
+      value: {{serviceName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: Operation
+      value: GET /healthcheck
+    -
+      name: Service
+      value: {{remoteServiceName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{remoteServiceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: {{remoteServiceName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: {{remoteServiceName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: K8s.RemoteNamespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: {{remoteServiceName}}
+    -
+      name: Service
+      value: {{serviceName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: K8s.RemoteNamespace
+      value: {{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceName}}
+    -
+      name: Service
+      value: {{serviceName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: K8s.RemoteNamespace
+      value: {{appNamespace}}
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceName}}
+    -
+      name: Service
+      value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/k8s/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/k8s/remote-service-trace.mustache
@@ -1,0 +1,91 @@
+[{
+  "name": "^{{serviceName}}$",
+  "http": {
+    "request": {
+      "url": "^{{endpoint}}/remote-service\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})/$",
+      "method": "^GET$"
+    },
+    "response": {
+      "status": "^200$"
+    }
+  },
+  "aws": {
+    "account_id": "^{{accountId}}$"
+  },
+  "annotations": {
+    "aws.local.service": "^{{serviceName}}$",
+    "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+    "HostedIn.K8s.Cluster": "^{{platformInfo}}$",
+    "aws.local.operation": "^GET /remote-service$"
+  },
+  "metadata": {
+      "default": {
+          "otel.resource.K8s.Workload": "^sample-app-deployment-{{testingId}}$",
+          "otel.resource.K8s.Node": "^i-[A-Za-z0-9]{17}$",
+          "otel.resource.K8s.Pod": "^sample-app-deployment-{{testingId}}(-[A-Za-z0-9]*)*$",
+          "aws.span.kind": "^LOCAL_ROOT$"
+      }
+  },
+  "subsegments": [
+    {
+      "subsegments": [
+        {
+          "name": "^{{remoteServiceDeploymentName}}$",
+          "http": {
+            "request": {
+              "url": "^http://(([0-9]{1,3}.){3}[0-9]{1,3}):8080/healthcheck$",
+              "method": "^GET$"
+            }
+          },
+          "annotations": {
+            "aws.local.service": "^{{serviceName}}$",
+            "aws.local.operation": "^GET /remote-service$",
+            "aws.remote.service": "^{{remoteServiceDeploymentName}}$",
+            "aws.remote.operation": "^GET /healthcheck$"
+          },
+          "metadata": {
+              "default": {
+                  "aws.span.kind": "^CLIENT$"
+              }
+           },
+          "namespace": "^remote$"
+        }
+      ]
+    }
+  ]
+},
+{
+  "name": "^{{remoteServiceDeploymentName}}$",
+  "http": {
+    "request": {
+      "url": "^http://(([0-9]{1,3}.){3}[0-9]{1,3}):8080/healthcheck$",
+      "method": "^GET$"
+    }
+  },
+  "annotations": {
+    "aws.local.service": "^{{remoteServiceDeploymentName}}$",
+    "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
+    "HostedIn.K8s.Cluster": "^{{platformInfo}}$",
+    "aws.local.operation": "^GET /healthcheck$"
+  },
+  "metadata": {
+      "default": {
+          "otel.resource.K8s.Workload": "^{{remoteServiceDeploymentName}}$",
+          "otel.resource.K8s.Node": "^i-[A-Za-z0-9]{17}$",
+          "otel.resource.K8s.Pod": "^{{remoteServiceDeploymentName}}(-[A-Za-z0-9]*)*$",
+          "aws.span.kind": "^LOCAL_ROOT$"
+      }
+  },
+  "subsegments": [
+    {
+      "name": "^RemoteServiceController\\.healthcheck$",
+      "annotations": {
+        "HostedIn.K8s.Namespace": "^sample-app-namespace$",
+        "HostedIn.K8s.Cluster": "^{{platformInfo}}$",
+        "aws.local.operation": "^GET /healthcheck$"
+      }
+    }
+  ]
+}]
+
+

--- a/validator/src/main/resources/validations/k8s/log-validation.yml
+++ b/validator/src/main/resources/validations/k8s/log-validation.yml
@@ -1,0 +1,24 @@
+-
+  validationType: "cw-log"
+  httpPath: "/outgoing-http-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedLogStructureTemplate: "K8S_OUTGOING_HTTP_CALL_LOG"
+-
+  validationType: "cw-log"
+  httpPath: "/aws-sdk-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedLogStructureTemplate: "K8S_AWS_SDK_CALL_LOG"
+-
+  validationType: "cw-log"
+  httpPath: "/remote-service"
+  httpMethod: "get"
+  callingType: "http-with-body"
+  expectedLogStructureTemplate: "K8S_REMOTE_SERVICE_LOG"
+-
+  validationType: "cw-log"
+  httpPath: "/client-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedLogStructureTemplate: "K8S_CLIENT_CALL_LOG"

--- a/validator/src/main/resources/validations/k8s/metric-validation.yml
+++ b/validator/src/main/resources/validations/k8s/metric-validation.yml
@@ -1,0 +1,24 @@
+-
+  validationType: "cw-metric"
+  httpPath: "/outgoing-http-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedMetricTemplate: "K8S_OUTGOING_HTTP_CALL_METRIC"
+-
+  validationType: "cw-metric"
+  httpPath: "/aws-sdk-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedMetricTemplate: "K8S_AWS_SDK_CALL_METRIC"
+-
+  validationType: "cw-metric"
+  httpPath: "/remote-service"
+  httpMethod: "get"
+  callingType: "http-with-body"
+  expectedMetricTemplate: "K8S_REMOTE_SERVICE_METRIC"
+-
+  validationType: "cw-metric"
+  httpPath: "/client-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedMetricTemplate: "K8S_CLIENT_CALL_METRIC"

--- a/validator/src/main/resources/validations/k8s/trace-validation.yml
+++ b/validator/src/main/resources/validations/k8s/trace-validation.yml
@@ -1,0 +1,24 @@
+-
+  validationType: "trace"
+  httpPath: "/outgoing-http-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedTraceTemplate: "K8S_OUTGOING_HTTP_CALL_TRACE"
+-
+  validationType: "trace"
+  httpPath: "/aws-sdk-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedTraceTemplate: "K8S_AWS_SDK_CALL_TRACE"
+-
+  validationType: "trace"
+  httpPath: "/remote-service"
+  httpMethod: "get"
+  callingType: "http-with-body"
+  expectedTraceTemplate: "K8S_REMOTE_SERVICE_TRACE"
+-
+  validationType: "trace"
+  httpPath: "/client-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedTraceTemplate: "K8S_CLIENT_CALL_TRACE"


### PR DESCRIPTION
We want to test app signals on native kubernetes.
I have set up a native K8s cluster in IAD using kubeadm running on two EC2 instances (a master and worker node). The cluster is set to be clean (no operator or sample app) while the test is not running. Due to the cluster set up being quite complicated, this test is only set up in IAD as of now. Future effort may be assigned to extending this to all regions.

This test adds the requirement for the following IAM policies to be added the the EC2 IAM instance profile used in the test case:
* `AmazonS3FullAccess` (instead of `AmazonS3ReadOnlyAccess`): Used to push and pull the deployment files for the sample application using the existing e2e test related S3 bucket
* `AmazonSSMFullAccess`: Used to push and pull the remote service pod IP (this cannot be emitted from the SSH connection to the terraform, and this alternative solution provides a way for us to emit and collect this information)
* `AWSAppRunnerServicePolicyForECRAccess`: Used to pull the ECR images for the main and remote service of our sample application

This change is already done and verified in the IAD account.

*Description of changes:*
* Implemented terraform scripts for deployment and teardown of operator + sample app
  * The scripts use an SSH connection to access a preexisting kubeadm native kubernetes cluster that is placed in our IAD testing account and that runs on 2 EC2 instances running Amazon Linux 2
* Implemented workflow to run the terraform and validation + emit metrics
* Implemented canary to call this workflow every 15 minutes
* Added validations for K8s use case to validator
* Also removed unused `TEST` environment variable from ec2 test case

*Testing:*
* 7 test runs: [link](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8427135248)
* 7 more test runs: [link](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8427640510)
* 7 more test runs after changing to <<-EOF syntax as per comments: [link](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8529478955)
* 7 more test runs after addressing more comments relating to region environment variable: [link](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8727065717)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

