### PR TITLE
Fix - Rename parameter name in e2e metric limiter test workflow

### DIFF
--- a/.github/workflows/appsignals-e2e-metric-limiter-test.yml
+++ b/.github/workflows/appsignals-e2e-metric-limiter-test.yml
@@ -301,7 +301,7 @@ jobs:
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-name sample-remote-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --request-body ip=${{ env.REMOTE_SERVICE_POD_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}
           --rollup'
 
       - name: Publish metric on test result


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8990123840/job/24694768687
```
Task :validator:classes
Unknown options: '--request-body', 'ip=10.0.130.213'
Possible solutions: --remote-service-name, --remote-service-deployment-name, --region
```

*Description of changes:*
Missed var name change that is required after https://github.com/aws-observability/aws-application-signals-test-framework/pull/41
`request-body` -> `query-string`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

