### PR TITLE
fix: Introducing gradle build workflow for PR and fix validator unit tests

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,24 @@
+name: PR Build
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Gradle Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: corretto
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Build with Gradle
+        run: ./gradlew build

--- a/validator/build.gradle.kts
+++ b/validator/build.gradle.kts
@@ -36,7 +36,8 @@ repositories {
 
 dependencies {
   // junit
-  testImplementation("org.junit.jupiter:junit-jupiter-api")
+  testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+  testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
   // log
   implementation(group = "org.apache.logging.log4j", name = "log4j-api", version = "2.20.0")
@@ -89,4 +90,8 @@ dependencies {
 application {
   // Define the main class for the application.
   mainClass.set("com.amazon.aoc.App")
+}
+
+tasks.named<Test>("test") {
+  useJUnitPlatform()
 }

--- a/validator/src/test/java/com/amazon/aoc/validators/CWMetricValidatorTest.java
+++ b/validator/src/test/java/com/amazon/aoc/validators/CWMetricValidatorTest.java
@@ -31,7 +31,6 @@ import com.amazon.aoc.models.ValidationConfig;
 import com.amazon.aoc.services.CloudWatchService;
 import com.amazonaws.services.cloudwatch.model.Metric;
 import java.util.List;
-import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
@@ -42,7 +41,7 @@ import org.junit.jupiter.api.condition.DisabledIf;
  */
 @DisabledIf("isWindows")
 public class CWMetricValidatorTest {
-  private CWMetricHelper cwMetricHelper = new CWMetricHelper();
+  private final CWMetricHelper cwMetricHelper = new CWMetricHelper();
   private static final String SERVICE_DIMENSION = "Service";
   private static final String REMOTE_SERVICE_DIMENSION = "RemoteService";
   private static final String REMOTE_TARGET_DIMENSION = "RemoteTarget";
@@ -85,7 +84,7 @@ public class CWMetricValidatorTest {
    */
   @Test
   public void testValidationSucceed() throws Exception {
-    ValidationConfig validationConfig = initValidationConfig("EKS_OUTGOING_HTTP_CALL_METRIC");
+    ValidationConfig validationConfig = initValidationConfig("JAVA_EKS_OUTGOING_HTTP_CALL_METRIC");
     runBasicValidation(validationConfig);
   }
 
@@ -121,7 +120,7 @@ public class CWMetricValidatorTest {
     List<Metric> localServiceMetrics = getTestMetrics("endToEnd_localMetricsWithService");
     List<Metric> remoteServiceMetrics = getTestMetrics("endToEnd_remoteMetricsWithService");
     // Skip remoteMetricsWithRemoteApp, which contains the [RemoteService] rollup.
-    List<Metric> remoteMetricsWithRemoteApp = Lists.newArrayList();
+    List<Metric> remoteMetricsWithRemoteApp = List.of();
     List<Metric> remoteMetricsWithAmazon = getTestMetrics("endToEnd_remoteMetricsWithAmazon");
     List<Metric> remoteMetricsWithAwsSdk = getTestMetrics("endToEnd_remoteMetricsWithAwsSdk");
     List<Metric> remoteMetricsWithAwsSdkWithTarget =


### PR DESCRIPTION
*Issue description:*

Today, there is no workflow before and after PR to run Gradle build to run unit tests for the validator.
In fact, the metric validator unit test is not functional even locally due to testing dependencies are not setup correctly.

<img width="1840" alt="image" src="https://github.com/aws-observability/aws-application-signals-test-framework/assets/7830699/88ab537e-44c6-4bfc-9e1a-3fcdba1c1004">


*Description of changes:*

This change fixed the unit test dependency setting and also introduced a workflow for PRs to build the package via Gradle.

Test run: https://github.com/jerry-shao/aws-application-signals-test-framework/actions/runs/9694520080/job/26752317040

<img width="1840" alt="image" src="https://github.com/aws-observability/aws-application-signals-test-framework/assets/7830699/e0d76dee-597d-4885-b6b7-0fe2d08aba36">


*Ensure you've run the following tests on your changes and include the link below:*
To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
