### PR TITLE
[E2E: EC2] Broaden AMI search

### DIFF
--- a/terraform/python/ec2/main.tf
+++ b/terraform/python/ec2/main.tf
@@ -46,7 +46,7 @@ data "aws_ami" "ami" {
   most_recent      = true
   filter {
    name = "name"
-   values = ["al2023-ami-2023.3.20240117.0-kernel-6.1-x86_64"]
+   values = ["al20*-ami-minimal-*-x86_64"]
   }
   filter {
     name   = "state"


### PR DESCRIPTION
Quick fix for failures that recently started

Proof it works (tested on my branch running completely different test cases/artifacts, but nonetheless it found the AMI): https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/8713081965/job/23900780344

Copied AMI filter from [here](https://github.com/aws-observability/aws-application-signals-test-framework/blob/main/terraform/ec2/main.tf#L49)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

