### PR TITLE
[EKS] Separating concurrency tag to be per region

### DIFF
--- a/.github/workflows/appsignals-e2e-eks-canary-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-canary-test.yml
@@ -11,10 +11,6 @@ on:
     - cron: '*/15 * * * *' # run the workflow every 15 minutes
   workflow_dispatch: # be able to run the workflow on demand
 
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
-
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -21,6 +21,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: '${{ github.workflow }} @ ${{ inputs.aws-region }}'
+  cancel-in-progress: false
+
 permissions:
   id-token: write
   contents: read


### PR DESCRIPTION
In the current state, if an EKS E2E test in a single region runs long then all regions will not be able to proceed until that one region is done running its test. This creates cross-region dependencies on our E2E test canary despite them being hosted on entirely separate infrastructure, and can cause false alarms to go off in all regions. As such, I've moved the concurrency tag accordingly and added the region to it so there is no interference

*Description of changes:*
- Remove concurrency tag from the job that generates the test matrix
- Add concurrency tag to the test itself with the region in the `group` attribute

*Testing:*
I do not have the infrastructure set up in my personal fork/account to run this commit as a canary, but I ran the workflows in the following commits twice to show the logic is functional and when checking the workflow runs the one that started second did wait for the first to complete appropriately and only at a regional level. Commits:
Commit 1: [link](https://github.com/aws-observability/aws-application-signals-test-framework/commit/a6c353650874b922c8ac67320b84506030be3bfc)
Commit 2: [link](https://github.com/aws-observability/aws-application-signals-test-framework/commit/18dc4ed8b373cc84c19496f4b01cf691619ac997)
<img width="1904" alt="Screenshot 2024-04-09 at 1 41 58 PM" src="https://github.com/aws-observability/aws-application-signals-test-framework/assets/134644284/03cc018f-f84c-4141-8ada-868f13af5319">
<img width="1596" alt="Screenshot 2024-04-09 at 1 41 51 PM" src="https://github.com/aws-observability/aws-application-signals-test-framework/assets/134644284/1c4bdfdf-f26b-4e6b-9d1b-03fb3c2be66d">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

