### PR TITLE
Change workflow name back

### DIFF
--- a/.github/workflows/application-signals-python-e2e-ec2-canary-test.yml
+++ b/.github/workflows/application-signals-python-e2e-ec2-canary-test.yml
@@ -28,7 +28,7 @@ jobs:
     secrets: inherit
     with:
       aws-region: ${{ matrix.aws-region }}
-      caller-workflow-name: 'appsignals-python-e2e-ec2-default-canary-test'
+      caller-workflow-name: 'appsignals-python-e2e-ec2-canary-test'
 
   python-e2e-ec2-asg-test:
     strategy:


### PR DESCRIPTION
*Issue #, if available:*
Changing the workflow name will trigger an alarm since it uses the old workflow name to check if it is failing. Revert the workflow name back


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

