### PR TITLE
Uncomment EC2 termination logic in cleanup workflow

### DIFF
--- a/.github/workflows/util/clean/ec2_instance_cleanup/cleaner.py
+++ b/.github/workflows/util/clean/ec2_instance_cleanup/cleaner.py
@@ -136,4 +136,4 @@ if __name__ == '__main__':
         logging.error("Failed to prepare report and upload. Aborting termination of instances.")
         exit(1)
 
-    # _terminate_instances(instances) # TODO: uncomment in the final PR
+    _terminate_instances(instances)


### PR DESCRIPTION
*Issue description:*
Verified that the workflow is filtering the right instances: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/9999408422

Moving on to terminate them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
