### PR TITLE
Point to new cluster for python test that is failing in us-east-2

### DIFF
--- a/.github/workflows/application-signals-python-e2e-eks-canary-test.yml
+++ b/.github/workflows/application-signals-python-e2e-eks-canary-test.yml
@@ -36,6 +36,6 @@ jobs:
     uses: ./.github/workflows/application-signals-python-e2e-eks-test.yml
     secrets: inherit
     with:
-      aws-region: 'us-east-2
+      aws-region: 'us-east-2'
       test-cluster-name: 'python-cluster'
       caller-workflow-name: 'appsignals-python-e2e-eks-canary-test'

--- a/.github/workflows/application-signals-python-e2e-eks-canary-test.yml
+++ b/.github/workflows/application-signals-python-e2e-eks-canary-test.yml
@@ -24,10 +24,18 @@ jobs:
         aws-region: ['af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
                      'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
-                     'us-east-1','us-east-2', 'us-west-1', 'us-west-2']
+                     'us-east-1', 'us-west-1', 'us-west-2']
     uses: ./.github/workflows/application-signals-python-e2e-eks-test.yml
     secrets: inherit
     with:
       aws-region: ${{ matrix.aws-region }}
       test-cluster-name: 'e2e-python-canary-test'
+      caller-workflow-name: 'appsignals-python-e2e-eks-canary-test'
+      
+  us-east-2:
+    uses: ./.github/workflows/application-signals-python-e2e-eks-test.yml
+    secrets: inherit
+    with:
+      aws-region: 'us-east-2
+      test-cluster-name: 'python-cluster'
       caller-workflow-name: 'appsignals-python-e2e-eks-canary-test'


### PR DESCRIPTION
Cluster was accidentally deleted during deployment despite testing that it wouldn't in gamma.