### PR TITLE
Update clean-up for e2e-k8s to delete the helm-charts repo

### DIFF
--- a/terraform/k8s/cleanup/main.tf
+++ b/terraform/k8s/cleanup/main.tf
@@ -18,7 +18,7 @@ resource "null_resource" "cleanup" {
       echo "LOG: Uninstalling CloudWatch Agent Operator"
       helm uninstall --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator --ignore-not-found
       echo "LOG: Deleting CloudWatch Agent Operator repo from environment"
-      [ ! -e amazon-cloudwatch-agent-operator ] || sudo rm -r amazon-cloudwatch-agent-operator
+      [ ! -e helm-charts ] || sudo rm -r helm-charts
 
       # Delete sample app resources
       echo "LOG: Deleting sample app namespace"

--- a/terraform/k8s/cleanup/main.tf
+++ b/terraform/k8s/cleanup/main.tf
@@ -17,7 +17,7 @@ resource "null_resource" "cleanup" {
       # Uninstall the operator and remove the repo from the EC2 instance
       echo "LOG: Uninstalling CloudWatch Agent Operator"
       helm uninstall --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator --ignore-not-found
-      echo "LOG: Deleting CloudWatch Agent Operator repo from environment"
+      echo "LOG: Deleting helm-charts repo from environment"
       [ ! -e helm-charts ] || sudo rm -r helm-charts
 
       # Delete sample app resources


### PR DESCRIPTION
*Issue #, if available:*
The K8s tests are failing due to remaining folder from previous runs after changes were made in this [PR](https://github.com/aws-observability/aws-application-signals-test-framework/pull/46).

*Description of changes:*
Delete the helm-charts repo during cleanup

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

