### PR TITLE
Prevent clean up command from failing retry

### DIFF
--- a/.github/workflows/actions/execute_and_retry/action.yml
+++ b/.github/workflows/actions/execute_and_retry/action.yml
@@ -56,7 +56,7 @@ runs:
           if [ $attempt_failed -ne 0 ]; then
             echo "Command failed for execute_and_retry action, executing cleanup command for another attempt"
 
-            eval "$CLEANUP"
+            eval "$CLEANUP" || command_failed=$?
             retry_counter=$(($retry_counter+1))
             sleep "$SLEEP_TIME"
           else


### PR DESCRIPTION
*Issue #, if available:*
The retry fails for some steps due to cleanup command failing

*Description of changes:*
Prevent cleanup command from failing the retries.

Test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8834468602/job/24256209603

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

