### PR TITLE
Update E2E Test Consistency of Generated Data between logs/metrics/traces for eks/ec2 on java/python

### DIFF
--- a/.github/workflows/application-signals-python-e2e-ec2-test.yml
+++ b/.github/workflows/application-signals-python-e2e-ec2-test.yml
@@ -167,10 +167,10 @@ jobs:
       - name: Call all test APIs
         continue-on-error: true
         run: |
-          curl -S -s -o /dev/null http://${{ env.MAIN_SERVICE_ENDPOINT }}/outgoing-http-call; echo
-          curl -S -s -o /dev/null http://${{ env.MAIN_SERVICE_ENDPOINT }}/aws-sdk-call?testingId=${{ env.TESTING_ID }}; echo
-          curl -S -s -o /dev/null http://${{ env.MAIN_SERVICE_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_IP }}; echo
-          curl -S -s -o /dev/null http://${{ env.MAIN_SERVICE_ENDPOINT }}/client-call; echo
+          curl -S -s -o /dev/null "http://${{ env.MAIN_SERVICE_ENDPOINT }}/outgoing-http-call"; echo
+          curl -S -s -o /dev/null "http://${{ env.MAIN_SERVICE_ENDPOINT }}/aws-sdk-call?ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}"; echo
+          curl -S -s -o /dev/null "http://${{ env.MAIN_SERVICE_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}"; echo
+          curl -S -s -o /dev/null "http://${{ env.MAIN_SERVICE_ENDPOINT }}/client-call"; echo
 
       - name: Initiate Gradlew Daemon
         uses: ./.github/workflows/actions/execute_and_retry
@@ -192,7 +192,7 @@ jobs:
           --log-group ${{ env.LOG_GROUP_NAME }}
           --service-name python-sample-application-${{ env.TESTING_ID }}
           --remote-service-name python-sample-remote-application-${{ env.TESTING_ID }}
-          --query-string ip=${{ env.REMOTE_SERVICE_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
           --instance-ami ${{ env.EC2_INSTANCE_AMI }}
           --rollup'
 
@@ -225,7 +225,7 @@ jobs:
           --log-group ${{ env.LOG_GROUP_NAME }}
           --service-name python-sample-application-${{ env.TESTING_ID }}
           --remote-service-name python-sample-remote-application-${{ env.TESTING_ID }}
-          --query-string ip=${{ env.REMOTE_SERVICE_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
           --instance-ami ${{ env.EC2_INSTANCE_AMI }}
           --rollup'
 

--- a/.github/workflows/application-signals-python-e2e-eks-test.yml
+++ b/.github/workflows/application-signals-python-e2e-eks-test.yml
@@ -258,10 +258,10 @@ jobs:
       - name: Call all test APIs
         continue-on-error: true
         run: |
-          curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/outgoing-http-call; echo
-          curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/aws-sdk-call?testingId=${{ env.TESTING_ID }}; echo
-          curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_POD_IP }}; echo
-          curl -S -s -o /dev/null http://${{ env.APP_ENDPOINT }}/client-call; echo
+          curl -S -s -o /dev/null "http://${{ env.APP_ENDPOINT }}/outgoing-http-call"; echo
+          curl -S -s -o /dev/null "http://${{ env.APP_ENDPOINT }}/aws-sdk-call?ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}"; echo
+          curl -S -s -o /dev/null "http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}"; echo
+          curl -S -s -o /dev/null "http://${{ env.APP_ENDPOINT }}/client-call"; echo
 
       - name: Initiate Gradlew Daemon
         uses: ./.github/workflows/actions/execute_and_retry
@@ -286,7 +286,7 @@ jobs:
           --platform-info ${{ inputs.test-cluster-name }}
           --service-name python-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
       - name: Call endpoints and validate generated metrics
@@ -320,7 +320,7 @@ jobs:
           --platform-info ${{ inputs.test-cluster-name }}
           --service-name python-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
       - name: Publish metric on test result

--- a/.github/workflows/appsignals-e2e-ec2-test.yml
+++ b/.github/workflows/appsignals-e2e-ec2-test.yml
@@ -164,10 +164,10 @@ jobs:
       - name: Call all test APIs
         continue-on-error: true
         run: |
-          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}/outgoing-http-call
-          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}/aws-sdk-call?testingId=${{ env.TESTING_ID }}
-          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_IP }}
-          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}/client-call
+          curl -S -s "http://${{ env.MAIN_SERVICE_ENDPOINT }}/outgoing-http-call"
+          curl -S -s "http://${{ env.MAIN_SERVICE_ENDPOINT }}/aws-sdk-call?ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}"
+          curl -S -s "http://${{ env.MAIN_SERVICE_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}"
+          curl -S -s "http://${{ env.MAIN_SERVICE_ENDPOINT }}/client-call"
 
       - name: Initiate Gradlew Daemon
         uses: ./.github/workflows/actions/execute_and_retry
@@ -190,7 +190,7 @@ jobs:
           --log-group ${{ env.LOG_GROUP_NAME }}
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-name sample-remote-application-${{ env.TESTING_ID }}
-          --query-string ip=${{ env.REMOTE_SERVICE_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
           --instance-ami ${{ env.EC2_INSTANCE_AMI }}
           --rollup'
 
@@ -224,7 +224,7 @@ jobs:
           --log-group ${{ env.LOG_GROUP_NAME }}
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-name sample-remote-application-${{ env.TESTING_ID }}
-          --query-string ip=${{ env.REMOTE_SERVICE_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
           --instance-ami ${{ env.EC2_INSTANCE_AMI }}
           --rollup'
 

--- a/.github/workflows/appsignals-e2e-eks-test.yml
+++ b/.github/workflows/appsignals-e2e-eks-test.yml
@@ -267,10 +267,10 @@ jobs:
       - name: Call all test APIs
         continue-on-error: true
         run: |
-          curl -S -s http://${{ env.APP_ENDPOINT }}/outgoing-http-call
-          curl -S -s http://${{ env.APP_ENDPOINT }}/aws-sdk-call?testingId=${{ env.TESTING_ID }}
-          curl -S -s http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_POD_IP }}
-          curl -S -s http://${{ env.APP_ENDPOINT }}/client-call
+          curl -S -s "http://${{ env.APP_ENDPOINT }}/outgoing-http-call"
+          curl -S -s "http://${{ env.APP_ENDPOINT }}/aws-sdk-call?ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}"
+          curl -S -s "http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}"
+          curl -S -s "http://${{ env.APP_ENDPOINT }}/client-call"
 
       - name: Initiate Gradlew Daemon
         uses: ./.github/workflows/actions/execute_and_retry
@@ -295,7 +295,7 @@ jobs:
           --platform-info ${{ inputs.test-cluster-name }}
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
       - name: Call endpoints and validate generated metrics
@@ -330,7 +330,7 @@ jobs:
           --platform-info ${{ inputs.test-cluster-name }}
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
       - name: Publish metric on test result

--- a/.github/workflows/appsignals-e2e-k8s-test.yml
+++ b/.github/workflows/appsignals-e2e-k8s-test.yml
@@ -101,10 +101,10 @@ jobs:
       - name: Call all test APIs
         continue-on-error: true
         run: |
-          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/outgoing-http-call; echo
-          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/aws-sdk-call?ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}; echo
-          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/remote-service?ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}; echo
-          curl -S -s http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/client-call; echo
+          curl -S -s "http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/outgoing-http-call"; echo
+          curl -S -s "http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/aws-sdk-call?ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}"; echo
+          curl -S -s "http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/remote-service?ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}"; echo
+          curl -S -s "http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100/client-call"; echo
 
       # Validation for pulse telemetry data
       - name: Validate generated EMF logs

--- a/.github/workflows/appsignals-e2e-metric-limiter-test.yml
+++ b/.github/workflows/appsignals-e2e-metric-limiter-test.yml
@@ -279,10 +279,10 @@ jobs:
       - name: Call all test APIs
         continue-on-error: true
         run: |
-          curl -S -s http://${{ env.APP_ENDPOINT }}/outgoing-http-call/; echo
-          curl -S -s http://${{ env.APP_ENDPOINT }}/aws-sdk-call/; echo
-          curl -S -s http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_POD_IP }}/; echo
-          curl -S -s http://${{ env.APP_ENDPOINT }}/client-call/; echo
+          curl -S -s "http://${{ env.APP_ENDPOINT }}/outgoing-http-call"; echo
+          curl -S -s "http://${{ env.APP_ENDPOINT }}/aws-sdk-call"; echo
+          curl -S -s "http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_POD_IP }}"; echo
+          curl -S -s "http://${{ env.APP_ENDPOINT }}/client-call"; echo
 
       - name: Initiate Gradlew Daemon
         uses: ./.github/workflows/actions/execute_and_retry

--- a/validator/src/main/resources/expected-data-template/ec2/aws-sdk-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/ec2/aws-sdk-call-log.mustache
@@ -12,6 +12,6 @@
   "Version": "^1$",
   "RemoteService": "AWS.SDK.S3",
   "RemoteOperation": "GetBucketLocation",
-  "RemoteTarget": "e2e-test-bucket-name",
+  "RemoteTarget": "^::s3:::e2e-test-bucket-name-{{testingId}}$",
   "aws.span.kind": "^CLIENT$"
 }]

--- a/validator/src/main/resources/expected-data-template/ec2/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/ec2/aws-sdk-call-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/aws-sdk-call$",
+      "url": "^{{endpoint}}/aws-sdk-call\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
       "method": "^GET$"
     },
     "response": {
@@ -32,7 +32,7 @@
           "name": "^S3$",
           "http": {
             "request": {
-              "url": "^https://e2e-test-bucket-name.s3.{{region}}.amazonaws.com\\?location$",
+              "url": "^https://e2e-test-bucket-name-{{testingId}}.s3.{{region}}.amazonaws.com\\?location$",
               "method": "^GET$"
             }
           },
@@ -42,7 +42,7 @@
             "aws.local.operation": "^GET /aws-sdk-call$",
             "aws.remote.service": "^AWS\\.SDK\\.S3$",
             "aws.remote.operation": "^GetBucketLocation$",
-            "aws.remote.target": "^::s3:::e2e-test-bucket-name$"
+            "aws.remote.target": "^::s3:::e2e-test-bucket-name-{{testingId}}$"
           },
           "metadata": {
             "default": {

--- a/validator/src/main/resources/expected-data-template/ec2/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/ec2/remote-service-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/remote-service\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})$",
+      "url": "^{{endpoint}}/remote-service\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
       "method": "^GET$"
     },
     "response": {

--- a/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-log.mustache
@@ -20,6 +20,6 @@
   "Version": "^1$",
   "RemoteService": "AWS.SDK.S3",
   "RemoteOperation": "GetBucketLocation",
-  "RemoteTarget": "e2e-test-bucket-name",
+  "RemoteTarget": "^::s3:::e2e-test-bucket-name-{{testingId}}$",
   "aws.span.kind": "^CLIENT$"
 }]

--- a/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/eks/aws-sdk-call-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/aws-sdk-call$",
+      "url": "^{{endpoint}}/aws-sdk-call\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
       "method": "^GET$"
     },
     "response": {
@@ -33,7 +33,7 @@
           "name": "^S3$",
           "http": {
             "request": {
-              "url": "^https://e2e-test-bucket-name.s3.{{region}}.amazonaws.com\\?location$",
+              "url": "^https://e2e-test-bucket-name-{{testingId}}.s3.{{region}}.amazonaws.com\\?location$",
               "method": "^GET$"
             }
           },
@@ -44,7 +44,7 @@
             "aws.local.operation": "^GET /aws-sdk-call$",
             "aws.remote.service": "^AWS\\.SDK\\.S3$",
             "aws.remote.operation": "GetBucketLocation",
-            "aws.remote.target": "^::s3:::e2e-test-bucket-name$"
+            "aws.remote.target": "^::s3:::e2e-test-bucket-name-{{testingId}}$"
           },
           "metadata": {
             "default": {

--- a/validator/src/main/resources/expected-data-template/eks/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/eks/remote-service-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/remote-service\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})$",
+      "url": "^{{endpoint}}/remote-service\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
       "method": "^GET$"
     },
     "response": {

--- a/validator/src/main/resources/expected-data-template/python/ec2/aws-sdk-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/aws-sdk-call-log.mustache
@@ -12,6 +12,6 @@
   "Version": "^1$",
   "RemoteService": "AWS.SDK.S3",
   "RemoteOperation": "GetBucketLocation",
-  "RemoteTarget": "::s3:::e2e-test-bucket-name",
+  "RemoteTarget": "^::s3:::e2e-test-bucket-name-{{testingId}}$",
   "aws.span.kind": "^CLIENT$"
 }]

--- a/validator/src/main/resources/expected-data-template/python/ec2/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/aws-sdk-call-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/aws-sdk-call$",
+      "url": "^{{endpoint}}/aws-sdk-call\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
       "method": "^GET$"
     },
     "response": {
@@ -42,7 +42,7 @@
         "aws.local.operation": "^GET aws-sdk-call$",
         "aws.remote.service": "^AWS\\.SDK\\.S3$",
         "aws.remote.operation": "^GetBucketLocation$",
-        "aws.remote.target": "^::s3:::e2e-test-bucket-name$"
+        "aws.remote.target": "^::s3:::e2e-test-bucket-name-{{testingId}}$"
       },
       "metadata": {
         "default": {

--- a/validator/src/main/resources/expected-data-template/python/ec2/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/remote-service-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/remote-service\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})$",
+      "url": "^{{endpoint}}/remote-service\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
       "method": "^GET$"
     },
     "response": {

--- a/validator/src/main/resources/expected-data-template/python/eks/aws-sdk-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/python/eks/aws-sdk-call-log.mustache
@@ -20,6 +20,6 @@
   "Version": "^1$",
   "RemoteService": "AWS.SDK.S3",
   "RemoteOperation": "GetBucketLocation",
-  "RemoteTarget": "::s3:::e2e-test-bucket-name",
+  "RemoteTarget": "^::s3:::e2e-test-bucket-name-{{testingId}}$",
   "aws.span.kind": "^CLIENT$"
 }]

--- a/validator/src/main/resources/expected-data-template/python/eks/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/python/eks/aws-sdk-call-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/aws-sdk-call$",
+      "url": "^{{endpoint}}/aws-sdk-call\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
       "method": "^GET$"
     },
     "response": {
@@ -45,7 +45,7 @@
         "aws.local.operation": "^GET aws-sdk-call$",
         "aws.remote.service": "^AWS\\.SDK\\.S3$",
         "aws.remote.operation": "GetBucketLocation",
-        "aws.remote.target": "::s3:::e2e-test-bucket-name"
+        "aws.remote.target": "^::s3:::e2e-test-bucket-name-{{testingId}}$"
       },
       "metadata": {
         "default": {

--- a/validator/src/main/resources/expected-data-template/python/eks/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/python/eks/remote-service-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/remote-service\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})$",
+      "url": "^{{endpoint}}/remote-service\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
       "method": "^GET$"
     },
     "response": {

--- a/validator/src/main/resources/validations/ec2/log-validation.yml
+++ b/validator/src/main/resources/validations/ec2/log-validation.yml
@@ -8,7 +8,7 @@
   validationType: "cw-log"
   httpPath: "/aws-sdk-call"
   httpMethod: "get"
-  callingType: "http"
+  callingType: "http-with-query"
   expectedLogStructureTemplate: "EC2_AWS_SDK_CALL_LOG"
 -
   validationType: "cw-log"

--- a/validator/src/main/resources/validations/ec2/trace-validation.yml
+++ b/validator/src/main/resources/validations/ec2/trace-validation.yml
@@ -8,7 +8,7 @@
   validationType: "trace"
   httpPath: "/aws-sdk-call"
   httpMethod: "get"
-  callingType: "http"
+  callingType: "http-with-query"
   expectedTraceTemplate: "EC2_AWS_SDK_CALL_TRACE"
 -
   validationType: "trace"

--- a/validator/src/main/resources/validations/eks/log-validation.yml
+++ b/validator/src/main/resources/validations/eks/log-validation.yml
@@ -8,7 +8,7 @@
   validationType: "cw-log"
   httpPath: "/aws-sdk-call"
   httpMethod: "get"
-  callingType: "http"
+  callingType: "http-with-query"
   expectedLogStructureTemplate: "EKS_AWS_SDK_CALL_LOG"
 -
   validationType: "cw-log"

--- a/validator/src/main/resources/validations/eks/trace-validation.yml
+++ b/validator/src/main/resources/validations/eks/trace-validation.yml
@@ -8,7 +8,7 @@
   validationType: "trace"
   httpPath: "/aws-sdk-call"
   httpMethod: "get"
-  callingType: "http"
+  callingType: "http-with-query"
   expectedTraceTemplate: "EKS_AWS_SDK_CALL_TRACE"
 -
   validationType: "trace"

--- a/validator/src/main/resources/validations/python/ec2/log-validation.yml
+++ b/validator/src/main/resources/validations/python/ec2/log-validation.yml
@@ -8,7 +8,7 @@
   validationType: "cw-log"
   httpPath: "/aws-sdk-call"
   httpMethod: "get"
-  callingType: "http"
+  callingType: "http-with-query"
   expectedLogStructureTemplate: "PYTHON_EC2_AWS_SDK_CALL_LOG"
 -
   validationType: "cw-log"

--- a/validator/src/main/resources/validations/python/ec2/trace-validation.yml
+++ b/validator/src/main/resources/validations/python/ec2/trace-validation.yml
@@ -8,7 +8,7 @@
   validationType: "trace"
   httpPath: "/aws-sdk-call"
   httpMethod: "get"
-  callingType: "http"
+  callingType: "http-with-query"
   expectedTraceTemplate: "PYTHON_EC2_AWS_SDK_CALL_TRACE"
 -
   validationType: "trace"

--- a/validator/src/main/resources/validations/python/eks/log-validation.yml
+++ b/validator/src/main/resources/validations/python/eks/log-validation.yml
@@ -8,7 +8,7 @@
   validationType: "cw-log"
   httpPath: "/aws-sdk-call"
   httpMethod: "get"
-  callingType: "http"
+  callingType: "http-with-query"
   expectedLogStructureTemplate: "PYTHON_EKS_AWS_SDK_CALL_LOG"
 -
   validationType: "cw-log"

--- a/validator/src/main/resources/validations/python/eks/trace-validation.yml
+++ b/validator/src/main/resources/validations/python/eks/trace-validation.yml
@@ -8,7 +8,7 @@
   validationType: "trace"
   httpPath: "/aws-sdk-call"
   httpMethod: "get"
-  callingType: "http"
+  callingType: "http-with-query"
   expectedTraceTemplate: "PYTHON_EKS_AWS_SDK_CALL_TRACE"
 -
   validationType: "trace"


### PR DESCRIPTION
*Issue #, if available:*
Followup from https://github.com/aws-observability/aws-application-signals-test-framework/pull/65 and https://github.com/aws-observability/aws-application-signals-test-framework/pull/41
In this PR, we make the data generated from the testing sample app more consistent between traces/metrics/logs.

*Description of changes:*
Make the inputted query-string to the sample app the same across the trace/metrics/logs validators.
> --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}

*Testing done:*
15 minute canaries running successfully for 12+ hours:
EC2 Java in IAD: https://github.com/jj22ee/aws-application-signals-test-framework/actions/workflows/test-ec2-java.yml
EKS Java in IAD: https://github.com/jj22ee/aws-application-signals-test-framework/actions/workflows/test-eks-java.yml
EC2 Python in IAD: https://github.com/jj22ee/aws-application-signals-test-framework/actions/workflows/test-ec2-python.yml
EKS Python in IAD: https://github.com/jj22ee/aws-application-signals-test-framework/actions/workflows/test-eks-python.yml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

