### PR TITLE
Update Gradlew Daemon to use existing build in cache

### DIFF
--- a/.github/workflows/appsignals-e2e-ec2-test.yml
+++ b/.github/workflows/appsignals-e2e-ec2-test.yml
@@ -73,8 +73,8 @@ jobs:
       - name: Deploy sample app via terraform and wait for endpoint to come online
         working-directory: terraform/ec2
         run: |
-          # Attempt to deploy the sample app on an EC2 instance and wait for its endpoint to come online. 
-          # There may be occasional failures due to transitivity issues, so try up to 2 times. 
+          # Attempt to deploy the sample app on an EC2 instance and wait for its endpoint to come online.
+          # There may be occasional failures due to transitivity issues, so try up to 2 times.
           # deployment_failed of 0 indicates that both the terraform deployment and the endpoint are running, while 1 indicates
           # that it failed at some point
           retry_counter=0
@@ -90,11 +90,11 @@ jobs:
               -var="get_cw_agent_rpm_command=${{ env.GET_CW_AGENT_RPM_COMMAND }}" \
               -var="get_adot_jar_command=${{ env.GET_ADOT_JAR_COMMAND }}" \
             || deployment_failed=$?
-          
+
             if [ $deployment_failed -eq 1 ]; then
               echo "Terraform deployment was unsuccessful. Will attempt to retry deployment."
             fi
-          
+
             # If the deployment_failed is still 0, then the terraform deployment succeeded and now try to connect to the endpoint.
             # Attempts to connect will be made for up to 10 minutes
             if [ $deployment_failed -eq 0 ]; then
@@ -108,12 +108,12 @@ jobs:
                   deployment_failed=1
                   break
                 fi
-          
+
                 printf '.'
                 attempt_counter=$(($attempt_counter+1))
                 sleep 10
               done
-          
+
               echo "Attempting to connect to the remote sample app endpoint"
               remote_sample_app_endpoint=http://$(terraform output sample_app_remote_service_public_ip):8080/healthcheck
               attempt_counter=0
@@ -124,26 +124,26 @@ jobs:
                   deployment_failed=1
                   break
                 fi
-          
+
                 printf '.'
                 attempt_counter=$(($attempt_counter+1))
                 sleep 10
               done
             fi
-          
+
             # If the success is 1 then either the terraform deployment or the endpoint connection failed, so first destroy the
             # resources created from terraform and try again.
             if [ $deployment_failed -eq 1 ]; then
               echo "Destroying terraform"
               terraform destroy -auto-approve \
-                -var="test_id=${{ env.TESTING_ID }}" 
-          
+                -var="test_id=${{ env.TESTING_ID }}"
+
               retry_counter=$(($retry_counter+1))
             else
               # If deployment succeeded, then exit the loop
               break
             fi
-          
+
             if [ $retry_counter -eq $max_retry ]; then
               echo "Max retry reached, failed to deploy terraform and connect to the endpoint. Exiting code"
               exit 1
@@ -169,6 +169,12 @@ jobs:
           curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}/aws-sdk-call/
           curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_IP }}/
           curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}/client-call/
+
+      - name: Initiate Gradlew Daemon
+        uses: ./.github/workflows/actions/execute_and_retry
+        with:
+          command: "./gradlew"
+          cleanup: "./gradlew clean"
 
       # Validation for pulse telemetry data
       - name: Validate generated EMF logs

--- a/.github/workflows/appsignals-e2e-ec2-test.yml
+++ b/.github/workflows/appsignals-e2e-ec2-test.yml
@@ -175,6 +175,8 @@ jobs:
         with:
           command: "./gradlew"
           cleanup: "./gradlew clean"
+          max_retry: 4
+          sleep_time: 30
 
       # Validation for pulse telemetry data
       - name: Validate generated EMF logs

--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -270,6 +270,8 @@ jobs:
         with:
           command: "./gradlew"
           cleanup: "./gradlew clean"
+          max_retry: 4
+          sleep_time: 30
 
       # Validation for app signals telemetry data
       - name: Call endpoint and validate generated EMF logs

--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -265,6 +265,12 @@ jobs:
           curl -S -s http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_POD_IP }}/
           curl -S -s http://${{ env.APP_ENDPOINT }}/client-call/
 
+      - name: Initiate Gradlew Daemon
+        uses: ./.github/workflows/actions/execute_and_retry
+        with:
+          command: "./gradlew"
+          cleanup: "./gradlew clean"
+
       # Validation for app signals telemetry data
       - name: Call endpoint and validate generated EMF logs
         id: log-validation

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,19 @@ RUN mv /tmp/eksctl /usr/local/bin
 COPY gradlew .
 COPY settings.gradle.kts .
 COPY gradlew.bat .
+COPY gradle.properties .
 COPY gradle/ /gradle/
 COPY buildSrc/ /buildSrc/
 COPY validator/ /validator/
 
 # Build gradlew here so that the canary doesn't spend time downloading and building the package
 RUN ./gradlew
+
+# Set a custom Gradle user home directory
+ENV GRADLE_USER_HOME=/.gradle/
+
+# Create the custom Gradle user home directory
+RUN mkdir -p $GRADLE_USER_HOME
+
+# Copy the Gradle cache from the default location to the custom location
+RUN cp -r ~/.gradle/* $GRADLE_USER_HOME

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.caching=true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,6 +17,12 @@ dependencyResolutionManagement {
     }
 }
 
+buildCache {
+    local {
+        isEnabled = true
+    }
+}
+
 
 // End to end tests
 include(":validator")


### PR DESCRIPTION
*Issue #, if available:*
When the gradlew daemon restarts it needs to download dependency to build the .jar files. This can cause transient issues if the download fails

*Description of changes:*
Make the daemon use cached build from ~/.gradle/build instead
We know this is working because if you look at the test [run](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8717247804/job/23912139825#step:13:29), it shows `FROM-CACHE` at the end of each build.

Test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8717247804
Test run after comment: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8727081926
Test run after adding retries and wait time: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8730663803/job/23954844966


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

