### PR TITLE
Revert 35 revert 33 build docker for e2e

### DIFF
--- a/.github/workflows/appsignals-e2e-ec2-test.yml
+++ b/.github/workflows/appsignals-e2e-ec2-test.yml
@@ -228,7 +228,7 @@ jobs:
       - name: Publish metric on test result
         if: always()
         run: |
-          if [[ "${{ steps.log-validation.outcome }}" == "success" && "${{ steps.metric-validation.outcome }}" == "success" && "${{ steps.trace-validation.outcome }}" == "success" ]]; then
+          if [ "${{ steps.log-validation.outcome }}" = "success" ] && [ "${{ steps.metric-validation.outcome }}" = "success" ] && [ "${{ steps.trace-validation.outcome }}" = "success" ]; then
             aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
             --metric-name Failure \
             --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=${{ inputs.caller-workflow-name }} \

--- a/.github/workflows/appsignals-e2e-ec2-test.yml
+++ b/.github/workflows/appsignals-e2e-ec2-test.yml
@@ -38,10 +38,7 @@ jobs:
   e2e-ec2-test:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/aws-observability/aws-application-signals-test-framework
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.PAT_PACKAGE_READ_ACCESS_TOKEN }}
+      image: public.ecr.aws/h6o3z5z9/aws-application-signals-test-framework-workflow-container:latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/appsignals-e2e-ec2-test.yml
+++ b/.github/workflows/appsignals-e2e-ec2-test.yml
@@ -31,13 +31,17 @@ env:
   LOG_GROUP_NAME: /aws/appsignals/generic
   TEST: ${{ inputs.test }}
   GET_ADOT_JAR_COMMAND: "wget -O adot.jar https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar"
+  TEST_RESOURCES_FOLDER: /__w/aws-application-signals-test-framework/aws-application-signals-test-framework
   GET_CW_AGENT_RPM_COMMAND: "wget -O cw-agent.rpm https://amazoncloudwatch-agent-${{ inputs.aws-region }}.s3.${{ inputs.aws-region }}.amazonaws.com/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm"
-  TEST_RESOURCES_FOLDER: /home/runner/work/aws-application-signals-test-framework/aws-application-signals-test-framework
-
 
 jobs:
   e2e-ec2-test:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/aws-observability/aws-application-signals-test-framework
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.PAT_PACKAGE_READ_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -63,13 +67,6 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ secrets.E2E_TEST_ROLE_ARN }}
           aws-region: ${{ inputs.aws-region }}
-
-      - name: Set up terraform
-        uses: ./.github/workflows/actions/execute_and_retry
-        with:
-          command: "wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg"
-          post-command: 'echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          && sudo apt update && sudo apt install terraform'
 
       - name: Initiate Terraform
         uses: ./.github/workflows/actions/execute_and_retry
@@ -176,13 +173,6 @@ jobs:
           curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}/aws-sdk-call/
           curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_IP }}/
           curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}/client-call/
-          
-      - name: Build Gradlew
-        uses: ./.github/workflows/actions/execute_and_retry
-        with:
-          max_retry: 2
-          command: "./gradlew"
-          cleanup: "./gradlew clean"
 
       # Validation for pulse telemetry data
       - name: Validate generated EMF logs

--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -313,7 +313,7 @@ jobs:
       - name: Publish metric on test result
         if: always()
         run: |
-          if [[ "${{ steps.log-validation.outcome }}" == "success" && "${{ steps.metric-validation.outcome }}" == "success" && "${{ steps.trace-validation.outcome }}" == "success" ]]; then
+          if [ "${{ steps.log-validation.outcome }}" = "success" ] && [ "${{ steps.metric-validation.outcome }}" = "success" ] && [ "${{ steps.trace-validation.outcome }}" = "success" ]; then
             aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
             --metric-name Failure \
             --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=${{ inputs.caller-workflow-name }} \

--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -41,11 +41,7 @@ jobs:
   e2e-eks-test:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/aws-observability/aws-application-signals-test-framework
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.PAT_PACKAGE_READ_ACCESS_TOKEN }}
-
+      image: public.ecr.aws/h6o3z5z9/aws-application-signals-test-framework-workflow-container:latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -35,11 +35,17 @@ env:
   SAMPLE_APP_REMOTE_SERVICE_IMAGE: ${{ secrets.APP_SIGNALS_E2E_TEST_ACC }}.dkr.ecr.${{ inputs.aws-region }}.amazonawss.com/${{ secrets.APP_SIGNALS_E2E_RE_SA_IMG }}
   METRIC_NAMESPACE: AppSignals
   LOG_GROUP_NAME: /aws/appsignals/eks
-  TEST_RESOURCES_FOLDER: /home/runner/work/aws-application-signals-test-framework/aws-application-signals-test-framework
+  TEST_RESOURCES_FOLDER: /__w/aws-application-signals-test-framework/aws-application-signals-test-framework
 
 jobs:
   e2e-eks-test:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/aws-observability/aws-application-signals-test-framework
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.PAT_PACKAGE_READ_ACCESS_TOKEN }}
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -82,23 +88,8 @@ jobs:
           role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ secrets.E2E_TEST_ROLE_ARN }}
           aws-region: ${{ inputs.aws-region }}
 
-      # local directory to store the kubernetes config
-      - name: Create kubeconfig directory
-        run: mkdir -p ${{ github.workspace }}/.kube
-
-      - name: Set KUBECONFIG environment variable
-        run: echo KUBECONFIG="${{ github.workspace }}/.kube/config" >> $GITHUB_ENV
-
       - name: Set up kubeconfig
         run: aws eks update-kubeconfig --name ${{ inputs.test-cluster-name }} --region ${{ inputs.aws-region }}
-
-      - name: Download and install eksctl
-        uses: ./.github/workflows/actions/execute_and_retry
-        with:
-          pre-command: 'mkdir ${{ github.workspace }}/eksctl'
-          command: 'curl -sLO "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_Linux_amd64.tar.gz" 
-          && tar -xzf eksctl_Linux_amd64.tar.gz -C ${{ github.workspace }}/eksctl && rm eksctl_Linux_amd64.tar.gz'
-          cleanup: 'rm -f eksctl_Linux_amd64.tar.gz'
 
       - name: Add eksctl to Github Path
         run: |
@@ -116,13 +107,6 @@ jobs:
           --attach-policy-arn arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess \
           --region ${{ inputs.aws-region }} \
           --approve"
-
-      - name: Set up terraform
-        uses: ./.github/workflows/actions/execute_and_retry
-        with:
-          command: "wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg"
-          post-command: 'echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
-          && sudo apt update && sudo apt install terraform'
 
       - name: Initiate Terraform
         uses: ./.github/workflows/actions/execute_and_retry
@@ -162,7 +146,7 @@ jobs:
             # If the deployment_failed is still 0, then the terraform deployment succeeded and now try to connect to the endpoint 
             # after installing App Signals. Attempts to connect will be made for up to 10 minutes
             if [ $deployment_failed -eq 0 ]; then
-              source ${{ env.TEST_RESOURCES_FOLDER }}/.github/workflows/util/execute_and_retry.sh
+              . ${{ env.TEST_RESOURCES_FOLDER }}/.github/workflows/util/execute_and_retry.sh
               execute_and_retry 2 \
               "${{ env.TEST_RESOURCES_FOLDER }}/enablement-script/enable-app-signals.sh \
               ${{ inputs.test-cluster-name }} \
@@ -272,13 +256,6 @@ jobs:
           curl -S -s http://${{ env.APP_ENDPOINT }}/aws-sdk-call/
           curl -S -s http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_POD_IP }}/
           curl -S -s http://${{ env.APP_ENDPOINT }}/client-call/
-
-      - name: Build Gradlew
-        uses: ./.github/workflows/actions/execute_and_retry
-        with:
-          max_retry: 2
-          command: "./gradlew"
-          cleanup: "./gradlew clean"
 
       # Validation for app signals telemetry data
       - name: Call endpoint and validate generated EMF logs

--- a/.github/workflows/e2e-test-docker-image-build.yml
+++ b/.github/workflows/e2e-test-docker-image-build.yml
@@ -2,29 +2,37 @@ name: Create and publish a Docker image
 
 on:
   workflow_dispatch:
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          role-to-assume: ${{ secrets.E2E_SECRET_TEST_ROLE_ARN }}
+          aws-region: us-east-1
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+      - name: Login to Amazon ECR
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v2
         with:
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          registry-type: public
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+          REGISTRY_ALIAS: h6o3z5z9
+          REPOSITORY: aws-application-signals-test-framework-workflow-container
+          IMAGE_TAG: latest
+        run: |
+          docker build -t $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG .
+          docker push $REGISTRY/$REGISTRY_ALIAS/$REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/e2e-test-docker-image-build.yml
+++ b/.github/workflows/e2e-test-docker-image-build.yml
@@ -1,0 +1,30 @@
+name: Create and publish a Docker image
+
+on:
+  workflow_dispatch:
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/util/execute_and_retry.sh
+++ b/.github/workflows/util/execute_and_retry.sh
@@ -30,4 +30,4 @@ execute_and_retry () {
   done
 }
 
-export -f execute_and_retry
+export VARIABLE=execute_and_retry

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+# Use an image with java 11 installed as the basis
+FROM openjdk:11-jdk
+
+# Set the Java path
+ENV JAVA_HOME=/usr/local/openjdk-11
+ENV PATH="$JAVA_HOME/bin:${PATH}"
+
+# Install the neccessary commands
+RUN \
+    apt-get update -y && \
+    apt-get install unzip -y && \
+    apt-get install wget -y && \
+    apt-get install vim -y && \
+    apt-get install curl -y && \
+    apt-get install git -y && \
+    apt-get install jq -y
+
+# Install kubectl
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
+    && chmod +x ./kubectl \
+    && mv ./kubectl /usr/local/bin/kubectl
+
+# Install awscli
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install && \
+    rm -rf awscliv2.zip ./aws
+
+# Install Terraform
+RUN wget https://releases.hashicorp.com/terraform/1.7.5/terraform_1.7.5_linux_amd64.zip
+RUN unzip terraform_1.7.5_linux_amd64.zip
+RUN mv terraform /usr/local/bin/
+
+# Install eksctl
+RUN curl -sLO "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_Linux_amd64.tar.gz"
+RUN tar -xzf eksctl_Linux_amd64.tar.gz -C /tmp && rm eksctl_Linux_amd64.tar.gz
+RUN mv /tmp/eksctl /usr/local/bin
+
+# Copy the Gradle wrapper files (gradlew and gradle wrapper jar) to the container
+COPY gradlew .
+COPY settings.gradle.kts .
+COPY gradlew.bat .
+COPY gradle/ /gradle/
+COPY buildSrc/ /buildSrc/
+COPY validator/ /validator/
+
+# Build gradlew here so that the canary doesn't spend time downloading and building the package
+RUN ./gradlew


### PR DESCRIPTION
*Issue #, if available:*
Had to revert this [PR](https://github.com/aws-observability/aws-application-signals-test-framework/pull/33) due to syntax error in the publish metric step. Reposting the change with error fixed

Test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8621464546
Also checked that the metric is present in the console
Test run after switching to ECR: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8644705184

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

