### PR TITLE
Update Metric Limiter Workflow Name and Add to All Region

### DIFF
--- a/.github/workflows/appsignals-e2e-metric-limiter-canary-test.yml
+++ b/.github/workflows/appsignals-e2e-metric-limiter-canary-test.yml
@@ -6,7 +6,7 @@
 ## Operator and our sample app and remote service onto a native K8s cluster, call the
 ## APIs, and validate the generated telemetry, including logs, metrics, and traces.
 ## It will then clean up the cluster and EC2 instance it runs on for the next test run.
-name:  App Signals Enablement - E2E K8s Canary Testing
+name:  App Signals Enablement - E2E Metric Limiter Canary Testing
 on:
   schedule:
     - cron: '*/15 * * * *' # run the workflow every 15 minutes
@@ -17,11 +17,14 @@ permissions:
   contents: read
 
 jobs:
-  e2e-eks-test-1:
+  e2e-metric-limiter-test-1:
     strategy:
       fail-fast: false
       matrix:
-        aws-region: ['us-east-1']
+        aws-region: [ 'af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
+                      'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
+                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+                      'us-east-1','us-east-2','us-west-1','us-west-2' ]
     uses: ./.github/workflows/appsignals-e2e-metric-limiter-test.yml
     secrets: inherit
     with:

--- a/.github/workflows/appsignals-e2e-metric-limiter-test.yml
+++ b/.github/workflows/appsignals-e2e-metric-limiter-test.yml
@@ -4,7 +4,7 @@
 # This is a reusable workflow for running the E2E test for App Signals.
 # It is meant to be called from another workflow.
 # Read more about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview
-name: App Signals Enablement E2E Testing - EKS
+name: App Signals Enablement E2E Testing - Metric Limiter
 on:
   workflow_call:
     inputs:
@@ -13,9 +13,6 @@ on:
         type: string
       test-cluster-name:
         required: true
-        type: string
-      appsignals-adot-image-name:
-        required: false
         type: string
       caller-workflow-name:
         required: true
@@ -41,7 +38,7 @@ env:
   TEST_RESOURCES_FOLDER: /__w/aws-application-signals-test-framework/aws-application-signals-test-framework
 
 jobs:
-  e2e-eks-test:
+  e2e-metric-limiter-test:
     runs-on: ubuntu-latest
     container:
       image: public.ecr.aws/h6o3z5z9/aws-application-signals-test-framework-workflow-container:latest
@@ -120,6 +117,7 @@ jobs:
         with:
           command: "cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/eks && terraform init && terraform validate"
           cleanup: "rm -rf .terraform && rm -rf .terraform.lock.hcl"
+          sleep_time: 60
 
       - name: Deploy sample app via terraform and wait for the endpoint to come online
         id: deploy-sample-app
@@ -282,6 +280,14 @@ jobs:
           curl -S -s http://${{ env.APP_ENDPOINT }}/aws-sdk-call/; echo
           curl -S -s http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_POD_IP }}/; echo
           curl -S -s http://${{ env.APP_ENDPOINT }}/client-call/; echo
+
+      - name: Initiate Gradlew Daemon
+        uses: ./.github/workflows/actions/execute_and_retry
+        with:
+          command: "./gradlew"
+          cleanup: "./gradlew clean"
+          max_retry: 4
+          sleep_time: 30
 
       - name: Call endpoints and validate generated metrics
         id: other-operation-metric-validation


### PR DESCRIPTION
*Description of changes:*
Update the metric limiter canary to run in all regions and also make minor fix/updates

Test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8854708923/job/24318314234

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

