### PR TITLE
[FIX][K8s] Add sleep after patch to wait for pods to come up

### DIFF
--- a/terraform/java/k8s/deploy/main.tf
+++ b/terraform/java/k8s/deploy/main.tf
@@ -84,6 +84,7 @@ resource "null_resource" "deploy" {
       kubectl patch service sample-app-deployment-${var.test_id} -n sample-app-namespace --type='json' --patch='[{"op": "replace", "path": "/spec/ports/0/nodePort", "value":30100}]'
 
       # Wait for sample app to be reach ready state
+      sleep 10
       kubectl wait --for=condition=Ready --request-timeout '5m' pod --all -n sample-app-namespace
 
       # Emit remote service pod IP

--- a/terraform/python/k8s/deploy/main.tf
+++ b/terraform/python/k8s/deploy/main.tf
@@ -85,6 +85,7 @@ resource "null_resource" "deploy" {
       kubectl patch service python-sample-app-deployment-${var.test_id} -n python-sample-app-namespace --type='json' --patch='[{"op": "replace", "path": "/spec/ports/0/nodePort", "value":30100}]'
 
       echo "Wait for sample app to be reach ready state"
+      sleep 10
       kubectl wait --for=condition=Ready --request-timeout '10m' pod --all -n python-sample-app-namespace
 
       # Emit remote service pod IP


### PR DESCRIPTION
***DESCRIPTION***
Causes this type of failure: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9729611686/job/26851705795

This is because the patch command right before deletes the pods and the wait command in the line below does not wait for the pods to exist and immediately fails since they do not come up quickly enough sometimes. Pods should not take 10s to come up, so this should fix the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
