### PR TITLE
Update python expected-data-template to match with cw agent rpm latest version

### DIFF
--- a/terraform/python/ec2/main.tf
+++ b/terraform/python/ec2/main.tf
@@ -115,7 +115,7 @@ resource "null_resource" "main_service_setup" {
       "echo $agent_config > amazon-cloudwatch-agent.json",
 
       # Get and run CW agent rpm
-      "wget -O cw-agent.rpm https://amazoncloudwatch-agent-us-east-1.s3.us-east-1.amazonaws.com/amazon_linux/amd64/1.300031.0b313/amazon-cloudwatch-agent.rpm",
+      "${var.get_cw_agent_rpm_command}",
       "sudo rpm -U ./cw-agent.rpm",
       "sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:./amazon-cloudwatch-agent.json",
 
@@ -191,7 +191,7 @@ resource "null_resource" "remote_service_setup" {
       "echo $agent_config > amazon-cloudwatch-agent.json",
 
       # Get and run CW agent rpm
-      "wget -O cw-agent.rpm https://amazoncloudwatch-agent-us-east-1.s3.us-east-1.amazonaws.com/amazon_linux/amd64/1.300031.0b313/amazon-cloudwatch-agent.rpm",
+      "${var.get_cw_agent_rpm_command}",
       "sudo rpm -U ./cw-agent.rpm",
       "sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:./amazon-cloudwatch-agent.json",
 

--- a/validator/src/main/resources/expected-data-template/python/ec2/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/aws-sdk-call-trace.mustache
@@ -13,9 +13,9 @@
     "account_id": "^{{accountId}}$"
   },
   "annotations": {
-    "aws_local_service": "^{{serviceName}}$",
-    "HostedIn_Environment": "^EC2$",
-    "aws_local_operation": "^GET aws-sdk-call$"
+    "aws.local.service": "^{{serviceName}}$",
+    "HostedIn.Environment": "^EC2$",
+    "aws.local.operation": "^GET /aws-sdk-call$"
   },
   "metadata": {
     "default": {
@@ -37,12 +37,12 @@
         "operation": "^GetBucketLocation$"
       },
       "annotations": {
-        "HostedIn_Environment": "^EC2$",
-        "aws_local_service": "^{{serviceName}}$",
-        "aws_local_operation": "^GET aws-sdk-call$",
-        "aws_remote_service": "^AWS\\.SDK\\.S3$",
-        "aws_remote_operation": "^GetBucketLocation$",
-        "aws_remote_target": "^::s3:::e2e-test-bucket-name$"
+        "HostedIn.Environment": "^EC2$",
+        "aws.local.service": "^{{serviceName}}$",
+        "aws.local.operation": "^GET aws-sdk-call$",
+        "aws.remote.service": "^AWS\\.SDK\\.S3$",
+        "aws.remote.operation": "^GetBucketLocation$",
+        "aws.remote.target": "^::s3:::e2e-test-bucket-name$"
       },
       "metadata": {
         "default": {

--- a/validator/src/main/resources/expected-data-template/python/ec2/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/aws-sdk-call-trace.mustache
@@ -15,7 +15,7 @@
   "annotations": {
     "aws.local.service": "^{{serviceName}}$",
     "HostedIn.Environment": "^EC2$",
-    "aws.local.operation": "^GET /aws-sdk-call$"
+    "aws.local.operation": "^GET aws-sdk-call$"
   },
   "metadata": {
     "default": {

--- a/validator/src/main/resources/expected-data-template/python/ec2/client-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/client-call-trace.mustache
@@ -1,9 +1,9 @@
 [{
   "name": "^{{serviceName}}$",
   "annotations": {
-    "aws_local_service": "^{{serviceName}}$",
-    "HostedIn_Environment": "^EC2$",
-    "aws_local_operation": "^InternalOperation$"
+    "aws.local.service": "^{{serviceName}}$",
+    "HostedIn.Environment": "^EC2$",
+    "aws.local.operation": "^InternalOperation$"
   },
   "metadata": {
     "default": {
@@ -23,11 +23,11 @@
           }
       },
       "annotations": {
-        "HostedIn_Environment": "^EC2$",
-        "aws_local_service": "^{{serviceName}}$",
-        "aws_local_operation": "^InternalOperation$",
-        "aws_remote_service": "^local-root-client-call$",
-        "aws_remote_operation": "GET /"
+        "HostedIn.Environment": "^EC2$",
+        "aws.local.service": "^{{serviceName}}$",
+        "aws.local.operation": "^InternalOperation$",
+        "aws.remote.service": "^local-root-client-call$",
+        "aws.remote.operation": "GET /"
       },
       "metadata": {
         "default": {
@@ -50,7 +50,7 @@
         }
     },
     "annotations": {
-        "aws_local_service": "^local-root-client-call$",
-        "aws_local_operation": "^GET /$"
+        "aws.local.service": "^local-root-client-call$",
+        "aws.local.operation": "^GET /$"
     }
 }]

--- a/validator/src/main/resources/expected-data-template/python/ec2/outgoing-http-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/outgoing-http-call-trace.mustache
@@ -15,7 +15,7 @@
   "annotations": {
     "aws.local.service": "^{{serviceName}}$",
     "HostedIn.Environment": "^EC2$",
-    "aws.local.operation": "^GET /outgoing-http-call$"
+    "aws.local.operation": "^GET outgoing-http-call$"
   },
   "metadata": {
       "default": {

--- a/validator/src/main/resources/expected-data-template/python/ec2/outgoing-http-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/outgoing-http-call-trace.mustache
@@ -13,9 +13,9 @@
     "account_id": "^{{accountId}}$"
   },
   "annotations": {
-    "aws_local_service": "^{{serviceName}}$",
-    "HostedIn_Environment": "^EC2$",
-    "aws_local_operation": "^GET outgoing-http-call$"
+    "aws.local.service": "^{{serviceName}}$",
+    "HostedIn.Environment": "^EC2$",
+    "aws.local.operation": "^GET /outgoing-http-call$"
   },
   "metadata": {
       "default": {
@@ -35,11 +35,11 @@
         }
       },
       "annotations": {
-        "HostedIn_Environment": "^EC2$",
-        "aws_local_service": "^{{serviceName}}$",
-        "aws_local_operation": "^GET outgoing-http-call$",
-        "aws_remote_service": "^www.amazon.com$",
-        "aws_remote_operation": "^GET /$"
+        "HostedIn.Environment": "^EC2$",
+        "aws.local.service": "^{{serviceName}}$",
+        "aws.local.operation": "^GET outgoing-http-call$",
+        "aws.remote.service": "^www.amazon.com$",
+        "aws.remote.operation": "^GET /$"
       },
       "metadata": {
         "default": {

--- a/validator/src/main/resources/expected-data-template/python/ec2/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/remote-service-trace.mustache
@@ -13,9 +13,9 @@
     "account_id": "^{{accountId}}$"
   },
   "annotations": {
-    "aws_local_service": "^{{serviceName}}$",
-    "HostedIn_Environment": "^EC2$",
-    "aws_local_operation": "^GET remote-service$"
+    "aws.local.service": "^{{serviceName}}$",
+    "HostedIn.Environment": "^EC2$",
+    "aws.local.operation": "^GET /remote-service$"
   },
   "metadata": {
       "default": {
@@ -35,10 +35,10 @@
         }
       },
       "annotations": {
-        "aws_local_service": "^{{serviceName}}$",
-        "aws_local_operation": "^GET remote-service$",
-        "aws_remote_service": "^{{remoteServiceDeploymentName}}$",
-        "aws_remote_operation": "^GET /healthcheck$"
+        "aws.local.service": "^{{serviceName}}$",
+        "aws.local.operation": "^GET remote-service$",
+        "aws.remote.service": "^{{remoteServiceDeploymentName}}$",
+        "aws.remote.operation": "^GET /healthcheck$"
       },
       "metadata": {
           "default": {
@@ -58,9 +58,9 @@
     }
   },
   "annotations": {
-    "HostedIn_Environment": "^EC2$",
-    "aws_local_service": "^{{remoteServiceName}}$",
-    "aws_local_operation": "^GET healthcheck$"
+    "HostedIn.Environment": "^EC2$",
+    "aws.local.service": "^{{remoteServiceName}}$",
+    "aws.local.operation": "^GET healthcheck$"
   },
   "metadata": {
       "default": {

--- a/validator/src/main/resources/expected-data-template/python/ec2/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/remote-service-trace.mustache
@@ -15,7 +15,7 @@
   "annotations": {
     "aws.local.service": "^{{serviceName}}$",
     "HostedIn.Environment": "^EC2$",
-    "aws.local.operation": "^GET /remote-service$"
+    "aws.local.operation": "^GET remote-service$"
   },
   "metadata": {
       "default": {


### PR DESCRIPTION
Update python expected-data-template to match with cw agent rpm latest version. 
Matching with Java EC2 canary change: https://github.com/aws-observability/aws-application-signals-test-framework/pull/28

An example of workflow test passed:
https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/8527133186/job/23357875065

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

