### PR TITLE
[Fix] Python k8s workflow file reference

### DIFF
--- a/.github/workflows/appsignals-python-e2e-k8s-canary-test.yml
+++ b/.github/workflows/appsignals-python-e2e-k8s-canary-test.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   e2e-k8s-test:
-    uses: ./.github/workflows/appsignals-e2e-python-k8s-test.yml
+    uses: ./.github/workflows/application-signals-python-e2e-k8s-test.yml
     secrets: inherit
     with:
       # To run in more regions, a cluster must be provisioned manually on EC2 instances in that region


### PR DESCRIPTION
Another quick fix

Proof it works: [link](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9293633737)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

