### PR TITLE
[Python] Add ec2-requirements.txt for otel version upgrade

### DIFF
--- a/sample-apps/python/django_frontend_service/ec2-requirements.txt
+++ b/sample-apps/python/django_frontend_service/ec2-requirements.txt
@@ -1,0 +1,5 @@
+Django~=4.2.9
+requests~=2.31.0
+boto3~=1.34.3
+schedule~=1.2.1
+python-dotenv~=1.0.1


### PR DESCRIPTION
*Issue description:*
ADOT Python version is doing an OTEL version upgrade to 1.25 that conflicts with this E2E test ONLY for EC2. OTEL version 1.22 is currently being used by the sample app to get the trace ID of the span sent by the instrumentation for the validator to validate the generated trace.

As such, we will:
1. Create a new ec2-requirements.txt file (this PR)
    1. Note: Only frontend service uses the OTEL 1.22 dependency, remote service does not depend on OTEL at all 
3. Update the S3 bucket that holds the sample app files in a ZIP for the EC2 test.
    1. Note: we will NOT be updating the EKS test in the same way, it is unimpacted
4. Update the Python EC2 tests to use the new requirements file when it is deployed

*Description of changes:*
- Create a new ec2-requirements.txt file only for the EC2 use case

*Testing:*
No testing needed, file that is being added is not used or deployed by anything

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
