### PR TITLE
Fix us west 1

### DIFF
--- a/.github/workflows/application-signals-java-e2e-ec2-asg-test.yml
+++ b/.github/workflows/application-signals-java-e2e-ec2-asg-test.yml
@@ -23,8 +23,8 @@ env:
   # The presence of this env var is required for use by terraform and AWS CLI commands
   # It is not redundant
   TEST_ACCOUNT: ${{ secrets.APP_SIGNALS_E2E_TEST_ACC }}
-  SAMPLE_APP_FRONTEND_SERVICE_JAR: s3://${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ inputs.aws-region }}/main-service.jar
-  SAMPLE_APP_REMOTE_SERVICE_JAR: s3://${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ inputs.aws-region }}/remote-service.jar
+  SAMPLE_APP_FRONTEND_SERVICE_JAR: s3://${{ inputs.aws-region == 'us-west-1' && secrets.APP_SIGNALS_E2E_EC2_JAR_US_WEST_1 || secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ inputs.aws-region }}/main-service.jar
+  SAMPLE_APP_REMOTE_SERVICE_JAR: s3://${{ inputs.aws-region == 'us-west-1' && secrets.APP_SIGNALS_E2E_EC2_JAR_US_WEST_1 || secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ inputs.aws-region }}/remote-service.jar
   APP_SIGNALS_ADOT_JAR: "https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar"
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: /aws/application-signals/data

--- a/.github/workflows/application-signals-java-e2e-ec2-default-test.yml
+++ b/.github/workflows/application-signals-java-e2e-ec2-default-test.yml
@@ -18,13 +18,12 @@ on:
 permissions:
   id-token: write
   contents: read
-
 env:
   # The presence of this env var is required for use by terraform and AWS CLI commands
   # It is not redundant
   TEST_ACCOUNT: ${{ secrets.APP_SIGNALS_E2E_TEST_ACC }}
-  SAMPLE_APP_FRONTEND_SERVICE_JAR: s3://${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ inputs.aws-region }}/main-service.jar
-  SAMPLE_APP_REMOTE_SERVICE_JAR: s3://${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ inputs.aws-region }}/remote-service.jar
+  SAMPLE_APP_FRONTEND_SERVICE_JAR: s3://${{ inputs.aws-region == 'us-west-1' && secrets.APP_SIGNALS_E2E_EC2_JAR_US_WEST_1 || secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ inputs.aws-region }}/main-service.jar
+  SAMPLE_APP_REMOTE_SERVICE_JAR: s3://${{ inputs.aws-region == 'us-west-1' && secrets.APP_SIGNALS_E2E_EC2_JAR_US_WEST_1 || secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ inputs.aws-region }}/remote-service.jar
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: /aws/application-signals/data
   GET_ADOT_JAR_COMMAND: "wget -O adot.jar https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar"

--- a/.github/workflows/application-signals-python-e2e-ec2-asg-test.yml
+++ b/.github/workflows/application-signals-python-e2e-ec2-asg-test.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 
 env:
-  SAMPLE_APP_ZIP: s3://${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ inputs.aws-region }}/python-sample-app.zip
+  SAMPLE_APP_ZIP: s3://${{ inputs.aws-region == 'us-west-1' && secrets.APP_SIGNALS_E2E_EC2_JAR_US_WEST_1 || secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ inputs.aws-region }}/python-sample-app.zip
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: /aws/application-signals/data
   ADOT_WHEEL_NAME: ${{ inputs.staging_wheel_name }}

--- a/.github/workflows/application-signals-python-e2e-ec2-default-test.yml
+++ b/.github/workflows/application-signals-python-e2e-ec2-default-test.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 
 env:
-  SAMPLE_APP_ZIP: s3://${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ inputs.aws-region }}/python-sample-app.zip
+  SAMPLE_APP_ZIP: s3://${{ inputs.aws-region == 'us-west-1' && secrets.APP_SIGNALS_E2E_EC2_JAR_US_WEST_1 || secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ inputs.aws-region }}/python-sample-app.zip
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: /aws/application-signals/data
   ADOT_WHEEL_NAME: ${{ inputs.staging_wheel_name }}

--- a/.github/workflows/django-sample-app-s3-deploy.yml
+++ b/.github/workflows/django-sample-app-s3-deploy.yml
@@ -50,5 +50,5 @@ jobs:
 
       - name: Upload to S3
         working-directory: sample-apps/python
-        run: aws s3api put-object --bucket ${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ matrix.aws-region }} --body ./python-sample-app.zip --key python-sample-app.zip
+        run: aws s3api put-object --bucket ${{ inputs.aws-region == 'us-west-1' && secrets.APP_SIGNALS_E2E_EC2_JAR_US_WEST_1 || secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ matrix.aws-region }} --body ./python-sample-app.zip --key python-sample-app.zip
 

--- a/.github/workflows/springboot-sample-app-s3-deploy.yml
+++ b/.github/workflows/springboot-sample-app-s3-deploy.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Upload to S3
         working-directory: sample-apps/springboot
-        run: aws s3api put-object --bucket ${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ matrix.aws-region }} --body ./build/libs/springboot-*-SNAPSHOT.jar --key main-service.jar
+        run: aws s3api put-object --bucket ${{ inputs.aws-region == 'us-west-1' && secrets.APP_SIGNALS_E2E_EC2_JAR_US_WEST_1 || secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ matrix.aws-region }} --body ./build/libs/springboot-*-SNAPSHOT.jar --key main-service.jar
 
   upload-remote-service-jar:
     strategy:
@@ -88,5 +88,5 @@ jobs:
 
       - name: Upload to S3
         working-directory: sample-apps/springboot-remote-service
-        run: aws s3api put-object --bucket ${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ matrix.aws-region }} --body build/libs/springboot-remote-service-*-SNAPSHOT.jar --key remote-service.jar
+        run: aws s3api put-object --bucket ${{ inputs.aws-region == 'us-west-1' && secrets.APP_SIGNALS_E2E_EC2_JAR_US_WEST_1 || secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ matrix.aws-region }} --body build/libs/springboot-remote-service-*-SNAPSHOT.jar --key remote-service.jar
 


### PR DESCRIPTION
*Issue description:*
us-west-1 account migration is blocked because s3 bucket names are global, and the required name is already being used by the old account. Updating us-west-1 s3 bucket to point to a temporary one until the migration is complete. Should take around 45 minutes after this PR is merged. Will revert his PR after.

*Description of changes:*
Adding logic to point to new secret if workflow is running in us-west-1

Test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9883595825

*Ensure you've run the following tests on your changes and include the link below:*
To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
