### PR TITLE
Adds E2E metric test for RDS database interactions for Python

### DIFF
--- a/.github/workflows/python-eks-e2e-test.yml
+++ b/.github/workflows/python-eks-e2e-test.yml
@@ -394,6 +394,7 @@ jobs:
           --platform-info ${{ env.CLUSTER_NAME }}
           --service-name python-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
+          --remote-resource-identifier "information_schema|${{env.RDS_MYSQL_CLUSTER_ENDPOINT}}|3306"
           --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 

--- a/.github/workflows/python-eks-e2e-test.yml
+++ b/.github/workflows/python-eks-e2e-test.yml
@@ -57,8 +57,8 @@ jobs:
           
       - uses: actions/checkout@v4
         with:
-          repository: 'aws-observability/aws-application-signals-test-framework'
-          ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
+          #repository: 'aws-observability/aws-application-signals-test-framework'
+          #ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
           fetch-depth: 0
 
         # We initialize Gradlew Daemon early on during the workflow because sometimes initialization

--- a/.github/workflows/python-eks-e2e-test.yml
+++ b/.github/workflows/python-eks-e2e-test.yml
@@ -378,6 +378,7 @@ jobs:
           --service-name python-application-${{ env.TESTING_ID }}
           --remote-service-name python-remote-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
+          --remote-resource-identifier "information_schema|${{env.RDS_MYSQL_CLUSTER_ENDPOINT}}|3306"
           --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 

--- a/.github/workflows/python-eks-e2e-test.yml
+++ b/.github/workflows/python-eks-e2e-test.yml
@@ -57,8 +57,8 @@ jobs:
           
       - uses: actions/checkout@v4
         with:
-          #repository: 'aws-observability/aws-application-signals-test-framework'
-          #ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
+          repository: 'aws-observability/aws-application-signals-test-framework'
+          ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
           fetch-depth: 0
 
         # We initialize Gradlew Daemon early on during the workflow because sometimes initialization

--- a/validator/src/main/java/com/amazon/aoc/App.java
+++ b/validator/src/main/java/com/amazon/aoc/App.java
@@ -75,6 +75,9 @@ public class App implements Callable<Integer> {
   @CommandLine.Option(names = {"--remote-service-deployment-name"})
   private String remoteServiceDeploymentName;
 
+  @CommandLine.Option(names = {"--remote-resource-identifier"})
+  private String remoteResourceIdentifier;
+
   @CommandLine.Option(names = {"--endpoint"})
   private String endpoint;
 
@@ -170,6 +173,7 @@ public class App implements Callable<Integer> {
     context.setServiceName(this.serviceName);
     context.setRemoteServiceName(this.remoteServiceName);
     context.setRemoteServiceDeploymentName(this.remoteServiceDeploymentName);
+    context.setRemoteResourceIdentifier(this.remoteResourceIdentifier);
     context.setEndpoint(this.endpoint);
     context.setQueryString(this.queryString);
     context.setLogGroup(this.logGroup);

--- a/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
+++ b/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
@@ -110,6 +110,8 @@ public enum PredefinedExpectedTemplate implements FileConfig {
   PYTHON_EKS_CLIENT_CALL_METRIC("/expected-data-template/python/eks/client-call-metric.mustache"),
   PYTHON_EKS_CLIENT_CALL_TRACE("/expected-data-template/python/eks/client-call-trace.mustache"),
 
+  PYTHON_EKS_RDS_MYSQL_TRACE("/expected-data-template/python/eks/rds-mysql-trace.mustache"),
+
   /** Python EC2 Default Test Case Validations */
   PYTHON_EC2_DEFAULT_OUTGOING_HTTP_CALL_LOG("/expected-data-template/python/ec2/default/outgoing-http-call-log.mustache"),
   PYTHON_EC2_DEFAULT_OUTGOING_HTTP_CALL_METRIC("/expected-data-template/python/ec2/default/outgoing-http-call-metric.mustache"),

--- a/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
+++ b/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
@@ -110,6 +110,7 @@ public enum PredefinedExpectedTemplate implements FileConfig {
   PYTHON_EKS_CLIENT_CALL_METRIC("/expected-data-template/python/eks/client-call-metric.mustache"),
   PYTHON_EKS_CLIENT_CALL_TRACE("/expected-data-template/python/eks/client-call-trace.mustache"),
 
+  PYTHON_EKS_RDS_MYSQL_METRIC("/expected-data-template/python/eks/rds-mysql-metric.mustache"),
   PYTHON_EKS_RDS_MYSQL_TRACE("/expected-data-template/python/eks/rds-mysql-trace.mustache"),
 
   /** Python EC2 Default Test Case Validations */

--- a/validator/src/main/java/com/amazon/aoc/models/Context.java
+++ b/validator/src/main/java/com/amazon/aoc/models/Context.java
@@ -49,6 +49,8 @@ public class Context {
 
   private String remoteServiceDeploymentName;
 
+  private String remoteResourceIdentifier;
+
   private String endpoint;
 
   private String queryString;

--- a/validator/src/main/resources/expected-data-template/python/eks/rds-mysql-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/python/eks/rds-mysql-metric.mustache
@@ -1,0 +1,434 @@
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /mysql
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /mysql
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteOperation
+      value: SELECT
+    -
+      name: RemoteService
+      value: mysql
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteService
+      value: mysql
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteOperation
+      value: SELECT
+    -
+      name: RemoteService
+      value: mysql
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteService
+      value: mysql
+    -
+      name: RemoteResourceType
+      value: DB::Connection
+    -
+      name: RemoteResourceIdentifier
+      value: {{remoteResourceIdentifier}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /mysql
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteOperation
+      value: SELECT
+    -
+      name: RemoteService
+      value: mysql
+    -
+      name: RemoteResourceType
+      value: DB::Connection
+    -
+      name: RemoteResourceIdentifier
+      value: {{remoteResourceIdentifier}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteOperation
+      value: SELECT
+    -
+      name: RemoteService
+      value: mysql
+    -
+      name: RemoteResourceType
+      value: DB::Connection
+    -
+      name: RemoteResourceIdentifier
+      value: {{remoteResourceIdentifier}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /mysql
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /mysql
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteOperation
+      value: SELECT
+    -
+      name: RemoteService
+      value: mysql
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteService
+      value: mysql
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteOperation
+      value: SELECT
+    -
+      name: RemoteService
+      value: mysql
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteService
+      value: mysql
+    -
+      name: RemoteResourceType
+      value: DB::Connection
+    -
+      name: RemoteResourceIdentifier
+      value: {{remoteResourceIdentifier}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /mysql
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteOperation
+      value: SELECT
+    -
+      name: RemoteService
+      value: mysql
+    -
+      name: RemoteResourceType
+      value: DB::Connection
+    -
+      name: RemoteResourceIdentifier
+      value: {{remoteResourceIdentifier}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteOperation
+      value: SELECT
+    -
+      name: RemoteService
+      value: mysql
+    -
+      name: RemoteResourceType
+      value: DB::Connection
+    -
+      name: RemoteResourceIdentifier
+      value: {{remoteResourceIdentifier}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /mysql
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /mysql
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteOperation
+      value: SELECT
+    -
+      name: RemoteService
+      value: mysql
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteService
+      value: mysql
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteOperation
+      value: SELECT
+    -
+      name: RemoteService
+      value: mysql
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteService
+      value: mysql
+    -
+      name: RemoteResourceType
+      value: DB::Connection
+    -
+      name: RemoteResourceIdentifier
+      value: {{remoteResourceIdentifier}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /mysql
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteOperation
+      value: SELECT
+    -
+      name: RemoteService
+      value: mysql
+    -
+      name: RemoteResourceType
+      value: DB::Connection
+    -
+      name: RemoteResourceIdentifier
+      value: {{remoteResourceIdentifier}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteOperation
+      value: SELECT
+    -
+      name: RemoteService
+      value: mysql
+    -
+      name: RemoteResourceType
+      value: DB::Connection
+    -
+      name: RemoteResourceIdentifier
+      value: {{remoteResourceIdentifier}}

--- a/validator/src/main/resources/expected-data-template/python/eks/rds-mysql-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/python/eks/rds-mysql-metric.mustache
@@ -4,7 +4,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /mysql
+      value: GET mysql
     -
       name: Service
       value: {{serviceName}}
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /mysql
+      value: GET mysql
     -
       name: Service
       value: {{serviceName}}
@@ -100,7 +100,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /mysql
+      value: GET mysql
     -
       name: Service
       value: {{serviceName}}
@@ -149,7 +149,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /mysql
+      value: GET mysql
     -
       name: Service
       value: {{serviceName}}
@@ -163,7 +163,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /mysql
+      value: GET mysql
     -
       name: Service
       value: {{serviceName}}
@@ -245,7 +245,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /mysql
+      value: GET mysql
     -
       name: Service
       value: {{serviceName}}
@@ -294,7 +294,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /mysql
+      value: GET mysql
     -
       name: Service
       value: {{serviceName}}
@@ -308,7 +308,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /mysql
+      value: GET mysql
     -
       name: Service
       value: {{serviceName}}
@@ -390,7 +390,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /mysql
+      value: GET mysql
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/python/eks/rds-mysql-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/python/eks/rds-mysql-trace.mustache
@@ -1,0 +1,94 @@
+[
+  {
+    "name": "^{{serviceName}}$",
+    "origin": "^AWS::EKS::Container$",
+    "subsegments": [
+      {
+        "name": "^mysql$",
+        "namespace": "^remote$",
+        "aws": {
+          "account_id": "^{{accountId}}$",
+          "xray": {
+            "auto_instrumentation": true,
+            "sdk": "^opentelemetry for python$"
+          }
+        },
+        "sql": {
+          "connection_string": "^localhost/information_schema$",
+          "url": "^SELECT$",
+          "sanitized_query": "^SELECT \\* FROM tables LIMIT 1;$",
+          "database_type": "^mysql$"
+        },
+        "metadata": {
+          "default": {
+            "aws.span.kind": "^CLIENT$",
+            "EKS.Cluster": "^e2e-python-canary-test$",
+            "PlatformType": "^AWS::EKS$"
+          }
+        },
+        "annotations": {
+          "aws.local.service": "^{{serviceName}}$",
+          "aws.local.operation": "^GET mysql$",
+          "aws.remote.resource.type": "^DB::Connection$",
+          "aws.remote.resource.identifier": "^{{remoteResourceIdentifier}}$",
+          "aws.remote.service": "^mysql$",
+          "aws.remote.operation": "^SELECT$"
+        }
+      }
+    ],
+    "http": {
+      "request": {
+        "url": "^{{endpoint}}/mysql$",
+        "method": "^GET$"
+      },
+      "response": {
+        "status": 200
+      }
+    },
+    "aws": {
+      "account_id": "^{{accountId}}$",
+      "xray": {
+        "auto_instrumentation": true,
+        "sdk": "^opentelemetry for python$"
+      }
+    },
+    "metadata": {
+      "default": {
+        "otel.resource.aws.log.group.names": "^/aws/containerinsights/e2e-python-canary-test/application$",
+        "otel.resource.service.name": "^{{serviceName}}$",
+        "aws.span.kind": "^LOCAL_ROOT$",
+        "otel.resource.cloud.platform": "^aws_eks$",
+        "EKS.Cluster": "^e2e-python-canary-test$",
+        "otel.resource.telemetry.sdk.name": "^opentelemetry$",
+        "otel.resource.ec2.tag.kubernetes.io/cluster/e2e-python-canary-test": "^owned$",
+        "otel.resource.k8s.container.name": "^back-end$",
+        "otel.resource.cloud.account.id": "^{{accountId}}$",
+        "http.route": "^mysql$",
+        "PlatformType": "^AWS::EKS$",
+        "otel.resource.telemetry.sdk.language": "^python$",
+        "otel.resource.cloud.provider": "^aws$"
+      }
+    },
+    "annotations": {
+      "aws.local.service": "^{{serviceName}}$",
+      "aws.local.operation": "^GET mysql$"
+    }
+  },
+  {
+    "name": "^mysql$",
+    "origin": "^Database::SQL$",
+    "inferred": true,
+    "sql": {
+      "connection_string": "^localhost/information_schema$",
+      "url": "^SELECT$",
+      "sanitized_query": "^SELECT \\* FROM tables LIMIT 1;$",
+      "database_type": "^mysql$"
+    },
+    "annotations": {
+      "aws.local.service": "^mysql$",
+      "aws.local.operation": "^SELECT$",
+      "aws.local.resource.identifier": "^{{remoteResourceIdentifier}}$",
+      "aws.local.resource.type": "^DB::Connection$"
+    }
+  }
+]

--- a/validator/src/main/resources/validations/python/eks/metric-validation.yml
+++ b/validator/src/main/resources/validations/python/eks/metric-validation.yml
@@ -22,3 +22,9 @@
   httpMethod: "get"
   callingType: "http"
   expectedMetricTemplate: "PYTHON_EKS_CLIENT_CALL_METRIC"
+-
+  validationType: "cw-metric"
+  httpPath: "/mysql"
+  httpMethod: "get"
+  callingType: "http"
+  expectedMetricTemplate: "PYTHON_EKS_RDS_MYSQL_METRIC"

--- a/validator/src/main/resources/validations/python/eks/trace-validation.yml
+++ b/validator/src/main/resources/validations/python/eks/trace-validation.yml
@@ -22,3 +22,9 @@
   httpMethod: "get"
   callingType: "http"
   expectedTraceTemplate: "PYTHON_EKS_CLIENT_CALL_TRACE"
+-
+  validationType: "trace"
+  httpPath: "/mysql"
+  httpMethod: "get"
+  callingType: "http"
+  expectedTraceTemplate: "PYTHON_EKS_RDS_MYSQL_TRACE"


### PR DESCRIPTION
*Issue description:* This commit adds a metrics test for the RDS database interactions for the Python programming language.

*Description of changes:* We are validating the metrics returned against a template to the end-to-end test to ensure we detect any regressions, similarly as we are doing for Java in [this PR](https://github.com/aws-observability/aws-application-signals-test-framework/pull/102). Please notice that this PR is building on top of the changes from [this other PR](https://github.com/aws-observability/aws-application-signals-test-framework/pull/128).

This change was tested in [this fork](https://github.com/georgeboc/aws-application-signals-test-framework/actions/runs/10076471510/job/27856923330).

*Ensure you've run the following tests on your changes and include the link below:*
To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
