### PR TITLE
Force use 1.8.0

### DIFF
--- a/terraform/java/k8s/deploy/main.tf
+++ b/terraform/java/k8s/deploy/main.tf
@@ -40,6 +40,7 @@ resource "null_resource" "deploy" {
       git clone https://github.com/aws-observability/helm-charts -q
 
       cd helm-charts/charts/amazon-cloudwatch-observability/
+      git reset --hard e0e99c77f69ef388b0ffce769371f7c735a776e4
 
       echo "LOG: Installing CloudWatch Agent Operator using Helm"
       helm upgrade --install --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator ./ --create-namespace --set region=${var.aws_region} --set clusterName=k8s-cluster-${var.test_id}

--- a/terraform/python/k8s/deploy/main.tf
+++ b/terraform/python/k8s/deploy/main.tf
@@ -40,6 +40,7 @@ resource "null_resource" "deploy" {
       echo "LOG: Cloning helm charts repo"
       git clone https://github.com/aws-observability/helm-charts.git -q
       cd helm-charts/charts/amazon-cloudwatch-observability
+      git reset --hard e0e99c77f69ef388b0ffce769371f7c735a776e4
 
       echo "LOG: Installing CloudWatch Agent Operator using Helm"
       helm upgrade --install --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator ./ --create-namespace --set region=${var.aws_region} --set clusterName=k8s-cluster-${var.test_id}


### PR DESCRIPTION
*Issue description:*
Use released helm version to avoid canary failure.

Commit picked from https://github.com/aws-observability/helm-charts/pull/57.

Verified
```
amazon-cloudwatch-observability % pwd
/Users/zmengyi/go/src/github.com/aws-observability/helm-charts/charts/amazon-cloudwatch-observability
amazon-cloudwatch-observability % git reset --hard e0e99c77f69ef388b0ffce769371f7c735a776e4
HEAD is now at e0e99c7 release 1.8.0 (#57)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
