### PR TITLE
Update E2E Tests Expected Data for K8s

### DIFF
--- a/.github/workflows/appsignals-e2e-k8s-test.yml
+++ b/.github/workflows/appsignals-e2e-k8s-test.yml
@@ -101,10 +101,10 @@ jobs:
       - name: Call all test APIs
         continue-on-error: true
         run: |
-          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/outgoing-http-call/; echo
-          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/aws-sdk-call/; echo
-          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/remote-service?ip=${{ env.REMOTE_SERVICE_IP }}/; echo
-          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/client-call/; echo
+          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/outgoing-http-call; echo
+          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/aws-sdk-call?testingId=${{ env.TESTING_ID }}; echo
+          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/remote-service?ip=${{ env.REMOTE_SERVICE_IP }}; echo
+          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/client-call; echo
 
       # Validation for pulse telemetry data
       - name: Validate generated EMF logs
@@ -138,7 +138,7 @@ jobs:
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-name sample-r-app-deployment-${{ env.TESTING_ID }}
           --remote-service-deployment-name sample-r-app-deployment-${{ env.TESTING_ID }}
-          --query-string ip=${{ env.REMOTE_SERVICE_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
       - name: Validate generated traces

--- a/.github/workflows/appsignals-e2e-k8s-test.yml
+++ b/.github/workflows/appsignals-e2e-k8s-test.yml
@@ -120,7 +120,7 @@ jobs:
           --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-name sample-r-app-deployment-${{ env.TESTING_ID }}
-          --query-string ip=${{ env.REMOTE_SERVICE_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
       - name: Validate generated metrics
@@ -156,7 +156,7 @@ jobs:
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-name sample-r-app-deployment-${{ env.TESTING_ID }}
           --remote-service-deployment-name sample-r-app-deployment-${{ env.TESTING_ID }}
-          --query-string ip=${{ env.REMOTE_SERVICE_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
       - name: Publish metric on test result

--- a/.github/workflows/appsignals-e2e-k8s-test.yml
+++ b/.github/workflows/appsignals-e2e-k8s-test.yml
@@ -102,8 +102,8 @@ jobs:
         continue-on-error: true
         run: |
           curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/outgoing-http-call; echo
-          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/aws-sdk-call?testingId=${{ env.TESTING_ID }}; echo
-          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/remote-service?ip=${{ env.REMOTE_SERVICE_IP }}; echo
+          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/aws-sdk-call?ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}; echo
+          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/remote-service?ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}; echo
           curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/client-call; echo
 
       # Validation for pulse telemetry data

--- a/validator/src/main/resources/expected-data-template/k8s/aws-sdk-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/k8s/aws-sdk-call-log.mustache
@@ -23,7 +23,7 @@
   "Version": "^1$",
   "RemoteService": "AWS.SDK.S3",
   "RemoteOperation": "GetBucketLocation",
-  "RemoteTarget": "::s3:::e2e-test-bucket-name",
+  "RemoteTarget": "^::s3:::e2e-test-bucket-name-{{testingId}}$",
   "aws.span.kind": "^CLIENT$",
   "host.name": "^ip(-[0-9]{1,3}){4}\\.ec2\\.internal$"
 }]

--- a/validator/src/main/resources/expected-data-template/k8s/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/k8s/aws-sdk-call-metric.mustache
@@ -113,7 +113,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name-{{testingId}}
 
 -
   metricName: Latency
@@ -136,7 +136,38 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: ::s3:::e2e-test-bucket-name-{{testingId}}
 
 -
   metricName: Error
@@ -253,7 +284,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name-{{testingId}}
 
 -
   metricName: Error
@@ -276,7 +307,38 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: ::s3:::e2e-test-bucket-name-{{testingId}}
 
 -
   metricName: Fault
@@ -393,7 +455,7 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name-{{testingId}}
 
 -
   metricName: Fault
@@ -416,4 +478,35 @@
       value: AWS.SDK.S3
     -
       name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name
+      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: HostedIn.K8s.Cluster
+      value: {{platformInfo}}
+    -
+      name: HostedIn.K8s.Namespace
+      value: {{appNamespace}}
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: AWS.SDK.S3
+    -
+      name: RemoteTarget
+      value: ::s3:::e2e-test-bucket-name-{{testingId}}

--- a/validator/src/main/resources/expected-data-template/k8s/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/k8s/aws-sdk-call-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/aws-sdk-call$",
+      "url": "^{{endpoint}}/aws-sdk-call\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
       "method": "^GET$"
     },
     "response": {
@@ -33,7 +33,7 @@
           "name": "^S3$",
           "http": {
             "request": {
-              "url": "^https://e2e-test-bucket-name.s3.{{region}}.amazonaws.com\\?location$",
+              "url": "^https://e2e-test-bucket-name-{{testingId}}.s3.{{region}}.amazonaws.com\\?location$",
               "method": "^GET$"
             }
           },
@@ -44,7 +44,7 @@
             "aws.local.operation": "^GET /aws-sdk-call$",
             "aws.remote.service": "^AWS\\.SDK\\.S3$",
             "aws.remote.operation": "GetBucketLocation",
-            "aws.remote.target": "::s3:::e2e-test-bucket-name"
+            "aws.remote.target": "^::s3:::e2e-test-bucket-name-{{testingId}}$"
           },
           "metadata": {
             "default": {

--- a/validator/src/main/resources/expected-data-template/k8s/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/k8s/remote-service-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/remote-service\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})$",
+      "url": "^{{endpoint}}/remote-service\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
       "method": "^GET$"
     },
     "response": {

--- a/validator/src/main/resources/validations/k8s/log-validation.yml
+++ b/validator/src/main/resources/validations/k8s/log-validation.yml
@@ -8,7 +8,7 @@
   validationType: "cw-log"
   httpPath: "/aws-sdk-call"
   httpMethod: "get"
-  callingType: "http"
+  callingType: "http-with-query"
   expectedLogStructureTemplate: "K8S_AWS_SDK_CALL_LOG"
 -
   validationType: "cw-log"

--- a/validator/src/main/resources/validations/k8s/metric-validation.yml
+++ b/validator/src/main/resources/validations/k8s/metric-validation.yml
@@ -8,7 +8,7 @@
   validationType: "cw-metric"
   httpPath: "/aws-sdk-call"
   httpMethod: "get"
-  callingType: "http"
+  callingType: "http-with-query"
   expectedMetricTemplate: "K8S_AWS_SDK_CALL_METRIC"
 -
   validationType: "cw-metric"

--- a/validator/src/main/resources/validations/k8s/trace-validation.yml
+++ b/validator/src/main/resources/validations/k8s/trace-validation.yml
@@ -8,7 +8,7 @@
   validationType: "trace"
   httpPath: "/aws-sdk-call"
   httpMethod: "get"
-  callingType: "http"
+  callingType: "http-with-query"
   expectedTraceTemplate: "K8S_AWS_SDK_CALL_TRACE"
 -
   validationType: "trace"


### PR DESCRIPTION
*Issue #, if available:*
Followup from: https://github.com/aws-observability/aws-application-signals-test-framework/pull/41
Previously, new metric rollup test cases were added for EC2 and EKS e2e tests in Python and Java. These need to be added for K8s e2e tests as well.

*Description of changes:*
Updating k8s tests (workflow and expected data) to have the same changes [previously applied for EC2/EKS](https://github.com/aws-observability/aws-application-signals-test-framework/commit/1690fde15c8a5a5889a5f97bc1bb51453b47b85f).

Additionally, changes were made to make the generated data between logs/metrics/traces to be more consistent in the tests.

*Testing:*
Ran K8s tests a few times In IAD using a node for testing changes: https://github.com/aws-observability/aws-application-signals-test-framework/actions/workflows/test.yml
- https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9069465891

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

