### PR TITLE
use helm-charts repo to install the cloudwatch agent operator

### DIFF
--- a/terraform/k8s/deploy/main.tf
+++ b/terraform/k8s/deploy/main.tf
@@ -36,9 +36,9 @@ resource "null_resource" "deploy" {
       [ ! -e remote-service-depl.yaml ] || rm remote-service-depl.yaml
 
       # Clone and install operator onto cluster
-      echo "LOG: Cloning operator repo"
-      git clone https://github.com/aws/amazon-cloudwatch-agent-operator -q
-      cd amazon-cloudwatch-agent-operator/helm/
+      echo "LOG: Cloning helm-charts repo"
+      git clone https://github.com/aws-observability/helm-charts -q
+      cd helm-charts/charts/amazon-cloudwatch-observability/
       echo "LOG: Installing CloudWatch Agent Operator using Helm"
       helm upgrade --install --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator ./ --create-namespace --set region=${var.aws_region} --set clusterName=k8s-cluster-${var.test_id}
 


### PR DESCRIPTION
*Description of changes:*
The amazon-cloudwatch-observability helm chart is now using the [aws-observability/helm-charts](https://github.com/aws-observability/helm-charts) repository as a source of truth. This PR is migrating the native k8s tests to use this new repo as the helm chart in the operator is now deprecated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

