### PR TITLE
Adds step to get RDS DB Cluster Identifier per each cluster

### DIFF
--- a/.github/workflows/java-eks-e2e-test.yml
+++ b/.github/workflows/java-eks-e2e-test.yml
@@ -137,12 +137,28 @@ jobs:
           --region ${{ env.E2E_TEST_AWS_REGION }}"
           sleep_time: 60
 
+      - name: Get RDS DB Cluster Identifier
+        run: |
+          if [ "${{ env.CLUSTER_NAME }}" = "e2e-enablement-script-test" ]; then
+            echo DB_CLUSTER_IDENTIFIER="rdsauroraenablementscriptpythone2eclusterformysql" >> $GITHUB_ENV
+          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-cw-agent-test" ]; then
+            echo DB_CLUSTER_IDENTIFIER="rdsauroracwagente2eclusterformysql" >> $GITHUB_ENV
+          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-adot-test" ]; then
+            echo DB_CLUSTER_IDENTIFIER="rdsauroraadote2eclusterformysql" >> $GITHUB_ENV
+          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-cw-agent-operator-test" ]; then
+            echo DB_CLUSTER_IDENTIFIER="rdsauroracwagentoperatore2eclusterformysql" >> $GITHUB_ENV
+          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-canary-test" ]; then
+            echo DB_CLUSTER_IDENTIFIER="rdsaurorajavaclusterformysql" >> $GITHUB_ENV
+          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-playground" ]; then
+            echo DB_CLUSTER_IDENTIFIER="rdsauroraplaygroundclusterformysql" >> $GITHUB_ENV
+          fi
+
       - name: Get RDS database cluster metadata
         continue-on-error: true
         run: |
-          RDS_MYSQL_CLUSTER_ENDPOINT=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier "rdsaurorajavaclusterformysql" --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].Endpoint" --output text)
+          RDS_MYSQL_CLUSTER_ENDPOINT=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier $DB_CLUSTER_IDENTIFIER --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].Endpoint" --output text)
           echo RDS_MYSQL_CLUSTER_ENDPOINT="$RDS_MYSQL_CLUSTER_ENDPOINT" >> $GITHUB_ENV
-          RDS_MYSQL_CLUSTER_IDENTIFIER=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier "rdsaurorajavaclusterformysql" --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].DBClusterIdentifier" --output text)
+          RDS_MYSQL_CLUSTER_IDENTIFIER=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier $DB_CLUSTER_IDENTIFIER --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].DBClusterIdentifier" --output text)
           RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME=$(aws secretsmanager list-secrets --region ${{inputs.aws-region}} --query "SecretList[?Tags[?Value=='arn:aws:rds:${{inputs.aws-region}}:${{env.ACCOUNT_ID}}:cluster:$RDS_MYSQL_CLUSTER_IDENTIFIER']].Name" --output text)
           echo RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME="$RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME" >> $GITHUB_ENV
 

--- a/.github/workflows/java-eks-e2e-test.yml
+++ b/.github/workflows/java-eks-e2e-test.yml
@@ -152,6 +152,9 @@ jobs:
             RDS_MYSQL_CLUSTER_IDENTIFIER="rdsaurorajavaclusterformysql"
           elif [ "${{ env.CLUSTER_NAME }}" = "e2e-playground" ]; then
             RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroraplaygroundclusterformysql"
+          else
+            echo "${{ env.CLUSTER_NAME }} is not a known cluster name"
+            exit 1
           fi
           RDS_MYSQL_CLUSTER_ENDPOINT=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier $RDS_MYSQL_CLUSTER_IDENTIFIER --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].Endpoint" --output text)
           echo RDS_MYSQL_CLUSTER_ENDPOINT="$RDS_MYSQL_CLUSTER_ENDPOINT" >> $GITHUB_ENV

--- a/.github/workflows/java-eks-e2e-test.yml
+++ b/.github/workflows/java-eks-e2e-test.yml
@@ -137,28 +137,24 @@ jobs:
           --region ${{ env.E2E_TEST_AWS_REGION }}"
           sleep_time: 60
 
-      - name: Get RDS DB Cluster Identifier
-        run: |
-          if [ "${{ env.CLUSTER_NAME }}" = "e2e-enablement-script-test" ]; then
-            echo DB_CLUSTER_IDENTIFIER="rdsauroraenablementscriptpythone2eclusterformysql" >> $GITHUB_ENV
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-cw-agent-test" ]; then
-            echo DB_CLUSTER_IDENTIFIER="rdsauroracwagente2eclusterformysql" >> $GITHUB_ENV
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-adot-test" ]; then
-            echo DB_CLUSTER_IDENTIFIER="rdsauroraadote2eclusterformysql" >> $GITHUB_ENV
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-cw-agent-operator-test" ]; then
-            echo DB_CLUSTER_IDENTIFIER="rdsauroracwagentoperatore2eclusterformysql" >> $GITHUB_ENV
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-canary-test" ]; then
-            echo DB_CLUSTER_IDENTIFIER="rdsaurorajavaclusterformysql" >> $GITHUB_ENV
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-playground" ]; then
-            echo DB_CLUSTER_IDENTIFIER="rdsauroraplaygroundclusterformysql" >> $GITHUB_ENV
-          fi
-
       - name: Get RDS database cluster metadata
         continue-on-error: true
         run: |
-          RDS_MYSQL_CLUSTER_ENDPOINT=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier $DB_CLUSTER_IDENTIFIER --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].Endpoint" --output text)
+          if [ "${{ env.CLUSTER_NAME }}" = "e2e-enablement-script-test" ]; then
+            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroraenablementscriptpythone2eclusterformysql"
+          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-cw-agent-test" ]; then
+            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroracwagente2eclusterformysql"
+          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-adot-test" ]; then
+            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroraadote2eclusterformysql"
+          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-cw-agent-operator-test" ]; then
+            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroracwagentoperatore2eclusterformysql"
+          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-canary-test" ]; then
+            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsaurorajavaclusterformysql"
+          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-playground" ]; then
+            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroraplaygroundclusterformysql"
+          fi
+          RDS_MYSQL_CLUSTER_ENDPOINT=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier $RDS_MYSQL_CLUSTER_IDENTIFIER --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].Endpoint" --output text)
           echo RDS_MYSQL_CLUSTER_ENDPOINT="$RDS_MYSQL_CLUSTER_ENDPOINT" >> $GITHUB_ENV
-          RDS_MYSQL_CLUSTER_IDENTIFIER=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier $DB_CLUSTER_IDENTIFIER --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].DBClusterIdentifier" --output text)
           RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME=$(aws secretsmanager list-secrets --region ${{inputs.aws-region}} --query "SecretList[?Tags[?Value=='arn:aws:rds:${{inputs.aws-region}}:${{env.ACCOUNT_ID}}:cluster:$RDS_MYSQL_CLUSTER_IDENTIFIER']].Name" --output text)
           echo RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME="$RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME" >> $GITHUB_ENV
 

--- a/.github/workflows/python-eks-e2e-test.yml
+++ b/.github/workflows/python-eks-e2e-test.yml
@@ -57,8 +57,8 @@ jobs:
           
       - uses: actions/checkout@v4
         with:
-          repository: 'aws-observability/aws-application-signals-test-framework'
-          ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
+          #repository: 'aws-observability/aws-application-signals-test-framework'
+          #ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
           fetch-depth: 0
 
         # We initialize Gradlew Daemon early on during the workflow because sometimes initialization

--- a/.github/workflows/python-eks-e2e-test.yml
+++ b/.github/workflows/python-eks-e2e-test.yml
@@ -138,12 +138,28 @@ jobs:
           --region ${{ env.E2E_TEST_AWS_REGION }}"
           sleep_time: 60
 
+      - name: Get RDS DB Cluster Identifier
+        run: |
+          if [ "${{ env.CLUSTER_NAME }}" = "e2e-enablement-script-test" ]; then
+            echo DB_CLUSTER_IDENTIFIER="rdsauroraenablementscriptpythone2eclusterformysql" >> $GITHUB_ENV
+          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-cw-agent-test" ]; then
+            echo DB_CLUSTER_IDENTIFIER="rdsauroracwagente2eclusterformysql" >> $GITHUB_ENV
+          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-python-adot-test" ]; then
+            echo DB_CLUSTER_IDENTIFIER="rdsauroraadotpythone2eclusterformysql" >> $GITHUB_ENV
+          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-cw-agent-operator-python-test" ]; then
+            echo DB_CLUSTER_IDENTIFIER="rdsauroracwagentoperatorpythone2eclusterformysql" >> $GITHUB_ENV
+          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-python-canary-test" ]; then
+            echo DB_CLUSTER_IDENTIFIER="rdsaurorapythonclusterformysql" >> $GITHUB_ENV
+          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-playground" ]; then
+            echo DB_CLUSTER_IDENTIFIER="rdsauroraplaygroundclusterformysql" >> $GITHUB_ENV
+          fi
+
       - name: Get RDS database cluster metadata
         continue-on-error: true
         run: |
-          RDS_MYSQL_CLUSTER_ENDPOINT=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier "rdsaurorapythonclusterformysql" --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].Endpoint | [0]" --output text)
+          RDS_MYSQL_CLUSTER_ENDPOINT=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier $DB_CLUSTER_IDENTIFIER --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].Endpoint | [0]" --output text)
           echo RDS_MYSQL_CLUSTER_ENDPOINT="$RDS_MYSQL_CLUSTER_ENDPOINT" >> $GITHUB_ENV
-          RDS_MYSQL_CLUSTER_IDENTIFIER=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier "rdsaurorapythonclusterformysql" --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].DBClusterIdentifier | [0]" --output text)
+          RDS_MYSQL_CLUSTER_IDENTIFIER=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier $DB_CLUSTER_IDENTIFIER --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].DBClusterIdentifier | [0]" --output text)
           RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME=$(aws secretsmanager list-secrets --region ${{inputs.aws-region}} --query "SecretList[?Tags[?Value=='arn:aws:rds:${{inputs.aws-region}}:${{env.ACCOUNT_ID}}:cluster:$RDS_MYSQL_CLUSTER_IDENTIFIER']].Name | [0]" --output text)
           echo RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME="$RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME" >> $GITHUB_ENV
 

--- a/.github/workflows/python-eks-e2e-test.yml
+++ b/.github/workflows/python-eks-e2e-test.yml
@@ -153,6 +153,9 @@ jobs:
             RDS_MYSQL_CLUSTER_IDENTIFIER="rdsaurorapythonclusterformysql"
           elif [ "${{ env.CLUSTER_NAME }}" = "e2e-playground" ]; then
             RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroraplaygroundclusterformysql"
+          else
+            echo "${{ env.CLUSTER_NAME }} is not a known cluster name"
+            exit 1
           fi
           RDS_MYSQL_CLUSTER_ENDPOINT=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier $RDS_MYSQL_CLUSTER_IDENTIFIER --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].Endpoint | [0]" --output text)
           echo RDS_MYSQL_CLUSTER_ENDPOINT="$RDS_MYSQL_CLUSTER_ENDPOINT" >> $GITHUB_ENV

--- a/.github/workflows/python-eks-e2e-test.yml
+++ b/.github/workflows/python-eks-e2e-test.yml
@@ -138,28 +138,24 @@ jobs:
           --region ${{ env.E2E_TEST_AWS_REGION }}"
           sleep_time: 60
 
-      - name: Get RDS DB Cluster Identifier
-        run: |
-          if [ "${{ env.CLUSTER_NAME }}" = "e2e-enablement-script-test" ]; then
-            echo DB_CLUSTER_IDENTIFIER="rdsauroraenablementscriptpythone2eclusterformysql" >> $GITHUB_ENV
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-cw-agent-test" ]; then
-            echo DB_CLUSTER_IDENTIFIER="rdsauroracwagente2eclusterformysql" >> $GITHUB_ENV
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-python-adot-test" ]; then
-            echo DB_CLUSTER_IDENTIFIER="rdsauroraadotpythone2eclusterformysql" >> $GITHUB_ENV
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-cw-agent-operator-python-test" ]; then
-            echo DB_CLUSTER_IDENTIFIER="rdsauroracwagentoperatorpythone2eclusterformysql" >> $GITHUB_ENV
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-python-canary-test" ]; then
-            echo DB_CLUSTER_IDENTIFIER="rdsaurorapythonclusterformysql" >> $GITHUB_ENV
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-playground" ]; then
-            echo DB_CLUSTER_IDENTIFIER="rdsauroraplaygroundclusterformysql" >> $GITHUB_ENV
-          fi
-
       - name: Get RDS database cluster metadata
         continue-on-error: true
         run: |
-          RDS_MYSQL_CLUSTER_ENDPOINT=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier $DB_CLUSTER_IDENTIFIER --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].Endpoint | [0]" --output text)
+          if [ "${{ env.CLUSTER_NAME }}" = "e2e-enablement-script-test" ]; then
+            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroraenablementscriptpythone2eclusterformysql"
+          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-cw-agent-test" ]; then
+            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroracwagente2eclusterformysql"
+          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-python-adot-test" ]; then
+            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroraadotpythone2eclusterformysql"
+          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-cw-agent-operator-python-test" ]; then
+            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroracwagentoperatorpythone2eclusterformysql"
+          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-python-canary-test" ]; then
+            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsaurorapythonclusterformysql"
+          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-playground" ]; then
+            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroraplaygroundclusterformysql"
+          fi
+          RDS_MYSQL_CLUSTER_ENDPOINT=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier $RDS_MYSQL_CLUSTER_IDENTIFIER --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].Endpoint | [0]" --output text)
           echo RDS_MYSQL_CLUSTER_ENDPOINT="$RDS_MYSQL_CLUSTER_ENDPOINT" >> $GITHUB_ENV
-          RDS_MYSQL_CLUSTER_IDENTIFIER=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier $DB_CLUSTER_IDENTIFIER --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].DBClusterIdentifier | [0]" --output text)
           RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME=$(aws secretsmanager list-secrets --region ${{inputs.aws-region}} --query "SecretList[?Tags[?Value=='arn:aws:rds:${{inputs.aws-region}}:${{env.ACCOUNT_ID}}:cluster:$RDS_MYSQL_CLUSTER_IDENTIFIER']].Name | [0]" --output text)
           echo RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME="$RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME" >> $GITHUB_ENV
 

--- a/.github/workflows/python-eks-e2e-test.yml
+++ b/.github/workflows/python-eks-e2e-test.yml
@@ -57,8 +57,8 @@ jobs:
           
       - uses: actions/checkout@v4
         with:
-          #repository: 'aws-observability/aws-application-signals-test-framework'
-          #ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
+          repository: 'aws-observability/aws-application-signals-test-framework'
+          ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
           fetch-depth: 0
 
         # We initialize Gradlew Daemon early on during the workflow because sometimes initialization


### PR DESCRIPTION
*Issue description:* This commit adds a step to get the RDS DB cluster identifier depending on which EKS cluster we are using. There's a 1:1 mapping between the EKS clusters and the RDS DB clusters. 

*Description of changes:* This commit adds a step that maps from the EKS cluster to the RDS DB cluster identifier, so that we can get the endpoint and the credentials that are going to be used by the sample app in both Python and Java.

*Ensure you've run the following tests on your changes and include the link below:*
To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

This change has been tested in [this fork of the repository](https://github.com/georgeboc/aws-application-signals-test-framework/actions/runs/10102522123/job/27938258542).

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
