### PR TITLE
Increase wait time for terraform retries

### DIFF
--- a/.github/workflows/application-signals-python-e2e-eks-test.yml
+++ b/.github/workflows/application-signals-python-e2e-eks-test.yml
@@ -117,6 +117,7 @@ jobs:
         with:
           command: "cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/python/eks && terraform init && terraform validate"
           cleanup: "rm -rf .terraform && rm -rf .terraform.lock.hcl"
+          sleep_time: 60
 
       - name: Deploy sample app via terraform and wait for the endpoint to come online
         id: deploy-python-app

--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -120,6 +120,7 @@ jobs:
         with:
           command: "cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/eks && terraform init && terraform validate"
           cleanup: "rm -rf .terraform && rm -rf .terraform.lock.hcl"
+          sleep_time: 60
 
       - name: Deploy sample app via terraform and wait for the endpoint to come online
         id: deploy-sample-app

--- a/.github/workflows/appsignals-e2e-k8s-test.yml
+++ b/.github/workflows/appsignals-e2e-k8s-test.yml
@@ -81,6 +81,7 @@ jobs:
         with:
           command: "cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/k8s/deploy && terraform init && terraform validate"
           cleanup: "rm -rf .terraform && rm -rf .terraform.lock.hcl"
+          sleep_time: 60
 
       - name: Deploy Operator and Sample App using Terraform
         working-directory: terraform/k8s/deploy


### PR DESCRIPTION
*Issue #, if available:*
Terraform init fails due to download file being unavailable despite trying 3 times

*Description of changes:*
Increase the wait time between each run, hopefully the download url can become available while it waits.

Test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8834891838

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

