### PR TITLE
fix: Make RDS information retrieval in E2E workflow works for CloudWatch Agent repo

### DIFF
--- a/.github/workflows/java-eks-e2e-test.yml
+++ b/.github/workflows/java-eks-e2e-test.yml
@@ -141,9 +141,9 @@ jobs:
         continue-on-error: true
         run: |
           if [ "${{ github.event.repository.name }}" = "amazon-cloudwatch-agent" ]; then
-          RDS_MYSQL_CLUSTER_IDENTIFIER="RdsAuroraCWAgentOperatorE2EClusterForMySQL"
+          RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroracwagentoperatore2eclusterformysql"
           elif [ "${{ github.event.repository.name }}" = "aws-application-signals-test-framework" ]; then
-          RDS_MYSQL_CLUSTER_IDENTIFIER="RdsAuroraJavaClusterForMySQL"
+          RDS_MYSQL_CLUSTER_IDENTIFIER="rdsaurorajavaclusterformysql"
           fi
           RDS_MYSQL_CLUSTER_ENDPOINT=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier $RDS_MYSQL_CLUSTER_IDENTIFIER --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].Endpoint" --output text)
           echo RDS_MYSQL_CLUSTER_ENDPOINT="$RDS_MYSQL_CLUSTER_ENDPOINT" >> $GITHUB_ENV

--- a/.github/workflows/java-eks-e2e-test.yml
+++ b/.github/workflows/java-eks-e2e-test.yml
@@ -140,9 +140,13 @@ jobs:
       - name: Get RDS database cluster metadata
         continue-on-error: true
         run: |
-          RDS_MYSQL_CLUSTER_ENDPOINT=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier "rdsaurorajavaclusterformysql" --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].Endpoint" --output text)
+          if [ "${{ github.event.repository.name }}" = "amazon-cloudwatch-agent" ]; then
+          RDS_MYSQL_CLUSTER_IDENTIFIER="RdsAuroraCWAgentOperatorE2EClusterForMySQL"
+          elif [ "${{ github.event.repository.name }}" = "aws-application-signals-test-framework" ]; then
+          RDS_MYSQL_CLUSTER_IDENTIFIER="RdsAuroraJavaClusterForMySQL"
+          fi
+          RDS_MYSQL_CLUSTER_ENDPOINT=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier $RDS_MYSQL_CLUSTER_IDENTIFIER --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].Endpoint" --output text)
           echo RDS_MYSQL_CLUSTER_ENDPOINT="$RDS_MYSQL_CLUSTER_ENDPOINT" >> $GITHUB_ENV
-          RDS_MYSQL_CLUSTER_IDENTIFIER=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier "rdsaurorajavaclusterformysql" --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].DBClusterIdentifier" --output text)
           RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME=$(aws secretsmanager list-secrets --region ${{inputs.aws-region}} --query "SecretList[?Tags[?Value=='arn:aws:rds:${{inputs.aws-region}}:${{env.ACCOUNT_ID}}:cluster:$RDS_MYSQL_CLUSTER_IDENTIFIER']].Name" --output text)
           echo RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME="$RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME" >> $GITHUB_ENV
 


### PR DESCRIPTION
*Issue description:*

The E2E workflow is also used in other repos like CloudWatch Agent as part of the release workflow. Due to the hard-coded RDS cluster name, the workflow executed in Agent release EKS cluster won't be able to access RDS cluster in E2E test VPC.

*Description of changes:*

We have created RDS cluster for different purpose. So this PR introduces a condition for Agent repo to retrieve RDS information for the right cluster.

This has been tested with E2E test workflow, we need help from Application Signals to try it in the Agent repo.
Test run: https://github.com/jerry-shao/aws-application-signals-test-framework/actions/runs/10100238412/job/27931130127

*Ensure you've run the following tests on your changes and include the link below:*
To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
