### PR TITLE
Append testing id to sample-app-namespace

### DIFF
--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Generate testing id and sample app namespace
         run: |
           echo TESTING_ID="${{ inputs.aws-region }}-${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
-          echo SAMPLE_APP_NAMESPACE="sample-app-namespace-${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
+          echo SAMPLE_APP_NAMESPACE="ns-${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -34,7 +34,6 @@ env:
   # It is not redundant
   AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
   ENABLEMENT_SCRIPT_S3_BUCKET: ${{ secrets.APP_SIGNALS_E2E_ENABLEMENT_SCRIPT }}
-  SAMPLE_APP_NAMESPACE: sample-app-namespace
   SAMPLE_APP_FRONTEND_SERVICE_IMAGE: ${{ secrets.APP_SIGNALS_E2E_TEST_ACC }}.dkr.ecr.${{ inputs.aws-region }}.amazonawss.com/${{ secrets.APP_SIGNALS_E2E_FE_SA_IMG }}
   SAMPLE_APP_REMOTE_SERVICE_IMAGE: ${{ secrets.APP_SIGNALS_E2E_TEST_ACC }}.dkr.ecr.${{ inputs.aws-region }}.amazonawss.com/${{ secrets.APP_SIGNALS_E2E_RE_SA_IMG }}
   METRIC_NAMESPACE: AppSignals
@@ -65,8 +64,10 @@ jobs:
           delete_log_group="aws logs delete-log-group --log-group-name '${{ env.LOG_GROUP_NAME }}' --region \$REGION"
           sed -i "s#$delete_log_group##g" clean-app-signals.sh
 
-      - name: Generate testing id
-        run: echo TESTING_ID="${{ inputs.aws-region }}-${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
+      - name: Generate testing id and sample app namespace
+        run: |
+          echo TESTING_ID="${{ inputs.aws-region }}-${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
+          echo SAMPLE_APP_NAMESPACE="sample-app-namespace-${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -376,6 +377,7 @@ jobs:
       - name: Terraform destroy
         if: always()
         continue-on-error: true
+        timeout-minutes: 5
         working-directory: terraform/eks
         run: |
           terraform destroy -auto-approve \

--- a/validator/src/main/resources/expected-data-template/eks/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/eks/remote-service-trace.mustache
@@ -80,7 +80,7 @@
     {
       "name": "^RemoteServiceController.healthcheck$",
       "annotations": {
-        "HostedIn.K8s.Namespace": "^sample-app-namespace$",
+        "HostedIn.K8s.Namespace": "^{{appNamespace}}$",
         "HostedIn.EKS.Cluster": "^{{platformInfo}}$",
         "aws.local.operation": "^GET /healthcheck$"
       }


### PR DESCRIPTION
*Issue #, if available:*
Test runs occasionally fail because the sample-app-namespace from the previous run is still terminating. 

*Description of changes:*
Append testing id at the end of the namespace

Note:
- Tried to make `sample-app-namespace-${{ env.Testing_Id }}`, but cloudformation doesn't allow stack name exceeding 128 characters, so `Create role for AWS access from the sample app` was failing due to final name being 130 characters. 
- Attempted to write command to delete all namespace with sample-app-namespace-*, but kubectl doesn't allow such formats. If we want to do that, will need to write a .sh script file. Since the previous sample-app-namespaces are in terminating status, deemed it not necessary to run the delete command again in subsequent runs. 

Test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8651339788
Another test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8654636588/job/23732190120

Test run after namespace change: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8666931415


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

