### PR TITLE
Point Python main-build to the adot-pending-release branch

### DIFF
--- a/.github/workflows/application-signals-python-e2e-ec2-test.yml
+++ b/.github/workflows/application-signals-python-e2e-ec2-test.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: ${{ inputs.caller-workflow-name == 'main-build' && 'aws-observability/aws-application-signals-test-framework' || github.repository }}
-          ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
+          ref: ${{ inputs.caller-workflow-name == 'main-build' && 'adot-pending-release' || github.ref }}
           fetch-depth: 0
 
       - name: Generate testing id

--- a/.github/workflows/application-signals-python-e2e-eks-test.yml
+++ b/.github/workflows/application-signals-python-e2e-eks-test.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: ${{ inputs.caller-workflow-name == 'main-build' && 'aws-observability/aws-application-signals-test-framework' || github.repository }}
-          ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
+          ref: ${{ inputs.caller-workflow-name == 'main-build' && 'adot-pending-release' || github.ref }}
           fetch-depth: 0
 
       - name: Download enablement script


### PR DESCRIPTION
*Issue #, if available:*
The OTEL Python repository main-build test is currently failing due to updating the artifact with the latest metric schema changes.  

*Description of changes:*
Point the main-build workflow to the `adot-pending-release` workflow which contains the required changes

Test run to check changes doesn't break existing canary: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9067492904

Note: Re-run main-build [test](https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/9021210355) on the OTEL Python repo to check if it passes after merging this PR

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

