### PR TITLE
[Python] Fix get adot command env variable for main build

### DIFF
--- a/.github/workflows/application-signals-python-e2e-ec2-test.yml
+++ b/.github/workflows/application-signals-python-e2e-ec2-test.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Set Get ADOT Wheel command environment variable
         working-directory: terraform/python/ec2
         run: |
-          if [ ${{ inputs.caller-workflow-name }} == "main-build" ]; then
+          if [ "${{ inputs.caller-workflow-name }}" = "main-build" ]; then
             # Reusing the adot-main-build-staging-jar bucket to store the python wheel file
             echo GET_ADOT_WHEEL_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && python3.9 -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
           else


### PR DESCRIPTION
The condition is not properly triggering because the container image that is used to run the test has been changed and different syntax is accepted here. As such, I changed the syntax of the condition to match that on L235 which we know works.

Test run ensuring we don't break canary with this change: [link](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9035438877)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

