### PR TITLE
Consolidate release for K8s

### DIFF
--- a/.github/workflows/java-k8s-e2e-canary-test.yml
+++ b/.github/workflows/java-k8s-e2e-canary-test.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 jobs:
-  e2e-test:
+  k8s:
     uses: ./.github/workflows/java-k8s-e2e-test.yml
     secrets: inherit
     with:

--- a/.github/workflows/java-k8s-e2e-canary-test.yml
+++ b/.github/workflows/java-k8s-e2e-canary-test.yml
@@ -1,10 +1,12 @@
 ## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 ## SPDX-License-Identifier: Apache-2.0
 
+## This workflow aims to run the Application Signals end-to-end tests as a canary to
+## test the artifacts for App Signals enablement. It will deploy the CloudWatch Agent
 ## Operator and our sample app and remote service onto a native K8s cluster, call the
 ## APIs, and validate the generated telemetry, including logs, metrics, and traces.
 ## It will then clean up the cluster and EC2 instance it runs on for the next test run.
-name: Application Signals Enablement - Python E2E K8s Canary Testing
+name: Java K8s E2E Canary Testing
 on:
   schedule:
     - cron: '*/15 * * * *' # run the workflow every 15 minutes
@@ -15,10 +17,10 @@ permissions:
   contents: read
 
 jobs:
-  e2e-k8s-test:
-    uses: ./.github/workflows/application-signals-python-e2e-k8s-test.yml
+  e2e-test:
+    uses: ./.github/workflows/java-k8s-e2e-test.yml
     secrets: inherit
     with:
       # To run in more regions, a cluster must be provisioned manually on EC2 instances in that region
       aws-region: 'us-east-1'
-      caller-workflow-name: 'appsignals-e2e-python-k8s-canary-test'
+      caller-workflow-name: 'appsignals-e2e-k8s-canary-test'

--- a/.github/workflows/java-k8s-e2e-test.yml
+++ b/.github/workflows/java-k8s-e2e-test.yml
@@ -21,9 +21,9 @@ on:
         required: false
         type: string
 
-#concurrency:
-#  group: '${{ github.workflow }} @ ${{ inputs.aws-region }}'
-#  cancel-in-progress: false
+concurrency:
+  group: '${{ github.workflow }} @ ${{ inputs.aws-region }}'
+  cancel-in-progress: false
 
 permissions:
   id-token: write
@@ -63,7 +63,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew"
+          command: "./gradlew :validator:build"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60
@@ -84,14 +84,6 @@ jobs:
             RELEASE_TESTING_ECR_ACCOUNT, e2e-test/${{ github.event.repository.name }}/java-k8s-release-testing-account
             MAIN_SERVICE_ENDPOINT, e2e-test/${{ github.event.repository.name }}/java-k8s-master-node-endpoint
             MASTER_NODE_SSH_KEY, e2e-test/${{ github.event.repository.name }}/java-k8s-ssh-key
-
-      # If the workflow is running as a canary, then we want to log in to the aws account in the appropriate region
-      - name: Configure AWS Credentials
-        if: ${{ github.event.repository.name == 'aws-application-signals-test-framework' }}
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
-          aws-region: ${{ env.E2E_TEST_AWS_REGION }}
 
       - name: Prepare and upload sample app deployment files
         working-directory: terraform/java/k8s/deploy/resources
@@ -167,7 +159,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew"
+          command: "./gradlew :validator:build"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60

--- a/.github/workflows/java-k8s-e2e-test.yml
+++ b/.github/workflows/java-k8s-e2e-test.yml
@@ -4,7 +4,7 @@
 # This is a reusable workflow for running the E2E test for App Signals.
 # It is meant to be called from another workflow.
 # Read more about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview
-name: Application Signals Enablement E2E Testing - Python K8s
+name: Java K8s on EC2 Use Case
 on:
   workflow_call:
     inputs:
@@ -14,98 +14,128 @@ on:
       caller-workflow-name:
         required: true
         type: string
+      adot-image-name:
+        required: false
+        type: string
+      cw-agent-operator-tag:
+        required: false
+        type: string
 
-concurrency:
-  group: '${{ github.workflow }} @ ${{ inputs.aws-region }}'
-  cancel-in-progress: false
+#concurrency:
+#  group: '${{ github.workflow }} @ ${{ inputs.aws-region }}'
+#  cancel-in-progress: false
 
 permissions:
   id-token: write
   contents: read
 
 env:
-  # The presence of this env var is required for use by terraform and AWS CLI commands
-  # It is not redundant
-  AWS_DEFAULT_REGION: ${{ inputs.aws-region }}
-  TEST_ACCOUNT: ${{ secrets.APP_SIGNALS_E2E_TEST_ACC }}
+  E2E_TEST_AWS_REGION: ${{ inputs.aws-region }}
+  CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
+  ADOT_IMAGE_NAME: ${{ inputs.adot-image-name }}
+  CW_AGENT_OPERATOR_TAG: ${{ inputs.cw-agent-operator-tag }}
+  E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
+  E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
+  SAMPLE_APP_NAMESPACE: sample-app-namespace
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: /aws/application-signals/data
-  MASTER_NODE_SSH_KEY: ${{ secrets.APP_SIGNALS_E2E_K8S_PYTHON_SSH_KEY_IAD }}
-  MAIN_SERVICE_ENDPOINT: ${{ secrets.APP_SIGNALS_E2E_PYTHON_K8S_GA_MASTER_NODE_ENDPOINT }}
-  SAMPLE_APP_NAMESPACE: python-sample-app-namespace
-  TEST_RESOURCES_FOLDER: /__w/aws-application-signals-test-framework/aws-application-signals-test-framework
+  TEST_RESOURCES_FOLDER: ${GITHUB_WORKSPACE}
 
 jobs:
-  e2e-k8s-test:
+  java-k8s:
     runs-on: ubuntu-latest
     container:
       image: public.ecr.aws/h6o3z5z9/aws-application-signals-test-framework-workflow-container:latest
     steps:
+      - name: Generate testing id
+        run: echo TESTING_ID="${{ env.E2E_TEST_AWS_REGION }}-${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
+
       - uses: actions/checkout@v4
         with:
+          repository: 'aws-observability/aws-application-signals-test-framework'
+          ref: ${{ env.CALLER_WORKFLOW_NAME == 'main-build' && 'main' || github.ref }}
           fetch-depth: 0
 
+        # We initialize Gradlew Daemon early on during the workflow because sometimes initialization
+        # fails due to transient issues. If it fails here, then we will try again later before the validators
       - name: Initiate Gradlew Daemon
         id: initiate-gradlew
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew :validator:build"
+          command: "./gradlew"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60
 
-      - name: Generate testing id
-        run: echo TESTING_ID="${{ env.AWS_DEFAULT_REGION }}-${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.E2E_IAD_TEST_ACCOUNT_ARN }}
+          role-to-assume: arn:aws:iam::${{ env.E2E_TEST_ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
           aws-region: us-east-1
 
       - name: Retrieve account
         uses: aws-actions/aws-secretsmanager-get-secrets@v1
         with:
-          secret-ids:
-            ACCOUNT_ID, region-account/${{ env.AWS_DEFAULT_REGION }}
+          secret-ids: |
+            ACCOUNT_ID, region-account/${{ env.E2E_TEST_AWS_REGION }}
+            JAVA_MAIN_SAMPLE_APP_IMAGE, e2e-test/java-main-sample-app-image
+            JAVA_REMOTE_SAMPLE_APP_IMAGE, e2e-test/java-remote-sample-app-image
+            RELEASE_TESTING_ECR_ACCOUNT, e2e-test/${{ github.event.repository.name }}/java-k8s-release-testing-account
+            MAIN_SERVICE_ENDPOINT, e2e-test/${{ github.event.repository.name }}/java-k8s-master-node-endpoint
+            MASTER_NODE_SSH_KEY, e2e-test/${{ github.event.repository.name }}/java-k8s-ssh-key
 
+      # If the workflow is running as a canary, then we want to log in to the aws account in the appropriate region
       - name: Configure AWS Credentials
+        if: ${{ github.event.repository.name == 'aws-application-signals-test-framework' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ secrets.E2E_TEST_ROLE_ARN }}
-          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
+          aws-region: ${{ env.E2E_TEST_AWS_REGION }}
 
       - name: Prepare and upload sample app deployment files
-        working-directory: terraform/python/k8s/deploy/resources
+        working-directory: terraform/java/k8s/deploy/resources
         run: |
-          sed -i 's#\${TESTING_ID}#${{ env.TESTING_ID }}#' python-frontend-service-depl.yaml
-          sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_DEFAULT_REGION }}.amazonaws.com/${{ secrets.APP_SIGNALS_PYTHON_E2E_FE_SA_IMG }}#' python-frontend-service-depl.yaml
-          sed -i 's#\${TESTING_ID}#${{ env.TESTING_ID }}#' python-remote-service-depl.yaml
-          sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_DEFAULT_REGION }}.amazonaws.com/${{ secrets.APP_SIGNALS_PYTHON_E2E_RE_SA_IMG }}#' python-remote-service-depl.yaml
-          aws s3api put-object --bucket ${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ env.AWS_DEFAULT_REGION }} --key python-frontend-service-depl.yaml --body python-frontend-service-depl.yaml
-          aws s3api put-object --bucket ${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ env.AWS_DEFAULT_REGION }} --key python-remote-service-depl.yaml --body python-remote-service-depl.yaml
+          sed -i 's#\${TESTING_ID}#${{ env.TESTING_ID }}#' frontend-service-depl.yaml
+          sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.JAVA_MAIN_SAMPLE_APP_IMAGE }}#' frontend-service-depl.yaml
+          sed -i 's#\${TESTING_ID}#${{ env.TESTING_ID }}#' remote-service-depl.yaml
+          sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.JAVA_REMOTE_SAMPLE_APP_IMAGE }}#' remote-service-depl.yaml
+          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key frontend-service-depl-${{ github.event.repository.name }}.yaml --body frontend-service-depl.yaml
+          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key remote-service-depl-${{ github.event.repository.name }}.yaml --body remote-service-depl.yaml
 
       - name: Initiate Terraform
         uses: ./.github/workflows/actions/execute_and_retry
         with:
-          command: "cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/python/k8s/deploy && terraform init && terraform validate"
+          command: "cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/java/k8s/deploy && terraform init && terraform validate"
           cleanup: "rm -rf .terraform && rm -rf .terraform.lock.hcl"
           max_retry: 6
           sleep_time: 60
 
+      - name: Get ECR to Patch
+        run: |
+          if [ "${{ github.event.repository.name }}" = "amazon-cloudwatch-agent" ]; then
+            echo PATCH_IMAGE_ARN="${{ secrets.AWS_ECR_PRIVATE_REGISTRY }}/cwagent-integration-test:${{ github.sha }}" >> $GITHUB_ENV
+          elif [ "${{ github.event.repository.name }}" = "amazon-cloudwatch-agent-operator" ]; then
+            echo PATCH_IMAGE_ARN="${{ vars.ECR_OPERATOR_STAGING_REPO }}:${{ env.CW_AGENT_OPERATOR_TAG }}" >> $GITHUB_ENV
+          elif [ "${{ github.event.repository.name }}" = "aws-otel-java-instrumentation" ]; then
+            echo PATCH_IMAGE_ARN="${{ env.ADOT_IMAGE_NAME }}" >> $GITHUB_ENV
+          fi
+
       - name: Deploy Operator and Sample App using Terraform
-        working-directory: terraform/python/k8s/deploy
+        working-directory: terraform/java/k8s/deploy
         run: |
           terraform apply -auto-approve \
-            -var="aws_region=${{ env.AWS_DEFAULT_REGION }}" \
+            -var="aws_region=${{ env.E2E_TEST_AWS_REGION }}" \
             -var="test_id=${{ env.TESTING_ID }}" \
             -var="ssh_key=${{ env.MASTER_NODE_SSH_KEY }}" \
-            -var="host=${{ env.MAIN_SERVICE_ENDPOINT }}"
+            -var="host=${{ env.MAIN_SERVICE_ENDPOINT }}" \
+            -var="repository=${{ github.event.repository.name }}" \
+            -var="patch_image_arn=${{ env.PATCH_IMAGE_ARN }}" \
+            -var="release_testing_ecr_account=${{ env.RELEASE_TESTING_ECR_ACCOUNT }}"
 
       - name: Get Remote Service IP
         run: |
-          echo REMOTE_SERVICE_IP="$(aws ssm get-parameter --region ${{ env.AWS_DEFAULT_REGION }} --name python-remote-service-ip | jq -r '.Parameter.Value')" >> $GITHUB_ENV
+          echo REMOTE_SERVICE_IP="$(aws ssm get-parameter --region ${{ env.E2E_TEST_AWS_REGION }} --name remote-service-ip-${{ env.TESTING_ID }} | jq -r '.Parameter.Value')" >> $GITHUB_ENV
 
       - name: Wait for app endpoint to come online
         id: endpoint-check
@@ -122,7 +152,6 @@ jobs:
             attempt_counter=$(($attempt_counter+1))
             sleep 10
           done
-
       # This steps increases the speed of the validation by creating the telemetry data in advance
       # It is run after the gradle build to give the app time to initialize after the pods become ready
       - name: Call all test APIs
@@ -138,7 +167,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew :validator:build"
+          command: "./gradlew"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60
@@ -146,53 +175,53 @@ jobs:
       # Validation for pulse telemetry data
       - name: Validate generated EMF logs
         id: log-validation
-        run: ./gradlew validator:run --args='-c python/k8s/log-validation.yml
+        run: ./gradlew validator:run --args='-c java/k8s/log-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100
-          --region ${{ env.AWS_DEFAULT_REGION }}
+          --region ${{ env.E2E_TEST_AWS_REGION }}
           --account-id ${{ env.ACCOUNT_ID }}
           --metric-namespace ${{ env.METRIC_NAMESPACE }}
           --log-group ${{ env.LOG_GROUP_NAME }}
           --platform-info k8s-cluster-${{ env.TESTING_ID }}
           --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
-          --service-name python-sample-application-${{ env.TESTING_ID }}
-          --remote-service-name python-sample-r-app-deployment-${{ env.TESTING_ID }}
+          --service-name sample-application-${{ env.TESTING_ID }}
+          --remote-service-name sample-r-app-deployment-${{ env.TESTING_ID }}
           --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
       - name: Validate generated metrics
         id: metric-validation
         if: (success() || steps.log-validation.outcome == 'failure') && !cancelled()
-        run: ./gradlew validator:run --args='-c python/k8s/metric-validation.yml
+        run: ./gradlew validator:run --args='-c java/k8s/metric-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100
-          --region ${{ env.AWS_DEFAULT_REGION }}
+          --region ${{ env.E2E_TEST_AWS_REGION }}
           --account-id ${{ env.ACCOUNT_ID }}
           --metric-namespace ${{ env.METRIC_NAMESPACE }}
           --log-group ${{ env.LOG_GROUP_NAME }}
           --platform-info k8s-cluster-${{ env.TESTING_ID }}
           --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
-          --service-name python-sample-application-${{ env.TESTING_ID }}
-          --remote-service-name python-sample-r-app-deployment-${{ env.TESTING_ID }}
-          --remote-service-deployment-name python-sample-r-app-deployment-${{ env.TESTING_ID }}
+          --service-name sample-application-${{ env.TESTING_ID }}
+          --remote-service-name sample-r-app-deployment-${{ env.TESTING_ID }}
+          --remote-service-deployment-name sample-r-app-deployment-${{ env.TESTING_ID }}
           --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
       - name: Validate generated traces
         id: trace-validation
         if: (success() || steps.log-validation.outcome == 'failure' || steps.metric-validation.outcome == 'failure') && !cancelled()
-        run: ./gradlew validator:run --args='-c python/k8s/trace-validation.yml
+        run: ./gradlew validator:run --args='-c java/k8s/trace-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100
-          --region ${{ env.AWS_DEFAULT_REGION }}
+          --region ${{ env.E2E_TEST_AWS_REGION }}
           --account-id ${{ env.ACCOUNT_ID }}
           --metric-namespace ${{ env.METRIC_NAMESPACE }}
           --log-group ${{ env.LOG_GROUP_NAME }}
           --platform-info k8s-cluster-${{ env.TESTING_ID }}
           --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
-          --service-name python-sample-application-${{ env.TESTING_ID }}
-          --remote-service-name python-sample-r-app-deployment-${{ env.TESTING_ID }}
-          --remote-service-deployment-name python-sample-r-app-deployment-${{ env.TESTING_ID }}
+          --service-name sample-application-${{ env.TESTING_ID }}
+          --remote-service-name sample-r-app-deployment-${{ env.TESTING_ID }}
+          --remote-service-deployment-name sample-r-app-deployment-${{ env.TESTING_ID }}
           --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
@@ -202,15 +231,15 @@ jobs:
           if [ "${{ steps.log-validation.outcome }}" = "success" ] && [ "${{ steps.metric-validation.outcome }}" = "success" ] && [ "${{ steps.trace-validation.outcome }}" = "success" ]; then
             aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
             --metric-name Failure \
-            --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=${{ inputs.caller-workflow-name }} \
+            --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=${{ env.CALLER_WORKFLOW_NAME }} \
             --value 0.0 \
-            --region ${{ env.AWS_DEFAULT_REGION }}
+            --region ${{ env.E2E_TEST_AWS_REGION }}
           else
             aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
             --metric-name Failure \
-            --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=${{ inputs.caller-workflow-name }} \
+            --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=${{ env.CALLER_WORKFLOW_NAME }} \
             --value 1.0 \
-            --region ${{ env.AWS_DEFAULT_REGION }}
+            --region ${{ env.E2E_TEST_AWS_REGION }}
           fi
 
       # Clean up Procedures
@@ -218,15 +247,15 @@ jobs:
         if: always()
         uses: ./.github/workflows/actions/execute_and_retry
         with:
-          command: "cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/python/k8s/cleanup && terraform init && terraform validate"
+          command: "cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/java/k8s/cleanup && terraform init && terraform validate"
           cleanup: "rm -rf .terraform && rm -rf .terraform.lock.hcl"
 
       - name: Clean Up Operator and Sample App using Terraform
         if: always()
-        working-directory: terraform/python/k8s/cleanup
+        working-directory: terraform/java/k8s/cleanup
         run: |
           terraform apply -auto-approve \
-            -var="aws_region=${{ env.AWS_DEFAULT_REGION }}" \
+            -var="aws_region=${{ env.E2E_TEST_AWS_REGION }}" \
             -var="test_id=${{ env.TESTING_ID }}" \
             -var="ssh_key=${{ env.MASTER_NODE_SSH_KEY }}" \
             -var="host=${{ env.MAIN_SERVICE_ENDPOINT }}"
@@ -234,7 +263,7 @@ jobs:
       - name: Terraform destroy - deployment
         if: always()
         continue-on-error: true
-        working-directory: terraform/python/k8s/deploy
+        working-directory: terraform/java/k8s/deploy
         run: |
           terraform destroy -auto-approve \
             -var="test_id=${{ env.TESTING_ID }}"
@@ -242,7 +271,7 @@ jobs:
       - name: Terraform destroy - cleanup
         if: always()
         continue-on-error: true
-        working-directory: terraform/python/k8s/cleanup
+        working-directory: terraform/java/k8s/cleanup
         run: |
           terraform destroy -auto-approve \
             -var="test_id=${{ env.TESTING_ID }}"

--- a/.github/workflows/python-k8s-e2e-canary-test.yml
+++ b/.github/workflows/python-k8s-e2e-canary-test.yml
@@ -1,12 +1,10 @@
 ## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 ## SPDX-License-Identifier: Apache-2.0
 
-## This workflow aims to run the Application Signals end-to-end tests as a canary to
-## test the artifacts for App Signals enablement. It will deploy the CloudWatch Agent
 ## Operator and our sample app and remote service onto a native K8s cluster, call the
 ## APIs, and validate the generated telemetry, including logs, metrics, and traces.
 ## It will then clean up the cluster and EC2 instance it runs on for the next test run.
-name: Application Signals Enablement - Java E2E K8s Canary Testing
+name: Python K8s E2E Canary Testing
 on:
   schedule:
     - cron: '*/15 * * * *' # run the workflow every 15 minutes
@@ -17,10 +15,10 @@ permissions:
   contents: read
 
 jobs:
-  e2e-k8s-test:
-    uses: ./.github/workflows/application-signals-java-e2e-k8s-test.yml
+  e2e-test:
+    uses: ./.github/workflows/python-k8s-e2e-test.yml
     secrets: inherit
     with:
       # To run in more regions, a cluster must be provisioned manually on EC2 instances in that region
       aws-region: 'us-east-1'
-      caller-workflow-name: 'appsignals-e2e-k8s-canary-test'
+      caller-workflow-name: 'appsignals-e2e-python-k8s-canary-test'

--- a/.github/workflows/python-k8s-e2e-canary-test.yml
+++ b/.github/workflows/python-k8s-e2e-canary-test.yml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 jobs:
-  e2e-test:
+  k8s:
     uses: ./.github/workflows/python-k8s-e2e-test.yml
     secrets: inherit
     with:

--- a/.github/workflows/python-k8s-e2e-test.yml
+++ b/.github/workflows/python-k8s-e2e-test.yml
@@ -4,7 +4,7 @@
 # This is a reusable workflow for running the E2E test for App Signals.
 # It is meant to be called from another workflow.
 # Read more about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview
-name: Application Signals Enablement E2E Testing - Java E2E K8s on EC2 Use Case
+name: Python K8s on EC2 Use Case
 on:
   workflow_call:
     inputs:
@@ -14,97 +14,128 @@ on:
       caller-workflow-name:
         required: true
         type: string
+      adot-image-name:
+        required: false
+        type: string
+      cw-agent-operator-tag:
+        required: false
+        type: string
 
-concurrency:
-  group: '${{ github.workflow }} @ ${{ inputs.aws-region }}'
-  cancel-in-progress: false
+#concurrency:
+#  group: '${{ github.workflow }} @ ${{ inputs.aws-region }}'
+#  cancel-in-progress: false
 
 permissions:
   id-token: write
   contents: read
 
 env:
-  # The presence of this env var is required for use by terraform and AWS CLI commands
-  # It is not redundant
-  TEST_ACCOUNT: ${{ secrets.APP_SIGNALS_E2E_TEST_ACC }}
+  E2E_TEST_AWS_REGION: ${{ inputs.aws-region }}
+  CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
+  ADOT_IMAGE_NAME: ${{ inputs.adot-image-name }}
+  CW_AGENT_OPERATOR_TAG: ${{ inputs.cw-agent-operator-tag }}
+  E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
+  E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
+  SAMPLE_APP_NAMESPACE: python-sample-app-namespace
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: /aws/application-signals/data
-  MASTER_NODE_SSH_KEY: ${{ secrets.APP_SIGNALS_E2E_K8S_SSH_KEY_IAD }}
-  MAIN_SERVICE_ENDPOINT: ${{ secrets.APP_SIGNALS_E2E_K8S_MASTER_NODE_ENDPOINT }}
-  SAMPLE_APP_NAMESPACE: sample-app-namespace
-  TEST_RESOURCES_FOLDER: /__w/aws-application-signals-test-framework/aws-application-signals-test-framework
+  TEST_RESOURCES_FOLDER: ${GITHUB_WORKSPACE}
 
 jobs:
-  e2e-k8s-test:
+  python-k8s:
     runs-on: ubuntu-latest
     container:
       image: public.ecr.aws/h6o3z5z9/aws-application-signals-test-framework-workflow-container:latest
     steps:
+      - name: Generate testing id
+        run: echo TESTING_ID="${{ env.E2E_TEST_AWS_REGION }}-${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
+
       - uses: actions/checkout@v4
         with:
+          repository: 'aws-observability/aws-application-signals-test-framework'
+          ref: ${{ env.CALLER_WORKFLOW_NAME == 'main-build' && 'main' || github.ref }}
           fetch-depth: 0
 
+        # We initialize Gradlew Daemon early on during the workflow because sometimes initialization
+        # fails due to transient issues. If it fails here, then we will try again later before the validators
       - name: Initiate Gradlew Daemon
         id: initiate-gradlew
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew :validator:build"
+          command: "./gradlew"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60
 
-      - name: Generate testing id
-        run: echo TESTING_ID="${{ inputs.aws-region }}-${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
-
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.E2E_IAD_TEST_ACCOUNT_ARN }}
+          role-to-assume: arn:aws:iam::${{ env.E2E_TEST_ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
           aws-region: us-east-1
 
       - name: Retrieve account
         uses: aws-actions/aws-secretsmanager-get-secrets@v1
         with:
-          secret-ids:
-            ACCOUNT_ID, region-account/${{ inputs.aws-region }}
+          secret-ids: |
+            ACCOUNT_ID, region-account/${{ env.E2E_TEST_AWS_REGION }}
+            PYTHON_MAIN_SAMPLE_APP_IMAGE, e2e-test/python-main-sample-app-image
+            PYTHON_REMOTE_SAMPLE_APP_IMAGE, e2e-test/python-remote-sample-app-image
+            RELEASE_TESTING_ECR_ACCOUNT, e2e-test/${{ github.event.repository.name }}/python-k8s-release-testing-account
+            MAIN_SERVICE_ENDPOINT, e2e-test/${{ github.event.repository.name }}/python-k8s-master-node-endpoint
+            MASTER_NODE_SSH_KEY, e2e-test/${{ github.event.repository.name }}/python-k8s-ssh-key
 
+      # If the workflow is running as a canary, then we want to log in to the aws account in the appropriate region
       - name: Configure AWS Credentials
+        if: ${{ github.event.repository.name == 'aws-application-signals-test-framework' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ secrets.E2E_TEST_ROLE_ARN }}
-          aws-region: ${{ inputs.aws-region }}
+          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
+          aws-region: ${{ env.E2E_TEST_AWS_REGION }}
 
       - name: Prepare and upload sample app deployment files
-        working-directory: terraform/java/k8s/deploy/resources
+        working-directory: terraform/python/k8s/deploy/resources
         run: |
-          sed -i 's#\${TESTING_ID}#${{ env.TESTING_ID }}#' frontend-service-depl.yaml
-          sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ inputs.aws-region }}.amazonaws.com/${{ secrets.APP_SIGNALS_E2E_FE_SA_IMG }}#' frontend-service-depl.yaml
-          sed -i 's#\${TESTING_ID}#${{ env.TESTING_ID }}#' remote-service-depl.yaml
-          sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ inputs.aws-region }}.amazonaws.com/${{ secrets.APP_SIGNALS_E2E_RE_SA_IMG }}#' remote-service-depl.yaml
-          aws s3api put-object --bucket ${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ inputs.aws-region }} --key frontend-service-depl.yaml --body frontend-service-depl.yaml
-          aws s3api put-object --bucket ${{ secrets.APP_SIGNALS_E2E_EC2_JAR }}-prod-${{ inputs.aws-region }} --key remote-service-depl.yaml --body remote-service-depl.yaml
+          sed -i 's#\${TESTING_ID}#${{ env.TESTING_ID }}#' python-frontend-service-depl.yaml
+          sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.PYTHON_MAIN_SAMPLE_APP_IMAGE }}#' python-frontend-service-depl.yaml
+          sed -i 's#\${TESTING_ID}#${{ env.TESTING_ID }}#' python-remote-service-depl.yaml
+          sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.PYTHON_REMOTE_SAMPLE_APP_IMAGE }}#' python-remote-service-depl.yaml
+          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key python-frontend-service-depl-${{ github.event.repository.name }}.yaml --body python-frontend-service-depl.yaml
+          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key python-remote-service-depl-${{ github.event.repository.name }}.yaml --body python-remote-service-depl.yaml
 
       - name: Initiate Terraform
         uses: ./.github/workflows/actions/execute_and_retry
         with:
-          command: "cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/java/k8s/deploy && terraform init && terraform validate"
+          command: "cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/python/k8s/deploy && terraform init && terraform validate"
           cleanup: "rm -rf .terraform && rm -rf .terraform.lock.hcl"
           max_retry: 6
           sleep_time: 60
 
+      - name: Get ECR to Patch
+        run: |
+          if [ "${{ github.event.repository.name }}" = "amazon-cloudwatch-agent" ]; then
+            echo PATCH_IMAGE_ARN="${{ secrets.AWS_ECR_PRIVATE_REGISTRY }}/cwagent-integration-test:${{ github.sha }}" >> $GITHUB_ENV
+          elif [ "${{ github.event.repository.name }}" = "amazon-cloudwatch-agent-operator" ]; then
+            echo PATCH_IMAGE_ARN="${{ vars.ECR_OPERATOR_STAGING_REPO }}:${{ env.CW_AGENT_OPERATOR_TAG }}" >> $GITHUB_ENV
+          elif [ "${{ github.event.repository.name }}" = "aws-otel-python-instrumentation" ]; then
+            echo PATCH_IMAGE_ARN="${{ env.ADOT_IMAGE_NAME }}" >> $GITHUB_ENV
+          fi
+
       - name: Deploy Operator and Sample App using Terraform
-        working-directory: terraform/java/k8s/deploy
+        working-directory: terraform/python/k8s/deploy
         run: |
           terraform apply -auto-approve \
-            -var="aws_region=${{ inputs.aws-region }}" \
+            -var="aws_region=${{ env.E2E_TEST_AWS_REGION }}" \
             -var="test_id=${{ env.TESTING_ID }}" \
             -var="ssh_key=${{ env.MASTER_NODE_SSH_KEY }}" \
-            -var="host=${{ env.MAIN_SERVICE_ENDPOINT }}"
+            -var="host=${{ env.MAIN_SERVICE_ENDPOINT }}" \
+            -var="repository=${{ github.event.repository.name }}" \
+            -var="patch_image_arn=${{ env.PATCH_IMAGE_ARN }}" \
+            -var="release_testing_ecr_account=${{ env.RELEASE_TESTING_ECR_ACCOUNT }}"
 
       - name: Get Remote Service IP
         run: |
-          echo REMOTE_SERVICE_IP="$(aws ssm get-parameter --region ${{ inputs.aws-region }} --name remote-service-ip | jq -r '.Parameter.Value')" >> $GITHUB_ENV
+          echo REMOTE_SERVICE_IP="$(aws ssm get-parameter --region us-east-1 --name python-remote-service-ip-${{ env.TESTING_ID }} | jq -r '.Parameter.Value')" >> $GITHUB_ENV
 
       - name: Wait for app endpoint to come online
         id: endpoint-check
@@ -121,6 +152,7 @@ jobs:
             attempt_counter=$(($attempt_counter+1))
             sleep 10
           done
+
       # This steps increases the speed of the validation by creating the telemetry data in advance
       # It is run after the gradle build to give the app time to initialize after the pods become ready
       - name: Call all test APIs
@@ -136,7 +168,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew :validator:build"
+          command: "./gradlew"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60
@@ -144,53 +176,53 @@ jobs:
       # Validation for pulse telemetry data
       - name: Validate generated EMF logs
         id: log-validation
-        run: ./gradlew validator:run --args='-c java/k8s/log-validation.yml
+        run: ./gradlew validator:run --args='-c python/k8s/log-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100
-          --region ${{ inputs.aws-region }}
+          --region ${{ env.E2E_TEST_AWS_REGION }}
           --account-id ${{ env.ACCOUNT_ID }}
           --metric-namespace ${{ env.METRIC_NAMESPACE }}
           --log-group ${{ env.LOG_GROUP_NAME }}
           --platform-info k8s-cluster-${{ env.TESTING_ID }}
           --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
-          --service-name sample-application-${{ env.TESTING_ID }}
-          --remote-service-name sample-r-app-deployment-${{ env.TESTING_ID }}
+          --service-name python-sample-application-${{ env.TESTING_ID }}
+          --remote-service-name python-sample-r-app-deployment-${{ env.TESTING_ID }}
           --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
       - name: Validate generated metrics
         id: metric-validation
         if: (success() || steps.log-validation.outcome == 'failure') && !cancelled()
-        run: ./gradlew validator:run --args='-c java/k8s/metric-validation.yml
+        run: ./gradlew validator:run --args='-c python/k8s/metric-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100
-          --region ${{ inputs.aws-region }}
+          --region ${{ env.E2E_TEST_AWS_REGION }}
           --account-id ${{ env.ACCOUNT_ID }}
           --metric-namespace ${{ env.METRIC_NAMESPACE }}
           --log-group ${{ env.LOG_GROUP_NAME }}
           --platform-info k8s-cluster-${{ env.TESTING_ID }}
           --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
-          --service-name sample-application-${{ env.TESTING_ID }}
-          --remote-service-name sample-r-app-deployment-${{ env.TESTING_ID }}
-          --remote-service-deployment-name sample-r-app-deployment-${{ env.TESTING_ID }}
+          --service-name python-sample-application-${{ env.TESTING_ID }}
+          --remote-service-name python-sample-r-app-deployment-${{ env.TESTING_ID }}
+          --remote-service-deployment-name python-sample-r-app-deployment-${{ env.TESTING_ID }}
           --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
       - name: Validate generated traces
         id: trace-validation
         if: (success() || steps.log-validation.outcome == 'failure' || steps.metric-validation.outcome == 'failure') && !cancelled()
-        run: ./gradlew validator:run --args='-c java/k8s/trace-validation.yml
+        run: ./gradlew validator:run --args='-c python/k8s/trace-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}:30100
-          --region ${{ inputs.aws-region }}
+          --region ${{ env.E2E_TEST_AWS_REGION }}
           --account-id ${{ env.ACCOUNT_ID }}
           --metric-namespace ${{ env.METRIC_NAMESPACE }}
           --log-group ${{ env.LOG_GROUP_NAME }}
           --platform-info k8s-cluster-${{ env.TESTING_ID }}
           --app-namespace ${{ env.SAMPLE_APP_NAMESPACE }}
-          --service-name sample-application-${{ env.TESTING_ID }}
-          --remote-service-name sample-r-app-deployment-${{ env.TESTING_ID }}
-          --remote-service-deployment-name sample-r-app-deployment-${{ env.TESTING_ID }}
+          --service-name python-sample-application-${{ env.TESTING_ID }}
+          --remote-service-name python-sample-r-app-deployment-${{ env.TESTING_ID }}
+          --remote-service-deployment-name python-sample-r-app-deployment-${{ env.TESTING_ID }}
           --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
@@ -200,15 +232,15 @@ jobs:
           if [ "${{ steps.log-validation.outcome }}" = "success" ] && [ "${{ steps.metric-validation.outcome }}" = "success" ] && [ "${{ steps.trace-validation.outcome }}" = "success" ]; then
             aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
             --metric-name Failure \
-            --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=${{ inputs.caller-workflow-name }} \
+            --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=${{ env.CALLER_WORKFLOW_NAME }} \
             --value 0.0 \
-            --region ${{ inputs.aws-region }}
+            --region ${{ env.E2E_TEST_AWS_REGION }}
           else
             aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
             --metric-name Failure \
-            --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=${{ inputs.caller-workflow-name }} \
+            --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=${{ env.CALLER_WORKFLOW_NAME }} \
             --value 1.0 \
-            --region ${{ inputs.aws-region }}
+            --region ${{ env.E2E_TEST_AWS_REGION }}
           fi
 
       # Clean up Procedures
@@ -216,15 +248,15 @@ jobs:
         if: always()
         uses: ./.github/workflows/actions/execute_and_retry
         with:
-          command: "cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/java/k8s/cleanup && terraform init && terraform validate"
+          command: "cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/python/k8s/cleanup && terraform init && terraform validate"
           cleanup: "rm -rf .terraform && rm -rf .terraform.lock.hcl"
 
       - name: Clean Up Operator and Sample App using Terraform
         if: always()
-        working-directory: terraform/java/k8s/cleanup
+        working-directory: terraform/python/k8s/cleanup
         run: |
           terraform apply -auto-approve \
-            -var="aws_region=${{ inputs.aws-region }}" \
+            -var="aws_region=${{ env.E2E_TEST_AWS_REGION }}" \
             -var="test_id=${{ env.TESTING_ID }}" \
             -var="ssh_key=${{ env.MASTER_NODE_SSH_KEY }}" \
             -var="host=${{ env.MAIN_SERVICE_ENDPOINT }}"
@@ -232,7 +264,7 @@ jobs:
       - name: Terraform destroy - deployment
         if: always()
         continue-on-error: true
-        working-directory: terraform/java/k8s/deploy
+        working-directory: terraform/python/k8s/deploy
         run: |
           terraform destroy -auto-approve \
             -var="test_id=${{ env.TESTING_ID }}"
@@ -240,7 +272,7 @@ jobs:
       - name: Terraform destroy - cleanup
         if: always()
         continue-on-error: true
-        working-directory: terraform/java/k8s/cleanup
+        working-directory: terraform/python/k8s/cleanup
         run: |
           terraform destroy -auto-approve \
             -var="test_id=${{ env.TESTING_ID }}"

--- a/.github/workflows/python-k8s-e2e-test.yml
+++ b/.github/workflows/python-k8s-e2e-test.yml
@@ -21,9 +21,9 @@ on:
         required: false
         type: string
 
-#concurrency:
-#  group: '${{ github.workflow }} @ ${{ inputs.aws-region }}'
-#  cancel-in-progress: false
+concurrency:
+  group: '${{ github.workflow }} @ ${{ inputs.aws-region }}'
+  cancel-in-progress: false
 
 permissions:
   id-token: write
@@ -63,7 +63,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew"
+          command: "./gradlew :validator:build"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60
@@ -84,14 +84,6 @@ jobs:
             RELEASE_TESTING_ECR_ACCOUNT, e2e-test/${{ github.event.repository.name }}/python-k8s-release-testing-account
             MAIN_SERVICE_ENDPOINT, e2e-test/${{ github.event.repository.name }}/python-k8s-master-node-endpoint
             MASTER_NODE_SSH_KEY, e2e-test/${{ github.event.repository.name }}/python-k8s-ssh-key
-
-      # If the workflow is running as a canary, then we want to log in to the aws account in the appropriate region
-      - name: Configure AWS Credentials
-        if: ${{ github.event.repository.name == 'aws-application-signals-test-framework' }}
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
-          aws-region: ${{ env.E2E_TEST_AWS_REGION }}
 
       - name: Prepare and upload sample app deployment files
         working-directory: terraform/python/k8s/deploy/resources
@@ -168,7 +160,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         continue-on-error: true
         with:
-          command: "./gradlew"
+          command: "./gradlew :validator:build"
           cleanup: "./gradlew clean"
           max_retry: 3
           sleep_time: 60

--- a/terraform/java/k8s/cleanup/main.tf
+++ b/terraform/java/k8s/cleanup/main.tf
@@ -31,6 +31,9 @@ resource "null_resource" "cleanup" {
       # Print cluster state when done clean up procedures
       echo "LOG: Printing cluster state after cleanup"
       kubectl get pods -A
+
+      # Delete ssm parameter for remote service ip
+      aws ssm delete-parameter --name remote-service-ip-${var.test_id}
       EOF
     ]
   }

--- a/terraform/java/k8s/deploy/main.tf
+++ b/terraform/java/k8s/deploy/main.tf
@@ -49,6 +49,48 @@ resource "null_resource" "deploy" {
       kubectl wait --for=condition=Ready pods --all --selector=app.kubernetes.io/name=amazon-cloudwatch-observability -n amazon-cloudwatch --timeout=60s
       kubectl wait --for=condition=Ready pods --all --selector=app.kubernetes.io/name=cloudwatch-agent -n amazon-cloudwatch --timeout=60s
 
+      if [ "${var.repository}" = "amazon-cloudwatch-agent" ]; then
+        RELEASE_TESTING_SECRET_NAME=release-testing-ecr-secret
+        RELEASE_TESTING_TOKEN=`aws ecr --region=us-west-2 get-authorization-token --output text --query authorizationData[].authorizationToken | base64 -d | cut -d: -f2`
+        kubectl delete secret -n amazon-cloudwatch --ignore-not-found $RELEASE_TESTING_SECRET_NAME
+        kubectl create secret -n amazon-cloudwatch docker-registry $RELEASE_TESTING_SECRET_NAME \
+          --docker-server=https://${var.release_testing_ecr_account}.dkr.ecr.us-west-2.amazonaws.com \
+          --docker-username=AWS \
+          --docker-password="$${RELEASE_TESTING_TOKEN}"
+
+        kubectl patch serviceaccount cloudwatch-agent -n amazon-cloudwatch -p='{"imagePullSecrets": [{"name": "release-testing-ecr-secret"}]}'
+        kubectl delete pods --all -n amazon-cloudwatch
+      elif [ "${var.repository}" = "amazon-cloudwatch-agent-operator" ]; then
+        RELEASE_TESTING_SECRET_NAME=release-testing-ecr-secret
+        RELEASE_TESTING_TOKEN=`aws ecr --region=us-west-2 get-authorization-token --output text --query authorizationData[].authorizationToken | base64 -d | cut -d: -f2`
+        kubectl delete secret -n amazon-cloudwatch --ignore-not-found $RELEASE_TESTING_SECRET_NAME
+        kubectl create secret -n amazon-cloudwatch docker-registry $RELEASE_TESTING_SECRET_NAME \
+          --docker-server=https://${var.release_testing_ecr_account}.dkr.ecr.us-west-2.amazonaws.com \
+          --docker-username=AWS \
+          --docker-password="$${RELEASE_TESTING_TOKEN}"
+
+        kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' -p='[{"op": "add", "path": "/spec/template/spec/imagePullSecrets", "value": [{"name": "release-testing-ecr-secret"}]}]'
+        kubectl delete pods --all -n amazon-cloudwatch
+      fi
+
+      if [ "${var.repository}" = "amazon-cloudwatch-agent-operator" ]; then
+        kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' -p '[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "${var.patch_image_arn}"}, {"op": "replace", "path": "/spec/template/spec/containers/0/imagePullPolicy", "value": "Always"}]]'
+        kubectl delete pods --all -n amazon-cloudwatch
+        sleep 10
+        kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
+      elif [ "${var.repository}" = "amazon-cloudwatch-agent" ]; then
+        kubectl patch amazoncloudwatchagents -n amazon-cloudwatch cloudwatch-agent --type='json' -p='[{"op": "replace", "path": "/spec/image", "value": ${var.patch_image_arn}}]'
+        kubectl delete pods --all -n amazon-cloudwatch
+        sleep 10
+        kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
+      elif [ "${var.repository}" = "aws-otel-java-instrumentation" ]; then
+        kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' \
+        -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/0", "value": "--auto-instrumentation-java-image=${var.patch_image_arn}"}]'
+        kubectl delete pods --all -n amazon-cloudwatch
+        sleep 10
+        kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
+      fi
+
       # Create sample app namespace
       echo "LOG: Creating sample app namespace"
       kubectl create namespace sample-app-namespace
@@ -72,8 +114,22 @@ resource "null_resource" "deploy" {
 
       # cd to ensure everything is downloaded into root directory so cleanup is each
       cd ~
-      aws s3api get-object --bucket aws-appsignals-sample-app-prod-us-east-1 --key frontend-service-depl.yaml frontend-service-depl.yaml
-      aws s3api get-object --bucket aws-appsignals-sample-app-prod-us-east-1 --key remote-service-depl.yaml remote-service-depl.yaml
+      aws s3api get-object --bucket aws-appsignals-sample-app-prod-us-east-1 --key frontend-service-depl-${var.repository}.yaml frontend-service-depl.yaml
+      aws s3api get-object --bucket aws-appsignals-sample-app-prod-us-east-1 --key remote-service-depl-${var.repository}.yaml remote-service-depl.yaml
+
+      # Patch the staging image if this is running as part of release testing
+      if [ "${var.repository}" = "aws-otel-java-instrumentation" ]; then
+        RELEASE_TESTING_SECRET_NAME=release-testing-ecr-secret
+        kubectl delete secret -n sample-app-namespace --ignore-not-found $RELEASE_TESTING_SECRET_NAME
+        kubectl create secret -n sample-app-namespace docker-registry $RELEASE_TESTING_SECRET_NAME \
+          --docker-server=https://${var.release_testing_ecr_account}.dkr.ecr.us-east-1.amazonaws.com \
+          --docker-username=AWS \
+          --docker-password="$${TOKEN}"
+
+        yq eval '.spec.template.spec.imagePullSecrets += [{"name": "release-testing-ecr-secret"}]' -i frontend-service-depl.yaml
+        yq eval '.spec.template.spec.imagePullSecrets += [{"name": "release-testing-ecr-secret"}]' -i remote-service-depl.yaml
+      fi
+
       echo "LOG: Applying sample app deployment files"
       kubectl apply -f frontend-service-depl.yaml
       kubectl apply -f remote-service-depl.yaml
@@ -89,7 +145,7 @@ resource "null_resource" "deploy" {
 
       # Emit remote service pod IP
       echo "LOG: Outputting remote service pod IP to SSM using put-parameter API"
-      aws ssm put-parameter --region ${var.aws_region} --name remote-service-ip --type String --overwrite --value $(kubectl get pod --selector=app=remote-app -n sample-app-namespace -o jsonpath='{.items[0].status.podIP}')
+      aws ssm put-parameter --region ${var.aws_region} --name remote-service-ip-${var.test_id} --type String --overwrite --value $(kubectl get pod --selector=app=remote-app -n sample-app-namespace -o jsonpath='{.items[0].status.podIP}')
 
       EOF
     ]

--- a/terraform/java/k8s/deploy/variables.tf
+++ b/terraform/java/k8s/deploy/variables.tf
@@ -34,3 +34,16 @@ variable "host" {
   default = "<HOST_IP_OR_DNS>"
   description = "This variable is responsible for defining which host (ec2 instance) we connect to for the K8s-on-EC2 test"
 }
+
+variable "repository" {
+  default = "aws-application-signals-test-framework"
+}
+
+variable "patch_image_arn" {
+  default = "<arn-address>"
+}
+
+variable "release_testing_ecr_account" {
+  default = "<aws-account-id>"
+  description = "This variable is to give the k8s cluster ecr secret to pull image from the staging image ecr"
+}

--- a/terraform/python/k8s/cleanup/main.tf
+++ b/terraform/python/k8s/cleanup/main.tf
@@ -45,6 +45,10 @@ resource "null_resource" "cleanup" {
       # Print cluster state when done clean up procedures
       echo "LOG: Printing cluster state after cleanup"
       kubectl get pods -A
+
+      # Delete ssm parameter for remote service ip
+      aws ssm delete-parameter --name python-remote-service-ip-${var.test_id}
+
       EOF
     ]
   }

--- a/terraform/python/k8s/deploy/main.tf
+++ b/terraform/python/k8s/deploy/main.tf
@@ -49,6 +49,48 @@ resource "null_resource" "deploy" {
       kubectl wait --for=condition=Ready pods --all --selector=app.kubernetes.io/name=amazon-cloudwatch-observability -n amazon-cloudwatch --timeout=60s
       kubectl wait --for=condition=Ready pods --all --selector=app.kubernetes.io/name=cloudwatch-agent -n amazon-cloudwatch --timeout=60s
 
+      if [ "${var.repository}" = "amazon-cloudwatch-agent" ]; then
+        RELEASE_TESTING_SECRET_NAME=release-testing-ecr-secret
+        RELEASE_TESTING_TOKEN=`aws ecr --region=us-west-2 get-authorization-token --output text --query authorizationData[].authorizationToken | base64 -d | cut -d: -f2`
+        kubectl delete secret -n amazon-cloudwatch --ignore-not-found $RELEASE_TESTING_SECRET_NAME
+        kubectl create secret -n amazon-cloudwatch docker-registry $RELEASE_TESTING_SECRET_NAME \
+          --docker-server=https://${var.release_testing_ecr_account}.dkr.ecr.us-west-2.amazonaws.com \
+          --docker-username=AWS \
+          --docker-password="$${RELEASE_TESTING_TOKEN}"
+
+        kubectl patch serviceaccount cloudwatch-agent -n amazon-cloudwatch -p='{"imagePullSecrets": [{"name": "release-testing-ecr-secret"}]}'
+        kubectl delete pods --all -n amazon-cloudwatch
+      elif [ "${var.repository}" = "amazon-cloudwatch-agent-operator" ]; then
+        RELEASE_TESTING_SECRET_NAME=release-testing-ecr-secret
+        RELEASE_TESTING_TOKEN=`aws ecr --region=us-west-2 get-authorization-token --output text --query authorizationData[].authorizationToken | base64 -d | cut -d: -f2`
+        kubectl delete secret -n amazon-cloudwatch --ignore-not-found $RELEASE_TESTING_SECRET_NAME
+        kubectl create secret -n amazon-cloudwatch docker-registry $RELEASE_TESTING_SECRET_NAME \
+          --docker-server=https://${var.release_testing_ecr_account}.dkr.ecr.us-west-2.amazonaws.com \
+          --docker-username=AWS \
+          --docker-password="$${RELEASE_TESTING_TOKEN}"
+
+        kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' -p='[{"op": "add", "path": "/spec/template/spec/imagePullSecrets", "value": [{"name": "release-testing-ecr-secret"}]}]'
+        kubectl delete pods --all -n amazon-cloudwatch
+      fi
+
+      if [ "${var.repository}" = "amazon-cloudwatch-agent-operator" ]; then
+        kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' -p '[{"op": "replace", "path": "/spec/template/spec/containers/0/image", "value": "${var.patch_image_arn}"}, {"op": "replace", "path": "/spec/template/spec/containers/0/imagePullPolicy", "value": "Always"}]]'
+        kubectl delete pods --all -n amazon-cloudwatch
+        sleep 10
+        kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
+      elif [ "${var.repository}" = "amazon-cloudwatch-agent" ]; then
+        kubectl patch amazoncloudwatchagents -n amazon-cloudwatch cloudwatch-agent --type='json' -p='[{"op": "replace", "path": "/spec/image", "value": ${var.patch_image_arn}}]'
+        kubectl delete pods --all -n amazon-cloudwatch
+        sleep 10
+        kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
+      elif [ "${var.repository}" = "aws-otel-python-instrumentation" ]; then
+        kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' \
+        -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/2", "value": "--auto-instrumentation-python-image=${var.patch_image_arn}"}]'
+        kubectl delete pods --all -n amazon-cloudwatch
+        sleep 10
+        kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
+      fi
+
       # Create sample app namespace
       echo "LOG: Creating sample app namespace"
       kubectl create namespace python-sample-app-namespace
@@ -72,8 +114,21 @@ resource "null_resource" "deploy" {
       echo "LOG: Pulling sample app deployment files"
       # cd to ensure everything is downloaded into root directory so cleanup is each
       cd ~
-      aws s3api get-object --bucket aws-appsignals-sample-app-prod-us-east-1 --key python-frontend-service-depl.yaml python-frontend-service-depl.yaml
-      aws s3api get-object --bucket aws-appsignals-sample-app-prod-us-east-1 --key python-remote-service-depl.yaml python-remote-service-depl.yaml
+      aws s3api get-object --bucket aws-appsignals-sample-app-prod-us-east-1 --key python-frontend-service-depl-${var.repository}.yaml python-frontend-service-depl.yaml
+      aws s3api get-object --bucket aws-appsignals-sample-app-prod-us-east-1 --key python-remote-service-depl-${var.repository}.yaml python-remote-service-depl.yaml
+
+      # Patch the staging image if this is running as part of release testing
+      if [ "${var.repository}" = "aws-otel-python-instrumentation" ]; then
+        RELEASE_TESTING_SECRET_NAME=release-testing-ecr-secret
+        kubectl delete secret -n python-sample-app-namespace --ignore-not-found $RELEASE_TESTING_SECRET_NAME
+        kubectl create secret -n python-sample-app-namespace docker-registry $RELEASE_TESTING_SECRET_NAME \
+          --docker-server=https://${var.release_testing_ecr_account}.dkr.ecr.us-east-1.amazonaws.com \
+          --docker-username=AWS \
+          --docker-password="$${TOKEN}"
+
+        yq eval '.spec.template.spec.imagePullSecrets += [{"name": "release-testing-ecr-secret"}]' -i python-frontend-service-depl.yaml
+        yq eval '.spec.template.spec.imagePullSecrets += [{"name": "release-testing-ecr-secret"}]' -i python-remote-service-depl.yaml
+      fi
 
       echo "LOG: Applying sample app deployment files"
       kubectl apply -f python-frontend-service-depl.yaml
@@ -90,7 +145,7 @@ resource "null_resource" "deploy" {
 
       # Emit remote service pod IP
       echo "LOG: Outputting remote service pod IP to SSM using put-parameter API"
-      aws ssm put-parameter --region ${var.aws_region} --name python-remote-service-ip --type String --overwrite --value $(kubectl get pod --selector=app=python-remote-app -n python-sample-app-namespace -o jsonpath='{.items[0].status.podIP}')
+      aws ssm put-parameter --region ${var.aws_region} --name python-remote-service-ip-${var.test_id} --type String --overwrite --value $(kubectl get pod --selector=app=python-remote-app -n python-sample-app-namespace -o jsonpath='{.items[0].status.podIP}')
       EOF
     ]
   }

--- a/terraform/python/k8s/deploy/variables.tf
+++ b/terraform/python/k8s/deploy/variables.tf
@@ -34,3 +34,16 @@ variable "host" {
   default = "<HOST_IP_OR_DNS>"
   description = "This variable is responsible for defining which host (ec2 instance) we connect to for the K8s-on-EC2 test"
 }
+
+variable "repository" {
+  default = "aws-application-signals-test-framework"
+}
+
+variable "patch_image_arn" {
+  default = "<ecr-address>"
+}
+
+variable "release_testing_ecr_account" {
+  default = "<aws-account-id>"
+  description = "This variable is to give the k8s cluster ecr secret to pull image from the staging image ecr"
+}


### PR DESCRIPTION
*Issue description:*
Separating this [PR](https://github.com/aws-observability/aws-application-signals-test-framework/pull/109) into two to make it easier for review: 

Test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9963325687

*Ensure you've run the following tests on your changes and include the link below:*
To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
