### PR TITLE
Fix native k8s cleanup script to delete helm-charts repo

### DIFF
--- a/terraform/k8s/cleanup/main.tf
+++ b/terraform/k8s/cleanup/main.tf
@@ -17,8 +17,8 @@ resource "null_resource" "cleanup" {
       # Uninstall the operator and remove the repo from the EC2 instance
       echo "LOG: Uninstalling CloudWatch Agent Operator"
       helm uninstall --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator --ignore-not-found
-      echo "LOG: Deleting CloudWatch Agent Operator repo from environment"
-      [ ! -e amazon-cloudwatch-agent-operator ] || sudo rm -r amazon-cloudwatch-agent-operator
+      echo "LOG: Deleting helm-charts repo from environment"
+      [ ! -e helm-charts ] || sudo rm -r helm-charts
 
       # Delete sample app resources
       echo "LOG: Deleting sample app namespace"


### PR DESCRIPTION
*Description of changes:*
E2E tests on native k8s passes the first time: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8822603826/job/24221182364

But fails every subsequent time [(example)](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8822807620) due to the following error:

```
null_resource.deploy (remote-exec): LOG: Rerunning cleanup commands in case of cleanup failure in previous run
null_resource.deploy (remote-exec): release "amazon-cloudwatch-operator" uninstalled
null_resource.deploy (remote-exec): LOG: Cloning helm-charts repo
null_resource.deploy (remote-exec): fatal: destination path 'helm-charts' already exists and is not an empty directory.
```

We need to delete the helm-charts repo on cleanup instead of the previous operator repo
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

