### PR TITLE
Prevent retry script from failing when cleanup fails

### DIFF
--- a/.github/workflows/actions/execute_and_retry/action.yml
+++ b/.github/workflows/actions/execute_and_retry/action.yml
@@ -56,7 +56,7 @@ runs:
           if [ $attempt_failed -ne 0 ]; then
             echo "Command failed for execute_and_retry action, executing cleanup command for another attempt"
 
-            eval "$CLEANUP" || command_failed=$?
+            eval "$CLEANUP" || true
             retry_counter=$(($retry_counter+1))
             sleep "$SLEEP_TIME"
           else

--- a/.github/workflows/util/execute_and_retry.sh
+++ b/.github/workflows/util/execute_and_retry.sh
@@ -21,7 +21,7 @@ execute_and_retry () {
 
    if [ $attempt_failed -ne 0 ]; then
      echo "Command failed for execute_and_retry.sh, executing cleanup command for another attempt"
-     eval "$cleanup"
+     eval "$cleanup" || true
      execute_retry_counter=$(($execute_retry_counter+1))
      sleep "${sleep_time:-10}"
    else


### PR DESCRIPTION
*Issue #, if available:*
This task was started because it was believed that the cleanup command had a bug that caused the retry scripts to exit prematurely when failed. However, testing shows that the retry scripts works fine. 

- Test [run](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9473507110/job/26101288040) with failure: Left out the change and added "exit 1" to the actual and cleanup command on the Download Enablement Script Step to verify that the script exits prematurely. It did not.

- Test [run](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9473637165) with failure: Same as above but with bug fixed. Verify that the retry worked 3 times

An example [run](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/8935086952/job/24543026873) where the cleanup command failed shows that it was during the Terraform Deployment step, which uses the retry script and not the action. The retry script doesn't seem to have the cleanup fail prevention implemented, hence why this run exited prematurely. 

Retry Action Script has a small bug that makes it such that failure in cleanup command will make retry exit prematurely. 

*Description of changes:*
Add the cleanup prevention step to the retry script

Test [run](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9489969220) with success

Test [run](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9490098736) where cleanup didn't exit prematurely for action

Test [run](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9490300250) where cleanup didn't exit prematurely for script



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

