### PR TITLE
Run E2E Test in docker container with packages already installed

### DIFF
--- a/.github/workflows/appsignals-e2e-ec2-test.yml
+++ b/.github/workflows/appsignals-e2e-ec2-test.yml
@@ -32,12 +32,17 @@ env:
   TEST: ${{ inputs.test }}
   GET_ADOT_JAR_COMMAND: "wget -O adot.jar https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar"
   GET_CW_AGENT_RPM_COMMAND: "wget -O cw-agent.rpm https://amazoncloudwatch-agent-${{ inputs.aws-region }}.s3.${{ inputs.aws-region }}.amazonaws.com/amazon_linux/amd64/1.300031.0b313/amazon-cloudwatch-agent.rpm"
-  TEST_RESOURCES_FOLDER: /home/runner/work/aws-application-signals-test-framework/aws-application-signals-test-framework
+  TEST_RESOURCES_FOLDER: /__w/aws-application-signals-test-framework/aws-application-signals-test-framework
 
 
 jobs:
   e2e-ec2-test:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/aws-observability/aws-application-signals-test-framework
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.PAT_PACKAGE_READ_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -63,13 +68,6 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ secrets.E2E_TEST_ROLE_ARN }}
           aws-region: ${{ inputs.aws-region }}
-
-      - name: Set up terraform
-        uses: ./.github/workflows/actions/execute_and_retry
-        with:
-          command: "wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg"
-          post-command: 'echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          && sudo apt update && sudo apt install terraform'
 
       - name: Initiate Terraform
         uses: ./.github/workflows/actions/execute_and_retry
@@ -176,13 +174,6 @@ jobs:
           curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}/aws-sdk-call/
           curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_IP }}/
           curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}/client-call/
-          
-      - name: Build Gradlew
-        uses: ./.github/workflows/actions/execute_and_retry
-        with:
-          max_retry: 2
-          command: "./gradlew"
-          cleanup: "./gradlew clean"
 
       # Validation for pulse telemetry data
       - name: Validate generated EMF logs

--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -35,11 +35,17 @@ env:
   SAMPLE_APP_REMOTE_SERVICE_IMAGE: ${{ secrets.APP_SIGNALS_E2E_TEST_ACC }}.dkr.ecr.${{ inputs.aws-region }}.amazonawss.com/${{ secrets.APP_SIGNALS_E2E_RE_SA_IMG }}
   METRIC_NAMESPACE: AppSignals
   LOG_GROUP_NAME: /aws/appsignals/eks
-  TEST_RESOURCES_FOLDER: /home/runner/work/aws-application-signals-test-framework/aws-application-signals-test-framework
+  TEST_RESOURCES_FOLDER: /__w/aws-application-signals-test-framework/aws-application-signals-test-framework
 
 jobs:
   e2e-eks-test:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/aws-observability/aws-application-signals-test-framework
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.PAT_PACKAGE_READ_ACCESS_TOKEN }}
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -88,23 +94,8 @@ jobs:
           role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ secrets.E2E_TEST_ROLE_ARN }}
           aws-region: ${{ inputs.aws-region }}
 
-      # local directory to store the kubernetes config
-      - name: Create kubeconfig directory
-        run: mkdir -p ${{ github.workspace }}/.kube
-
-      - name: Set KUBECONFIG environment variable
-        run: echo KUBECONFIG="${{ github.workspace }}/.kube/config" >> $GITHUB_ENV
-
       - name: Set up kubeconfig
         run: aws eks update-kubeconfig --name ${{ inputs.test-cluster-name }} --region ${{ inputs.aws-region }}
-
-      - name: Download and install eksctl
-        uses: ./.github/workflows/actions/execute_and_retry
-        with:
-          pre-command: 'mkdir ${{ github.workspace }}/eksctl'
-          command: 'curl -sLO "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_Linux_amd64.tar.gz" 
-          && tar -xzf eksctl_Linux_amd64.tar.gz -C ${{ github.workspace }}/eksctl && rm eksctl_Linux_amd64.tar.gz'
-          cleanup: 'rm -f eksctl_Linux_amd64.tar.gz'
 
       - name: Add eksctl to Github Path
         run: |
@@ -122,13 +113,6 @@ jobs:
           --attach-policy-arn arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess \
           --region ${{ inputs.aws-region }} \
           --approve"
-
-      - name: Set up terraform
-        uses: ./.github/workflows/actions/execute_and_retry
-        with:
-          command: "wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg"
-          post-command: 'echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          && sudo apt update && sudo apt install terraform'
 
       - name: Initiate Terraform
         uses: ./.github/workflows/actions/execute_and_retry
@@ -168,7 +152,7 @@ jobs:
             # If the deployment_failed is still 0, then the terraform deployment succeeded and now try to connect to the endpoint 
             # after installing App Signals. Attempts to connect will be made for up to 10 minutes
             if [ $deployment_failed -eq 0 ]; then
-              source ${{ env.TEST_RESOURCES_FOLDER }}/.github/workflows/util/execute_and_retry.sh
+              . ${{ env.TEST_RESOURCES_FOLDER }}/.github/workflows/util/execute_and_retry.sh
               execute_and_retry 2 \
               "${{ env.TEST_RESOURCES_FOLDER }}/enablement-script/enable-app-signals.sh \
               ${{ inputs.test-cluster-name }} \
@@ -278,13 +262,6 @@ jobs:
           curl -S -s http://${{ env.APP_ENDPOINT }}/aws-sdk-call/
           curl -S -s http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_POD_IP }}/
           curl -S -s http://${{ env.APP_ENDPOINT }}/client-call/
-
-      - name: Build Gradlew
-        uses: ./.github/workflows/actions/execute_and_retry
-        with:
-          max_retry: 2
-          command: "./gradlew"
-          cleanup: "./gradlew clean"
 
       # Validation for app signals telemetry data
       - name: Call endpoint and validate generated EMF logs

--- a/.github/workflows/e2e-test-docker-image-build.yml
+++ b/.github/workflows/e2e-test-docker-image-build.yml
@@ -1,0 +1,30 @@
+name: Create and publish a Docker image
+
+on:
+  workflow_dispatch:
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/util/execute_and_retry.sh
+++ b/.github/workflows/util/execute_and_retry.sh
@@ -30,4 +30,4 @@ execute_and_retry () {
   done
 }
 
-export -f execute_and_retry
+export VARIABLE=execute_and_retry

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# Use an image with java 11 installed as the basis
+FROM openjdk:11-jdk
+
+# Set the Java path
+ENV JAVA_HOME=/usr/local/openjdk-11
+ENV PATH="$JAVA_HOME/bin:${PATH}"
+
+# Install the neccessary commands
+RUN \
+    apt-get update -y && \
+    apt-get install unzip -y && \
+    apt-get install wget -y && \
+    apt-get install vim -y && \
+    apt-get install curl -y && \
+    apt-get install git -y && \
+    apt-get install jq -y
+
+# Install kubectl
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
+    && chmod +x ./kubectl \
+    && mv ./kubectl /usr/local/bin/kubectl
+
+# Install awscli
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2.zip ./aws
+
+# Install Terraform
+RUN wget https://releases.hashicorp.com/terraform/1.7.5/terraform_1.7.5_linux_amd64.zip
+RUN unzip terraform_1.7.5_linux_amd64.zip
+RUN mv terraform /usr/local/bin/
+
+# Install eksctl
+RUN curl -sLO "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_Linux_amd64.tar.gz"
+RUN tar -xzf eksctl_Linux_amd64.tar.gz -C /tmp && rm eksctl_Linux_amd64.tar.gz
+RUN mv /tmp/eksctl /usr/local/bin
+
+# Copy the Gradle wrapper files (gradlew and gradle wrapper jar) to the container
+COPY gradlew .
+COPY settings.gradle.kts .
+COPY gradlew.bat .
+COPY gradle/ /gradle/
+COPY buildSrc/ /buildSrc/
+COPY validator/ /validator/
+
+# Build gradlew here so that the canary doesn't spend time downloading and building the package
+RUN ./gradlew


### PR DESCRIPTION
*Issue #, if available:*
The e2e canary occasionally fails while downloading packages (Terraform, Gradlew, Eksctl) due to transient issues. Currently we have wrapped those packages with retries, but they are still causing issues that is triggering the canary to fail. 

*Description of changes:*
Rather than attempting to download the packages during every canary run, we will build a docker image that already has all the necessary packages installed. This docker image will be built using a dispatch workflow, and stored in the github container registry (Can see under package [tab](https://github.com/aws-observability/aws-application-signals-test-framework/pkgs/container/aws-application-signals-test-framework)) The canary will run in the docker container, so this should prevent issues such as gradlew failing to build successfully. 

- Dispatch workflow to update the docker image. This should only run when there is changes in the Dockerfile.
- Changed the eks and ec2 tests to run in a container
- Removed eksctl, awscli, gradle setup in the tests

Test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8525187366

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

