### PR TITLE
fix: Build gradle fully before running validator

### DIFF
--- a/.github/workflows/application-signals-java-e2e-ec2-asg-test.yml
+++ b/.github/workflows/application-signals-java-e2e-ec2-asg-test.yml
@@ -47,7 +47,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew"
+          command: "./gradlew :validator:build"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60
@@ -187,7 +187,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew"
+          command: "./gradlew :validator:build"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60

--- a/.github/workflows/application-signals-java-e2e-ec2-default-test.yml
+++ b/.github/workflows/application-signals-java-e2e-ec2-default-test.yml
@@ -46,7 +46,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew"
+          command: "./gradlew :validator:build"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60
@@ -186,7 +186,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew"
+          command: "./gradlew :validator:build"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60

--- a/.github/workflows/application-signals-java-e2e-eks-test.yml
+++ b/.github/workflows/application-signals-java-e2e-eks-test.yml
@@ -55,7 +55,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew"
+          command: "./gradlew :validator:build"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60
@@ -282,7 +282,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew"
+          command: "./gradlew :validator:build"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60

--- a/.github/workflows/application-signals-java-e2e-k8s-test.yml
+++ b/.github/workflows/application-signals-java-e2e-k8s-test.yml
@@ -49,7 +49,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew"
+          command: "./gradlew :validator:build"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60
@@ -136,7 +136,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew"
+          command: "./gradlew :validator:build"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60

--- a/.github/workflows/application-signals-java-e2e-metric-limiter-test.yml
+++ b/.github/workflows/application-signals-java-e2e-metric-limiter-test.yml
@@ -52,7 +52,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew"
+          command: "./gradlew :validator:build"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60
@@ -293,7 +293,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew"
+          command: "./gradlew :validator:build"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60

--- a/.github/workflows/application-signals-python-e2e-ec2-asg-test.yml
+++ b/.github/workflows/application-signals-python-e2e-ec2-asg-test.yml
@@ -48,7 +48,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew"
+          command: "./gradlew :validator:build"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60
@@ -206,7 +206,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew"
+          command: "./gradlew :validator:build"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60

--- a/.github/workflows/application-signals-python-e2e-ec2-default-test.yml
+++ b/.github/workflows/application-signals-python-e2e-ec2-default-test.yml
@@ -48,7 +48,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew"
+          command: "./gradlew :validator:build"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60
@@ -206,7 +206,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew"
+          command: "./gradlew :validator:build"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60

--- a/.github/workflows/application-signals-python-e2e-eks-test.yml
+++ b/.github/workflows/application-signals-python-e2e-eks-test.yml
@@ -54,7 +54,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew"
+          command: "./gradlew :validator:build"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60
@@ -294,7 +294,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew"
+          command: "./gradlew :validator:build"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60

--- a/.github/workflows/application-signals-python-e2e-k8s-test.yml
+++ b/.github/workflows/application-signals-python-e2e-k8s-test.yml
@@ -50,7 +50,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew"
+          command: "./gradlew :validator:build"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60
@@ -138,7 +138,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew"
+          command: "./gradlew :validator:build"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60


### PR DESCRIPTION
*Issue description:*
Gradle doesn't build fully, this change allows it to build the entire validator instead of just starting the gradle daemon alone.

*Description of changes:*
- Replace `./gradlew` with `./gradlew :validator:build` where relevant

Before changes:
- Initiate gradle step does not build validator: [link](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9726293142/job/26844581975#step:4:80)
- First validation step has to build validator part of project: [link](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9726293142/job/26844581975#step:22:37)
After changes:
- Initiate gradle step builds the validator: [link](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9726153233/job/26844273638#step:4:83)
- Validation steps recognize this and go straight into the logic: [link](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9726153233/job/26844273638#step:22:40)

*Ensure you've run the following tests on your changes and include the link below:*
Test run: [link](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9726153233/)

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
