### PR TITLE
Update Java K8s with New Secret

### DIFF
--- a/.github/workflows/application-signals-java-e2e-k8s-test.yml
+++ b/.github/workflows/application-signals-java-e2e-k8s-test.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.E2E_SECRET_TEST_ROLE_ARN }}
+          role-to-assume: ${{ secrets.E2E_IAD_TEST_ACCOUNT_ARN }}
           aws-region: us-east-1
 
       - name: Retrieve account


### PR DESCRIPTION
*Issue #, if available:*
Migrated secrets in secret manager to new account. Correspondingly updating github secret to point to new account.
This PR is for Java K8s. Once it is stable will update the rest of canary

Test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9506177589

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

