### PR TITLE
Calling mysql API in the Java SampleApp to trigger Database queries

### DIFF
--- a/.github/workflows/application-signals-java-e2e-eks-test.yml
+++ b/.github/workflows/application-signals-java-e2e-eks-test.yml
@@ -296,6 +296,7 @@ jobs:
           curl -S -s "http://${{ env.APP_ENDPOINT }}/aws-sdk-call?ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}"
           curl -S -s "http://${{ env.APP_ENDPOINT }}/remote-service?ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}"
           curl -S -s "http://${{ env.APP_ENDPOINT }}/client-call"
+          curl -S -s "http://${{ env.APP_ENDPOINT }}/mysql"
 
       - name: Initiate Gradlew Daemon
         if: steps.initiate-gradlew == 'failure'


### PR DESCRIPTION
*Issue description:*
We introduced the /mysql API in https://github.com/aws-observability/aws-application-signals-test-framework/pull/96 but not invoking it.

*Description of changes:*
Calling mysql API in the Java SampleApp to trigger Database queries and continue on failure, make sure it won't impact existed E2E tests.

*Testing*
Happy case (where I have RDS database and the latest SampleApp Image): All passed in eu-west-1: https://github.com/jerry-shao/aws-application-signals-test-framework/actions/runs/9782306016/job/27008320300
SampleApp Image upload workflow: https://github.com/jerry-shao/aws-application-signals-test-framework/actions/runs/9782258002

Edge case 1: No RDS database, using `mydatabase` as the database name for example with the latest SampleApp Image:
Call APIs workflow shows error message for /mysql API but succeed.

Log:
```
{"traceId": "1-66858ccc-a81431cad0bd60bf24210d02"}{"traceId": "1-66858ccd-a1348a88a3a82be70a4e91b1"}{"traceId": "1-66858cce-7f66194a85b96f76e413e2a9"}{"traceId": "1-00000000-000000000000000000000000"}{"timestamp":"2024-07-03T17:39:27.162+00:00","status":500,"error":"Internal Server Error","path":"/mysql"}
```

workflow link (eu-west-1 succeed): https://github.com/jerry-shao/aws-application-signals-test-framework/actions/runs/9782406886/job/27008637905

Edge case 2: No RDS database, using `mydatabase` as the database name for example without the latest SampleApp image, so there is no /mysql API at all.

Image build and upload with old SampleAPP (no /mysql API): https://github.com/jerry-shao/aws-application-signals-test-framework/actions/runs/9782492925

Workflow succeed with error message in the calling test APIs step:
```
{"traceId": "1-66858f39-80179ceda664cd6a8eddca1a"}{"traceId": "1-66858f3a-28a5cfeb533bfd92b84ef643"}{"traceId": "1-66858f3b-b51418ce3c514b25d0924cc2"}{"traceId": "1-00000000-000000000000000000000000"}{"timestamp":"2024-07-03T17:49:48.124+00:00","status":404,"error":"Not Found","path":"/mysql"}
```
workflow link:https://github.com/jerry-shao/aws-application-signals-test-framework/actions/runs/9782518767/job/27009022228


Metric also showed no failure for all these three cases:
<img width="1625" alt="image" src="https://github.com/aws-observability/aws-application-signals-test-framework/assets/7830699/232ec1b7-0e4c-4bd9-89d2-987b0f81a6f4">


So this PR is safe to merge regardless of the SampleApp version :D



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
