### PR TITLE
Fix - Update metric limiter callingType for metric validation

### DIFF
--- a/validator/src/main/resources/validations/metric_limiter/metric-validation.yml
+++ b/validator/src/main/resources/validations/metric_limiter/metric-validation.yml
@@ -14,7 +14,7 @@
   validationType: "cw-metric"
   httpPath: "/remote-service"
   httpMethod: "get"
-  callingType: "http-with-body"
+  callingType: "http-with-query"
   expectedMetricTemplate: "METRIC_LIMITER_REMOTE_SERVICE_METRIC"
 -
   validationType: "cw-metric"


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8990477656/job/24695891452
``` 
com.amazon.aoc.exception.BaseException: caller type not existed
```

*Description of changes:*
Update validator callingType that is required after https://github.com/aws-observability/aws-application-signals-test-framework/pull/41
`http-with-body` -> `http-with-query`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

