### PR TITLE
Update Metric Limiter with latest release

### DIFF
--- a/.github/workflows/application-signals-java-e2e-metric-limiter-canary-test.yml
+++ b/.github/workflows/application-signals-java-e2e-metric-limiter-canary-test.yml
@@ -6,7 +6,7 @@
 ## Operator and our sample app and remote service onto a native K8s cluster, call the
 ## APIs, and validate the generated telemetry, including logs, metrics, and traces.
 ## It will then clean up the cluster and EC2 instance it runs on for the next test run.
-name:  App Signals Enablement - E2E Metric Limiter Canary Testing
+name: Application Signals Enablement - Java E2E Metric Limiter Canary Testing
 on:
   schedule:
     - cron: '*/15 * * * *' # run the workflow every 15 minutes
@@ -25,7 +25,7 @@ jobs:
                       'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
                       'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
                       'us-east-1','us-east-2','us-west-1','us-west-2' ]
-    uses: ./.github/workflows/appsignals-e2e-metric-limiter-test.yml
+    uses: ./.github/workflows/application-signals-java-e2e-metric-limiter-test.yml
     secrets: inherit
     with:
       aws-region: ${{ matrix.aws-region }}

--- a/.github/workflows/application-signals-java-e2e-metric-limiter-test.yml
+++ b/.github/workflows/application-signals-java-e2e-metric-limiter-test.yml
@@ -170,8 +170,8 @@ jobs:
                 --region ${{ inputs.aws-region }} \
                 --configuration-values '{"agent":{"config":{"logs":{"metrics_collected":{"app_signals":{"limiter":{"drop_threshold":2}}}}}}}'
                     
-              execute_and_retry 2 "kubectl delete pods --all -n ${{ env.SAMPLE_APP_NAMESPACE }}"
-              execute_and_retry 2 "kubectl wait --for=condition=Ready --request-timeout '5m' pod --all -n ${{ env.SAMPLE_APP_NAMESPACE }}"
+              execute_and_retry 2 "kubectl delete pods --all -n ${{ env.SAMPLE_APP_NAMESPACE }}" "" 60
+              execute_and_retry 2 "kubectl wait --for=condition=Ready --request-timeout '5m' pod --all -n ${{ env.SAMPLE_APP_NAMESPACE }}" "" 10
                     
               echo "Attempting to connect to the main sample app endpoint"
               main_sample_app_endpoint=http://$(terraform output sample_app_endpoint)
@@ -272,10 +272,10 @@ jobs:
       - name: Call all test APIs
         continue-on-error: true
         run: |
-          curl -S -s "http://${{ env.APP_ENDPOINT }}/outgoing-http-call"
-          curl -S -s "http://${{ env.APP_ENDPOINT }}/aws-sdk-call?ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}"
-          curl -S -s "http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}"
-          curl -S -s "http://${{ env.APP_ENDPOINT }}/client-call"
+          curl -S -s "http://${{ env.APP_ENDPOINT }}/outgoing-http-call"; echo
+          curl -S -s "http://${{ env.APP_ENDPOINT }}/aws-sdk-call?ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}"; echo
+          curl -S -s "http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}"; echo
+          curl -S -s "http://${{ env.APP_ENDPOINT }}/client-call"; echo
 
       - name: Initiate Gradlew Daemon
         uses: ./.github/workflows/actions/execute_and_retry

--- a/.github/workflows/application-signals-java-e2e-metric-limiter-test.yml
+++ b/.github/workflows/application-signals-java-e2e-metric-limiter-test.yml
@@ -4,7 +4,7 @@
 # This is a reusable workflow for running the E2E test for App Signals.
 # It is meant to be called from another workflow.
 # Read more about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview
-name: App Signals Enablement E2E Testing - Metric Limiter
+name: Application Signals Enablement E2E Testing - Java Metric Limiter
 on:
   workflow_call:
     inputs:
@@ -33,8 +33,8 @@ env:
   ENABLEMENT_SCRIPT_S3_BUCKET: ${{ secrets.APP_SIGNALS_E2E_ENABLEMENT_SCRIPT }}
   SAMPLE_APP_FRONTEND_SERVICE_IMAGE: ${{ secrets.APP_SIGNALS_E2E_TEST_ACC }}.dkr.ecr.${{ inputs.aws-region }}.amazonawss.com/${{ secrets.APP_SIGNALS_E2E_FE_SA_IMG }}
   SAMPLE_APP_REMOTE_SERVICE_IMAGE: ${{ secrets.APP_SIGNALS_E2E_TEST_ACC }}.dkr.ecr.${{ inputs.aws-region }}.amazonawss.com/${{ secrets.APP_SIGNALS_E2E_RE_SA_IMG }}
-  METRIC_NAMESPACE: AppSignals
-  LOG_GROUP_NAME: /aws/appsignals/eks
+  METRIC_NAMESPACE: ApplicationSignals
+  LOG_GROUP_NAME: /aws/application-signals/data
   TEST_RESOURCES_FOLDER: /__w/aws-application-signals-test-framework/aws-application-signals-test-framework
 
 jobs:
@@ -55,12 +55,6 @@ jobs:
           && wget https://raw.githubusercontent.com/aws-observability/application-signals-demo/main/scripts/eks/appsignals/clean-app-signals.sh"
           cleanup: "rm -f enable-app-signals.sh && rm -f clean-app-signals.sh"
           post-command: "chmod +x enable-app-signals.sh && chmod +x clean-app-signals.sh"
-
-      # In preparation for next release so we do not get alarms once the release is done
-      - name: Enforce EKS add on v1.6.0-eksbuild.1
-        working-directory: enablement-script
-        run: |
-          sed -i '\#--addon-name amazon-cloudwatch-observability \\#a--addon-version v1.6.0-eksbuild.1 \\' enable-app-signals.sh
 
       - name: Remove log group deletion command
         if: always()
@@ -176,9 +170,8 @@ jobs:
                 --region ${{ inputs.aws-region }} \
                 --configuration-values '{"agent":{"config":{"logs":{"metrics_collected":{"app_signals":{"limiter":{"drop_threshold":2}}}}}}}'
                     
-          
-              execute_and_retry 2 "kubectl delete pods --all -n ${{ env.SAMPLE_APP_NAMESPACE }}" "" 60
-              execute_and_retry 2 "kubectl wait --for=condition=Ready --request-timeout '5m' pod --all -n ${{ env.SAMPLE_APP_NAMESPACE }}" "" 10
+              execute_and_retry 2 "kubectl delete pods --all -n ${{ env.SAMPLE_APP_NAMESPACE }}"
+              execute_and_retry 2 "kubectl wait --for=condition=Ready --request-timeout '5m' pod --all -n ${{ env.SAMPLE_APP_NAMESPACE }}"
                     
               echo "Attempting to connect to the main sample app endpoint"
               main_sample_app_endpoint=http://$(terraform output sample_app_endpoint)
@@ -279,10 +272,10 @@ jobs:
       - name: Call all test APIs
         continue-on-error: true
         run: |
-          curl -S -s "http://${{ env.APP_ENDPOINT }}/outgoing-http-call"; echo
-          curl -S -s "http://${{ env.APP_ENDPOINT }}/aws-sdk-call"; echo
-          curl -S -s "http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_POD_IP }}"; echo
-          curl -S -s "http://${{ env.APP_ENDPOINT }}/client-call"; echo
+          curl -S -s "http://${{ env.APP_ENDPOINT }}/outgoing-http-call"
+          curl -S -s "http://${{ env.APP_ENDPOINT }}/aws-sdk-call?ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}"
+          curl -S -s "http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}"
+          curl -S -s "http://${{ env.APP_ENDPOINT }}/client-call"
 
       - name: Initiate Gradlew Daemon
         uses: ./.github/workflows/actions/execute_and_retry
@@ -307,7 +300,7 @@ jobs:
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-name sample-remote-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}
+          --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
       - name: Publish metric on test result

--- a/validator/src/main/resources/expected-data-template/metric_limiter/metric-limiter-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/metric_limiter/metric-limiter-metric.mustache
@@ -9,11 +9,8 @@
       name: Service
       value: {{serviceName}}
     -
-      name: HostedIn.EKS.Cluster
-      value: {{platformInfo}}
-    -
-      name: HostedIn.K8s.Namespace
-      value: {{appNamespace}}
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
 
 -
   metricName: Latency
@@ -23,11 +20,8 @@
       name: Service
       value: {{serviceName}}
     -
-      name: HostedIn.EKS.Cluster
-      value: {{platformInfo}}
-    -
-      name: HostedIn.K8s.Namespace
-      value: {{appNamespace}}
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
 
 -
   metricName: Error
@@ -40,11 +34,8 @@
       name: Service
       value: {{serviceName}}
     -
-      name: HostedIn.EKS.Cluster
-      value: {{platformInfo}}
-    -
-      name: HostedIn.K8s.Namespace
-      value: {{appNamespace}}
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
 
 -
   metricName: Error
@@ -54,11 +45,8 @@
       name: Service
       value: {{serviceName}}
     -
-      name: HostedIn.EKS.Cluster
-      value: {{platformInfo}}
-    -
-      name: HostedIn.K8s.Namespace
-      value: {{appNamespace}}
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
 
 -
   metricName: Fault
@@ -71,11 +59,8 @@
       name: Service
       value: {{serviceName}}
     -
-      name: HostedIn.EKS.Cluster
-      value: {{platformInfo}}
-    -
-      name: HostedIn.K8s.Namespace
-      value: {{appNamespace}}
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
 
 -
   metricName: Fault
@@ -85,8 +70,5 @@
       name: Service
       value: {{serviceName}}
     -
-      name: HostedIn.EKS.Cluster
-      value: {{platformInfo}}
-    -
-      name: HostedIn.K8s.Namespace
-      value: {{appNamespace}}
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}


### PR DESCRIPTION
*Issue #, if available:*
New Java Artifacts will be released. The new release includes significant changes in the metric schema of the telemetry. We need to update the validation templates to reflect the new expected changes. 

May 30, 2024 Update:
Java Artifacts have been released.
- Updated file name from appsignals -> application-signals
- Removed code forcing old version of artifact

Test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9322261852
Second run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9322363457
Third run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9324310243


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

