### PR TITLE
feat: Adding unit test for TraceValidator

### DIFF
--- a/validator/build.gradle.kts
+++ b/validator/build.gradle.kts
@@ -37,6 +37,7 @@ repositories {
 dependencies {
   // junit
   testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+  testImplementation("org.mockito:mockito-junit-jupiter:5.12.0")
   testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
   // log

--- a/validator/src/main/java/com/amazon/aoc/validators/ValidatorFactory.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/ValidatorFactory.java
@@ -22,6 +22,7 @@ import com.amazon.aoc.exception.ExceptionCode;
 import com.amazon.aoc.fileconfigs.FileConfig;
 import com.amazon.aoc.models.Context;
 import com.amazon.aoc.models.ValidationConfig;
+import com.amazon.aoc.services.XRayService;
 
 public class ValidatorFactory {
   private Context context;
@@ -43,7 +44,7 @@ public class ValidatorFactory {
     FileConfig expectedData = null;
     switch (validationConfig.getValidationType()) {
       case "trace":
-        validator = new TraceValidator();
+        validator = new TraceValidator(new XRayService(context.getRegion()), 2, 5);
         expectedData = validationConfig.getExpectedTraceTemplate();
         break;
       case "cw-metric":

--- a/validator/src/test/java/com/amazon/aoc/validators/TraceValidatorTest.java
+++ b/validator/src/test/java/com/amazon/aoc/validators/TraceValidatorTest.java
@@ -1,0 +1,60 @@
+package com.amazon.aoc.validators;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.when;
+
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.util.List;
+
+import com.amazon.aoc.callers.HttpCaller;
+import com.amazon.aoc.models.ValidationConfig;
+import com.amazon.aoc.services.XRayService;
+
+import com.amazonaws.services.xray.model.Segment;
+import com.amazonaws.services.xray.model.Trace;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class TraceValidatorTest extends ValidatorBaseTest {
+
+    private static final String TRACE_ID = "1-00000000-000000000000000000000001";
+
+    @Mock
+    private XRayService xRayService;
+    @Mock
+    private Trace trace;
+    @Mock
+    private Segment segment;
+
+    private TraceValidator traceValidator;
+    private String DOCUMENT;
+
+    @BeforeEach
+    public void beforeEach() throws Exception {
+        HttpCaller httpCaller = mockHttpCaller(TRACE_ID);
+        ValidationConfig validationConfig = initValidationConfig(TEMPLATE_ROOT + "trace/expected/example-trace.mustache");
+        traceValidator = new TraceValidator(xRayService, 1, 1);
+        traceValidator.init(
+                initContext(),
+                validationConfig, httpCaller,
+                validationConfig.getExpectedTraceTemplate()
+        );
+        DOCUMENT = IOUtils.toString(new URL(TEMPLATE_ROOT + "trace/actual/example-trace-document.json"), Charset.defaultCharset());
+    }
+
+    @Test
+    public void testValidate() {
+        when(xRayService.listTraceByIds(List.of(TRACE_ID))).thenReturn(List.of(trace));
+        when(trace.getSegments()).thenReturn(List.of(segment));
+        when(segment.getDocument()).thenReturn(DOCUMENT);
+
+        assertDoesNotThrow(() -> traceValidator.validate());
+    }
+}

--- a/validator/src/test/java/com/amazon/aoc/validators/ValidatorBaseTest.java
+++ b/validator/src/test/java/com/amazon/aoc/validators/ValidatorBaseTest.java
@@ -1,0 +1,52 @@
+package com.amazon.aoc.validators;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.amazon.aoc.callers.HttpCaller;
+import com.amazon.aoc.models.Context;
+import com.amazon.aoc.models.SampleAppResponse;
+import com.amazon.aoc.models.ValidationConfig;
+
+public class ValidatorBaseTest {
+    private static final String SERVICE_DIMENSION = "Service";
+    private static final String REMOTE_SERVICE_DIMENSION = "RemoteService";
+    private static final String REMOTE_TARGET_DIMENSION = "RemoteTarget";
+    protected static final String TEMPLATE_ROOT =
+            "file://" + System.getProperty("user.dir") + "/src/test/test-resources/";
+    private static final String SERVICE_NAME = "serviceName";
+    private static final String REMOTE_SERVICE_NAME = "remoteServiceName";
+    private static final String REMOTE_SERVICE_DEPLOYMENT_NAME = "remoteServiceDeploymentName";
+    private static final String TESTING_ID = "testIdentifier";
+
+    protected HttpCaller mockHttpCaller(String traceId) throws Exception {
+        HttpCaller httpCaller = mock(HttpCaller.class);
+        SampleAppResponse sampleAppResponse = new SampleAppResponse();
+        sampleAppResponse.setTraceId(traceId);
+        when(httpCaller.callSampleApp()).thenReturn(sampleAppResponse);
+        return httpCaller;
+    }
+
+    protected Context initContext() {
+        // fake vars
+        String testingId = "testingId";
+        String region = "region";
+        String namespace = "metricNamespace";
+
+        // faked context
+        Context context = new Context(testingId, region, false, false);
+        context.setMetricNamespace(namespace);
+        context.setServiceName(SERVICE_NAME);
+        context.setRemoteServiceName(REMOTE_SERVICE_NAME);
+        context.setRemoteServiceDeploymentName(REMOTE_SERVICE_DEPLOYMENT_NAME);
+        context.setTestingId(TESTING_ID);
+        return context;
+    }
+
+    protected ValidationConfig initValidationConfig(String traceTemplate) {
+        ValidationConfig validationConfig = new ValidationConfig();
+        validationConfig.setCallingType("http");
+        validationConfig.setExpectedTraceTemplate(traceTemplate);
+        return validationConfig;
+    }
+}

--- a/validator/src/test/java/com/amazon/aoc/validators/ValidatorBaseTest.java
+++ b/validator/src/test/java/com/amazon/aoc/validators/ValidatorBaseTest.java
@@ -9,9 +9,6 @@ import com.amazon.aoc.models.SampleAppResponse;
 import com.amazon.aoc.models.ValidationConfig;
 
 public class ValidatorBaseTest {
-    private static final String SERVICE_DIMENSION = "Service";
-    private static final String REMOTE_SERVICE_DIMENSION = "RemoteService";
-    private static final String REMOTE_TARGET_DIMENSION = "RemoteTarget";
     protected static final String TEMPLATE_ROOT =
             "file://" + System.getProperty("user.dir") + "/src/test/test-resources/";
     private static final String SERVICE_NAME = "serviceName";

--- a/validator/src/test/test-resources/trace/actual/example-trace-document.json
+++ b/validator/src/test/test-resources/trace/actual/example-trace-document.json
@@ -3,7 +3,7 @@
   "name": "serviceName",
   "http": {
     "request": {
-      "url": "http://127.0.0.1/aws-sdk-call?ip=1.2.3.4&testingId=abc",
+      "url": "http://127.0.0.1/aws-sdk-call?ip=1.2.3.4&testingId=testIdentifier",
       "method": "GET"
     },
     "response": {

--- a/validator/src/test/test-resources/trace/actual/example-trace-document.json
+++ b/validator/src/test/test-resources/trace/actual/example-trace-document.json
@@ -1,0 +1,59 @@
+{
+  "trace_id": "1-00000000-000000000000000000000001",
+  "name": "serviceName",
+  "http": {
+    "request": {
+      "url": "http://127.0.0.1/aws-sdk-call?ip=1.2.3.4&testingId=abc",
+      "method": "GET"
+    },
+    "response": {
+      "status": 200
+    }
+  },
+  "aws": {
+    "account_id": "1234567890123"
+  },
+  "annotations": {
+    "aws.local.service": "serviceName",
+    "aws.local.operation": "GET /aws-sdk-call",
+    "aws.local.environment": "eks:platformInfo/appNamespace"
+  },
+  "metadata": {
+    "default": {
+      "aws.span.kind": "LOCAL_ROOT",
+      "otel.resource.K8s.Node": "i-123456789abcdefgh",
+      "otel.resource.K8s.Workload": "sample-app-deployment-eu-west-1-1234",
+      "EC2.AutoScalingGroup": "eks-1234-abcdefg",
+      "otel.resource.K8s.Pod": "sample-app-deployment-region-abcd",
+      "otel.resource.host.name": "ip-10-0-0-2.ab-west-9.compute.internal",
+      "K8s.Namespace": "appNamespace",
+      "EKS.Cluster": "platformInfo",
+      "PlatformType": "AWS::EKS"
+    }
+  },
+  "subsegments": [
+    {
+      "subsegments": [
+        {
+          "name": "S3",
+          "annotations": {
+            "aws.local.operation": "GET /aws-sdk-call",
+            "aws.remote.service": "AWS::S3",
+            "aws.remote.operation": "GetBucketLocation",
+            "aws.remote.resource.type": "AWS::S3::Bucket",
+            "aws.remote.resource.identifier": "e2e-test-bucket-name-abcd$"
+          },
+          "metadata": {
+            "default": {
+              "EC2.AutoScalingGroup": "eks-abcd",
+              "EKS.Cluster": "platformInfo",
+              "PlatformType": "AWS::EKS",
+              "aws.span.kind": "CLIENT"
+            }
+          },
+          "namespace": "aws"
+        }
+      ]
+    }
+  ]
+}

--- a/validator/src/test/test-resources/trace/expected/example-trace.mustache
+++ b/validator/src/test/test-resources/trace/expected/example-trace.mustache
@@ -1,0 +1,58 @@
+[{
+  "name": "^serviceName$",
+  "http": {
+    "request": {
+      "url": "^http://.*/aws-sdk-call\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId=.*",
+      "method": "^GET$"
+    },
+    "response": {
+      "status": "^200$"
+    }
+  },
+  "aws": {
+    "account_id": "[0-9]{13}"
+  },
+  "annotations": {
+    "aws.local.service": "^serviceName$",
+    "aws.local.operation": "^GET /aws-sdk-call$",
+    "aws.local.environment": "^eks:platformInfo/appNamespace$"
+  },
+  "metadata": {
+    "default": {
+        "EC2.AutoScalingGroup": "^eks-.+",
+        "EKS.Cluster": "^platformInfo$",
+        "K8s.Namespace": "^appNamespace",
+        "otel.resource.K8s.Workload": "^sample-app-deployment-.*",
+        "otel.resource.K8s.Node": "^i-[A-Za-z0-9]{17}$",
+        "otel.resource.K8s.Pod": "^sample-app-deployment-.*",
+        "otel.resource.host.name": "^ip(-[0-9]{1,3}){4}.*$",
+        "PlatformType": "^AWS::EKS$",
+        "aws.span.kind": "^LOCAL_ROOT$"
+    }
+  },
+  "subsegments": [
+    {
+      "subsegments": [
+        {
+          "name": "^S3$",
+          "annotations": {
+            "aws.local.operation": "^GET /aws-sdk-call$",
+            "aws.remote.service": "^AWS::S3$",
+            "aws.remote.operation": "^GetBucketLocation$",
+            "aws.remote.resource.type": "^AWS::S3::Bucket$",
+            "aws.remote.resource.identifier": "^e2e-test-bucket-name-.*"
+          },
+          "metadata": {
+            "default": {
+              "EC2.AutoScalingGroup": "^eks-.+",
+              "EKS.Cluster": "^platformInfo$",
+              "PlatformType": "^AWS::EKS$",
+              "aws.span.kind": "^CLIENT$"
+            }
+          },
+          "namespace": "^aws$"
+        }
+      ]
+    }
+  ]
+}]


### PR DESCRIPTION
*Issue description:*

There is only unit testing for MetricValidator only, it's hard to understand whether TraceValidator is working as expected.

*Description of changes:*

This change introduces a unit test for TraceValidator which could make sure the TraceValidator is working as expected. Also this could help developers debug the difference between actual traces and the mustache template.

This unit test will also be executed for every PR to make sure new changes won't break validator behaviour.

E2E testing workflow: https://github.com/jerry-shao/aws-application-signals-test-framework/actions/runs/9716864880/job/26821375468
(Note: Only eu-west-1 passed because that's the region I have E2E infrastructure deployed)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
