### PR TITLE
Downgrading mysql connector version to 8.0.33

### DIFF
--- a/sample-apps/springboot/build.gradle.kts
+++ b/sample-apps/springboot/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
   implementation("io.opentelemetry:opentelemetry-api:1.34.1")
   implementation("software.amazon.awssdk:s3")
   implementation("software.amazon.awssdk:sts")
-  implementation("com.mysql:mysql-connector-j:8.4.0")
+  implementation("com.mysql:mysql-connector-j:8.0.33")
 }
 
 jib {


### PR DESCRIPTION
*Issue description:*

**Personal Account (977252051917):**

- During the execution of the Java E2E workflow, additional metrics and logs were observed.
- Investigation revealed that these were related to an underlying SELECT query used to load SQL server variables.

<img width="791" alt="image" src="https://github.com/user-attachments/assets/d3e1536e-7129-4088-943b-7c4aeae24f4d">

**Babel Playground Account (590183964621):**

- Using the [CWBabelPlaygroundCDK](https://code.amazon.com/packages/CWBabelPlaygroundCDK/trees/mainline) package, no extra metrics or logs were found during similar testing in the Java E2E workflow.

<img width="791" alt="image" src="https://github.com/user-attachments/assets/2225c60d-fe83-4d18-b6e7-5c3646d03d7e">

**Python E2E Workflow:**

- Testing the Python E2E workflow in both personal and playground accounts did not reveal any extra metrics or logs.

<img width="791" alt="image" src="https://github.com/user-attachments/assets/d06c6ed4-60b9-4003-80df-dd098e4bc3c9">

<img width="800" alt="image" src="https://github.com/user-attachments/assets/9a788004-8e4c-4284-a515-c536e8fe7c83">

**Investigation and Resolution:**

**Root Cause Analysis:**
- The extra metrics and logs issue in the Java E2E workflow was traced back to the MySQL connector version 8.4.0.
- The underlying SELECT query used to load SQL server variables led to these additional metrics and logs because of the new feature in MySQL connector version 8.4.0 which adds more support for OpenTelemetry.

**Feature Description:**
- MySQL Connector/J 8.4.0 introduced enhanced support for OpenTelemetry, including the capability of propagating the context to the MySQL Server it connects to, allowing for more complete observability of the application stack. This enhancement is detailed in the [release notes](https://dev.mysql.com/doc/connector-j/en/connector-j-opentelemetry.html).
- The extra metrics and logs are not a bug but an intentional feature to provide better tracing and observability.

**Solution**
- As a temporary measure, downgrading the MySQL connector version to 8.0.33 removes the extra metrics and logs.
- For long-term solutions, leveraging the enhanced observability features or adjusting the logging to account for the new spans can be considered.

**Conclusion**
- The additional metrics and logs observed in the Java E2E workflow are due to an underlying SELECT query to load SQL server variables which is added as new OpenTelemetry support in MySQL Connector/J version 8.4.0.
- This feature improves tracing by propagating context to the database layer, resulting in extra metrics and logs.
- Temporarily downgrading to an earlier version (e.g., 8.0.33) mitigates this, but future adjustments should account for the improved observability features.

<img width="799" alt="image" src="https://github.com/user-attachments/assets/9d29f797-cf1e-4241-ba4b-c3b1ad0d29e7">

Workflow link (Tested in us-east-1 region) - https://github.com/ektabj/aws-application-signals-test-framework/actions/runs/10006911947/job/27660545353

*Description of changes:*
Downgrading mysql connector version to 8.0.33

For more details, refer:
- [Duplicate-EMF-Logs](https://quip-amazon.com/IUaOA2tfltO6/Duplicate-EMF-Logs)
- [Babel-EMF-Log-Review](https://quip-amazon.com/n7FPA6CGIb4z/Babel-EMF-Log-Review)

*Ensure you've run the following tests on your changes and include the link below:*
To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
