### PR TITLE
Fix version of all artifacts to current release versions

### DIFF
--- a/.github/workflows/application-signals-python-e2e-ec2-test.yml
+++ b/.github/workflows/application-signals-python-e2e-ec2-test.yml
@@ -29,7 +29,7 @@ env:
   LOG_GROUP_NAME: /aws/appsignals/generic
   ADOT_WHEEL_NAME: ${{ inputs.staging_wheel_name }}
   TEST_RESOURCES_FOLDER: ${GITHUB_WORKSPACE}
-  GET_CW_AGENT_RPM_COMMAND: "wget -O cw-agent.rpm https://amazoncloudwatch-agent-${{ inputs.aws-region }}.s3.${{ inputs.aws-region }}.amazonaws.com/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm"
+  GET_CW_AGENT_RPM_COMMAND: "wget -O cw-agent.rpm https://amazoncloudwatch-agent-${{ inputs.aws-region }}.s3.${{ inputs.aws-region }}.amazonaws.com/amazon_linux/amd64/1.300035.0b547/amazon-cloudwatch-agent.rpm"
 
 jobs:
   python-e2e-ec2-test:
@@ -67,11 +67,11 @@ jobs:
       - uses: actions/download-artifact@v3
         if: inputs.caller-workflow-name == 'main-build'
         with:
-          name: ${{ inputs.staging_wheel_name }}
+          name: ${{ env.ADOT_WHEEL_NAME }}
 
       - name: Upload main-build adot.whl to s3
         if: inputs.caller-workflow-name == 'main-build'
-        run: aws s3 cp ${{ inputs.staging_wheel_name }} s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }}
+        run: aws s3 cp ${{ env.ADOT_WHEEL_NAME }} s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }}
 
       - name: Set Get ADOT Wheel command environment variable
         working-directory: terraform/python/ec2
@@ -80,7 +80,7 @@ jobs:
             # Reusing the adot-main-build-staging-jar bucket to store the python wheel file
             echo GET_ADOT_WHEEL_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && python3.9 -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
           else
-            echo GET_ADOT_WHEEL_COMMAND="python3.9 -m pip install aws-opentelemetry-distro" >> $GITHUB_ENV
+            echo GET_ADOT_WHEEL_COMMAND="python3.9 -m pip install ${{ env.ADOT_WHEEL_NAME }}==0.1.1" >> $GITHUB_ENV
           fi
 
       - name: Initiate Terraform

--- a/.github/workflows/application-signals-python-e2e-eks-test.yml
+++ b/.github/workflows/application-signals-python-e2e-eks-test.yml
@@ -54,6 +54,12 @@ jobs:
           cleanup: "rm -f enable-app-signals.sh && rm -f clean-app-signals.sh"
           post-command: "chmod +x enable-app-signals.sh && chmod +x clean-app-signals.sh"
 
+      # In preparation for next release so we do not get alarms once the release is done
+      - name: Enforce EKS add on v1.6.0-eksbuild.1
+        working-directory: enablement-script
+        run: |
+          sed -i '\#--addon-name amazon-cloudwatch-observability \\#a--addon-version v1.6.0-eksbuild.1 \\' enable-app-signals.sh
+
       - name: Remove log group deletion command
         if: always()
         working-directory: enablement-script

--- a/.github/workflows/appsignals-e2e-ec2-test.yml
+++ b/.github/workflows/appsignals-e2e-ec2-test.yml
@@ -26,12 +26,11 @@ env:
   TEST_ACCOUNT: ${{ secrets.APP_SIGNALS_E2E_TEST_ACC }}
   SAMPLE_APP_FRONTEND_SERVICE_JAR: s3://${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ inputs.aws-region }}/main-service.jar
   SAMPLE_APP_REMOTE_SERVICE_JAR: s3://${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ inputs.aws-region }}/remote-service.jar
-  APP_SIGNALS_ADOT_JAR: "https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar"
   METRIC_NAMESPACE: AppSignals
   LOG_GROUP_NAME: /aws/appsignals/generic
-  GET_ADOT_JAR_COMMAND: "wget -O adot.jar https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar"
+  GET_ADOT_JAR_COMMAND: "wget -O adot.jar https://github.com/aws-observability/aws-otel-java-instrumentation/releases/download/v1.32.1/aws-opentelemetry-agent.jar"
   TEST_RESOURCES_FOLDER: /__w/aws-application-signals-test-framework/aws-application-signals-test-framework
-  GET_CW_AGENT_RPM_COMMAND: "wget -O cw-agent.rpm https://amazoncloudwatch-agent-${{ inputs.aws-region }}.s3.${{ inputs.aws-region }}.amazonaws.com/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm"
+  GET_CW_AGENT_RPM_COMMAND: "wget -O cw-agent.rpm https://amazoncloudwatch-agent-${{ inputs.aws-region }}.s3.${{ inputs.aws-region }}.amazonaws.com/amazon_linux/amd64/1.300035.0b547/amazon-cloudwatch-agent.rpm"
 
 jobs:
   e2e-ec2-test:

--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -59,6 +59,12 @@ jobs:
           cleanup: "rm -f enable-app-signals.sh && rm -f clean-app-signals.sh"
           post-command: "chmod +x enable-app-signals.sh && chmod +x clean-app-signals.sh"
 
+      # In preparation for next release so we do not get alarms once the release is done
+      - name: Enforce EKS add on v1.6.0-eksbuild.1
+        working-directory: enablement-script
+        run: |
+          sed -i '\#--addon-name amazon-cloudwatch-observability \\#a--addon-version v1.6.0-eksbuild.1 \\' enable-app-signals.sh
+
       - name: Remove log group deletion command
         if: always()
         working-directory: enablement-script

--- a/.github/workflows/appsignals-e2e-metric-limiter-test.yml
+++ b/.github/workflows/appsignals-e2e-metric-limiter-test.yml
@@ -56,6 +56,12 @@ jobs:
           cleanup: "rm -f enable-app-signals.sh && rm -f clean-app-signals.sh"
           post-command: "chmod +x enable-app-signals.sh && chmod +x clean-app-signals.sh"
 
+      # In preparation for next release so we do not get alarms once the release is done
+      - name: Enforce EKS add on v1.6.0-eksbuild.1
+        working-directory: enablement-script
+        run: |
+          sed -i '\#--addon-name amazon-cloudwatch-observability \\#a--addon-version v1.6.0-eksbuild.1 \\' enable-app-signals.sh
+
       - name: Remove log group deletion command
         if: always()
         working-directory: enablement-script

--- a/terraform/k8s/deploy/main.tf
+++ b/terraform/k8s/deploy/main.tf
@@ -38,7 +38,12 @@ resource "null_resource" "deploy" {
       # Clone and install operator onto cluster
       echo "LOG: Cloning helm-charts repo"
       git clone https://github.com/aws-observability/helm-charts -q
-      cd helm-charts/charts/amazon-cloudwatch-observability/
+
+      # Temporarily override helm chart version to current latest so new releases do not cause alarms
+      cd helm-charts/
+      git reset --hard 78d4b094afb622fea7238e784bc4c07ffe340766
+      cd amazon-cloudwatch-observability/
+
       echo "LOG: Installing CloudWatch Agent Operator using Helm"
       helm upgrade --install --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator ./ --create-namespace --set region=${var.aws_region} --set clusterName=k8s-cluster-${var.test_id}
 


### PR DESCRIPTION
With the upcoming releases for all artifacts (ADOT ECR, CW Agent ECR, ADOT JAR, CW Agent RPM, EKS add on), we will expect failures as behaviour of the latest available artifacts begins changing. As such, we want to fix the artifact versions to the currently available and tested versions so we can update in the future when each artifact becomes available.

*Description of changes:*
- Override EKS add on version in EKS workflows by adding `--addon-version v1.6.0-eksbuild.1` option to addon installation command
- For EC2:
  - [Java] ADOT JAR version fixed to `v1.32.1` instead of using latest release from aws-otel-java-instrumentation repo
  - [Python] ADOT WHL version fixed to `0.1.1`
  - [Java/Python] CW Agent RPM version fixed to latest version that is available in all regions, confirmed with CW Agent team that this is `1.300035.0b547`
- K8s: Pin the current latest and functional commit of the helm-charts repo at the time of this PR by using `git reset --hard 78d4b094afb622fea7238e784bc4c07ffe340766` - [link](https://github.com/aws-observability/helm-charts/commit/78d4b094afb622fea7238e784bc4c07ffe340766)

*Testing:*
Testing done for Java/Python/metrics limiter test case on EKS in IAD and Java/Python on EC2 in all regions:
- [Run 1](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9022293453)
- [Run 2](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9022777470)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

