### PR TITLE
Check if Python Remote App Endpoint is Up

### DIFF
--- a/.github/workflows/application-signals-python-e2e-ec2-default-test.yml
+++ b/.github/workflows/application-signals-python-e2e-ec2-default-test.yml
@@ -131,6 +131,22 @@ jobs:
                 attempt_counter=$(($attempt_counter+1))
                 sleep 10
               done
+          
+              echo "Attempting to connect to the remote sample app endpoint"
+              remote_sample_app_endpoint=http://$(terraform output sample_app_remote_service_public_ip):8001/healthcheck
+              attempt_counter=0
+              max_attempts=30
+              until $(curl --output /dev/null --silent --head --fail $(echo "$remote_sample_app_endpoint" | tr -d '"')); do
+                if [ ${attempt_counter} -eq ${max_attempts} ];then
+                  echo "Failed to connect to endpoint. Will attempt to redeploy sample app."
+                  deployment_failed=1
+                  break
+                fi
+
+                printf '.'
+                attempt_counter=$(($attempt_counter+1))
+                sleep 10
+              done
             fi
           
             # If the success is 1 then either the terraform deployment or the endpoint connection failed, so first destroy the

--- a/.github/workflows/application-signals-python-e2e-eks-test.yml
+++ b/.github/workflows/application-signals-python-e2e-eks-test.yml
@@ -191,6 +191,23 @@ jobs:
                 attempt_counter=$(($attempt_counter+1))
                 sleep 10
               done
+          
+              echo "Attempting to connect to the remote sample app endpoint"
+              remote_sample_app_endpoint=http://$(terraform output python_r_app_endpoint)/healthcheck
+              echo $remote_sample_app_endpoint
+              attempt_counter=0
+              max_attempts=30
+              until $(curl --output /dev/null --silent --head --fail $(echo "$remote_sample_app_endpoint" | tr -d '"')); do
+                if [ ${attempt_counter} -eq ${max_attempts} ];then
+                  echo "Failed to connect to endpoint. Will attempt to redeploy sample app."
+                  deployment_failed=1
+                  break
+                fi
+          
+                printf '.'
+                attempt_counter=$(($attempt_counter+1))
+                sleep 10
+              done
             fi
           
             # If the deployment_failed is 1 then either the terraform deployment or the endpoint connection failed, so first destroy the

--- a/terraform/python/eks/main.tf
+++ b/terraform/python/eks/main.tf
@@ -263,6 +263,45 @@ resource "kubernetes_service" "python_r_app_service" {
   }
 }
 
+resource "kubernetes_ingress_v1" "python-r-app-ingress" {
+  depends_on = [kubernetes_service.python_r_app_service]
+  wait_for_load_balancer = true
+  metadata {
+    name = "python-r-app-ingress-${var.test_id}"
+    namespace = var.test_namespace
+    annotations = {
+      "kubernetes.io/ingress.class" = "alb"
+      "alb.ingress.kubernetes.io/scheme" = "internet-facing"
+      "alb.ingress.kubernetes.io/target-type" = "ip"
+    }
+    labels = {
+      app = "python-r-app-ingress"
+    }
+  }
+  spec {
+    rule {
+      http {
+        path {
+          path = "/"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = kubernetes_service.python_r_app_service.metadata[0].name
+              port {
+                number = 8001
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 output "python_app_endpoint" {
   value = kubernetes_ingress_v1.python-app-ingress.status.0.load_balancer.0.ingress.0.hostname
+}
+
+output "python_r_app_endpoint" {
+  value = kubernetes_ingress_v1.python-r-app-ingress.status.0.load_balancer.0.ingress.0.hostname
 }


### PR DESCRIPTION
*Issue #, if available:*
Occasionally the remote sample app for Python doesn't initiate properly and causes errors during metric validation

*Description of changes:*
Add a step to check if Python remote sample app endpoint is properly initiated.

Test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9487123419

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

