### PR TITLE
Update python validation to match java

### DIFF
--- a/validator/src/main/resources/expected-data-template/python/ec2/aws-sdk-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/aws-sdk-call-log.mustache
@@ -10,8 +10,7 @@
   "Operation": "GET aws-sdk-call",
   "OTelLib": "^AwsSpanMetricsProcessor$",
   "Version": "^1$",
-  "RemoteService": "AWS.SDK.S3",
+  "RemoteService": "AWS::S3",
   "RemoteOperation": "GetBucketLocation",
-  "RemoteTarget": "::s3:::e2e-test-bucket-name",
   "aws.span.kind": "^CLIENT$"
 }]

--- a/validator/src/main/resources/expected-data-template/python/ec2/aws-sdk-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/aws-sdk-call-log.mustache
@@ -12,5 +12,7 @@
   "Version": "^1$",
   "RemoteService": "AWS::S3",
   "RemoteOperation": "GetBucketLocation",
-  "aws.span.kind": "^CLIENT$"
+  "aws.span.kind": "^CLIENT$",
+  "aws.remote.resource.identifier": "^e2e-test-bucket-name-{{testingId}}$",
+  "aws.remote.resource.type": "^AWS::S3::Bucket$"
 }]

--- a/validator/src/main/resources/expected-data-template/python/ec2/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/aws-sdk-call-metric.mustache
@@ -30,7 +30,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
+      value: AWS::S3
 
 -
   metricName: Latency
@@ -55,7 +55,7 @@
       value: EC2
     -
       name: RemoteService
-      value: AWS.SDK.S3
+      value: AWS::S3
 
 -
   metricName: Latency
@@ -72,7 +72,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
+      value: AWS::S3
 
 -
   metricName: Latency
@@ -92,10 +92,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+      value: AWS::S3
 
 -
   metricName: Latency
@@ -112,10 +109,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+      value: AWS::S3
 
 -
   metricName: Latency
@@ -129,21 +123,7 @@
       value: EC2
     -
       name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
-
--
-  metricName: Latency
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+      value: AWS::S3
 
 -
   metricName: Error
@@ -177,7 +157,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
+      value: AWS::S3
 
 -
   metricName: Error
@@ -202,7 +182,7 @@
       value: EC2
     -
       name: RemoteService
-      value: AWS.SDK.S3
+      value: AWS::S3
 
 -
   metricName: Error
@@ -219,7 +199,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
+      value: AWS::S3
 
 -
   metricName: Error
@@ -239,10 +219,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+      value: AWS::S3
 
 -
   metricName: Error
@@ -259,10 +236,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+      value: AWS::S3
 
 -
   metricName: Error
@@ -276,21 +250,7 @@
       value: EC2
     -
       name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+      value: AWS::S3
 
 -
   metricName: Fault
@@ -324,7 +284,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
+      value: AWS::S3
 
 -
   metricName: Fault
@@ -349,7 +309,7 @@
       value: EC2
     -
       name: RemoteService
-      value: AWS.SDK.S3
+      value: AWS::S3
 
 -
   metricName: Fault
@@ -366,7 +326,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
+      value: AWS::S3
 
 -
   metricName: Fault
@@ -386,10 +346,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+      value: AWS::S3
 
 -
   metricName: Fault
@@ -406,10 +363,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+      value: AWS::S3
 
 -
   metricName: Fault
@@ -423,19 +377,5 @@
       value: EC2
     -
       name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
-
--
-  metricName: Fault
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+      value: AWS::S3
 

--- a/validator/src/main/resources/expected-data-template/python/ec2/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/aws-sdk-call-trace.mustache
@@ -45,7 +45,9 @@
       },
       "metadata": {
         "default": {
-          "aws.span.kind": "^CLIENT$"
+          "aws.span.kind": "^CLIENT$",
+          "aws.remote.resource.type": "AWS::S3::Bucket",
+          "aws.remote.resource.identifier": "e2e-test-bucket-name"
         }
       },
       "namespace": "^aws$"

--- a/validator/src/main/resources/expected-data-template/python/ec2/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/aws-sdk-call-trace.mustache
@@ -40,9 +40,8 @@
         "HostedIn.Environment": "^EC2$",
         "aws.local.service": "^{{serviceName}}$",
         "aws.local.operation": "^GET aws-sdk-call$",
-        "aws.remote.service": "^AWS\\.SDK\\.S3$",
-        "aws.remote.operation": "^GetBucketLocation$",
-        "aws.remote.target": "^::s3:::e2e-test-bucket-name$"
+        "aws.remote.service": "^AWS::S3$",
+        "aws.remote.operation": "^GetBucketLocation$"
       },
       "metadata": {
         "default": {

--- a/validator/src/main/resources/expected-data-template/python/eks/aws-sdk-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/python/eks/aws-sdk-call-log.mustache
@@ -20,5 +20,7 @@
   "Version": "^1$",
   "RemoteService": "AWS::S3",
   "RemoteOperation": "GetBucketLocation",
-  "aws.span.kind": "^CLIENT$"
+  "aws.span.kind": "^CLIENT$",
+  "aws.remote.resource.identifier": "^e2e-test-bucket-name-{{testingId}}$",
+  "aws.remote.resource.type": "^AWS::S3::Bucket$"
 }]

--- a/validator/src/main/resources/expected-data-template/python/eks/aws-sdk-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/python/eks/aws-sdk-call-log.mustache
@@ -18,8 +18,7 @@
   "Operation": "GET aws-sdk-call",
   "OTelLib": "^AwsSpanMetricsProcessor$",
   "Version": "^1$",
-  "RemoteService": "AWS.SDK.S3",
+  "RemoteService": "AWS::S3",
   "RemoteOperation": "GetBucketLocation",
-  "RemoteTarget": "::s3:::e2e-test-bucket-name",
   "aws.span.kind": "^CLIENT$"
 }]

--- a/validator/src/main/resources/expected-data-template/python/eks/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/python/eks/aws-sdk-call-metric.mustache
@@ -36,7 +36,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
+      value: AWS::S3
 
 -
   metricName: Latency
@@ -67,7 +67,7 @@
       value: {{appNamespace}}
     -
       name: RemoteService
-      value: AWS.SDK.S3
+      value: AWS::S3
 
 -
   metricName: Latency
@@ -87,7 +87,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
+      value: AWS::S3
 
 -
   metricName: Latency
@@ -110,10 +110,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+      value: AWS::S3
 
 -
   metricName: Latency
@@ -133,10 +130,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+      value: AWS::S3
 
 -
   metricName: Latency
@@ -153,21 +147,7 @@
       value: {{appNamespace}}
     -
       name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
-
--
-  metricName: Latency
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+      value: AWS::S3
 
 -
   metricName: Error
@@ -207,7 +187,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
+      value: AWS::S3
 
 -
   metricName: Error
@@ -238,7 +218,7 @@
       value: {{appNamespace}}
     -
       name: RemoteService
-      value: AWS.SDK.S3
+      value: AWS::S3
 
 -
   metricName: Error
@@ -258,7 +238,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
+      value: AWS::S3
 
 -
   metricName: Error
@@ -281,10 +261,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+      value: AWS::S3
 
 -
   metricName: Error
@@ -304,10 +281,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+      value: AWS::S3
 
 -
   metricName: Error
@@ -324,21 +298,7 @@
       value: {{appNamespace}}
     -
       name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+      value: AWS::S3
 
 -
   metricName: Fault
@@ -378,7 +338,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
+      value: AWS::S3
 
 -
   metricName: Fault
@@ -409,7 +369,7 @@
       value: {{appNamespace}}
     -
       name: RemoteService
-      value: AWS.SDK.S3
+      value: AWS::S3
 
 -
   metricName: Fault
@@ -429,7 +389,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
+      value: AWS::S3
 
 -
   metricName: Fault
@@ -452,10 +412,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+      value: AWS::S3
 
 -
   metricName: Fault
@@ -475,10 +432,7 @@
       value: GetBucketLocation
     -
       name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+      value: AWS::S3
 
 -
   metricName: Fault
@@ -495,18 +449,4 @@
       value: {{appNamespace}}
     -
       name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
-
--
-  metricName: Fault
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: RemoteService
-      value: AWS.SDK.S3
-    -
-      name: RemoteTarget
-      value: ::s3:::e2e-test-bucket-name-{{testingId}}
+      value: AWS::S3

--- a/validator/src/main/resources/expected-data-template/python/eks/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/python/eks/aws-sdk-call-trace.mustache
@@ -43,9 +43,8 @@
         "HostedIn.EKS.Cluster": "^{{platformInfo}}$",
         "aws.local.service": "^{{serviceName}}$",
         "aws.local.operation": "^GET aws-sdk-call$",
-        "aws.remote.service": "^AWS\\.SDK\\.S3$",
-        "aws.remote.operation": "GetBucketLocation",
-        "aws.remote.target": "::s3:::e2e-test-bucket-name"
+        "aws.remote.service": "^AWS::S3$",
+        "aws.remote.operation": "GetBucketLocation"
       },
       "metadata": {
         "default": {

--- a/validator/src/main/resources/expected-data-template/python/eks/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/python/eks/aws-sdk-call-trace.mustache
@@ -48,7 +48,9 @@
       },
       "metadata": {
         "default": {
-          "aws.span.kind": "^CLIENT$"
+          "aws.span.kind": "^CLIENT$",
+          "aws.remote.resource.type": "AWS::S3::Bucket",
+          "aws.remote.resource.identifier": "e2e-test-bucket-name"
         }
       },
       "namespace": "^aws$"


### PR DESCRIPTION
*Issue #, if available:*
Python main-build is failing due to metric schema changes: https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/9021210355

*Description of changes:*
Update the validation templates for python as well to match the java changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

