### PR TITLE
Reapplies "Adds E2E tracing test for RDS database interactions for Python (#128)"

### DIFF
--- a/.github/workflows/python-eks-e2e-test.yml
+++ b/.github/workflows/python-eks-e2e-test.yml
@@ -395,6 +395,7 @@ jobs:
           --platform-info ${{ env.CLUSTER_NAME }}
           --service-name python-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
+          --remote-resource-identifier "information_schema|${{env.RDS_MYSQL_CLUSTER_ENDPOINT}}|3306"
           --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 

--- a/.github/workflows/python-eks-e2e-test.yml
+++ b/.github/workflows/python-eks-e2e-test.yml
@@ -180,9 +180,9 @@ jobs:
             echo "${{ env.CLUSTER_NAME }} is not a known cluster name"
             exit 1
           fi
-          RDS_MYSQL_CLUSTER_ENDPOINT=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier $RDS_MYSQL_CLUSTER_IDENTIFIER --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].Endpoint | [0]" --output text)
+          RDS_MYSQL_CLUSTER_ENDPOINT=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier $RDS_MYSQL_CLUSTER_IDENTIFIER --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].Endpoint" --output text)
           echo RDS_MYSQL_CLUSTER_ENDPOINT="$RDS_MYSQL_CLUSTER_ENDPOINT" >> $GITHUB_ENV
-          RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME=$(aws secretsmanager list-secrets --region ${{inputs.aws-region}} --query "SecretList[?Tags[?Value=='arn:aws:rds:${{inputs.aws-region}}:${{env.ACCOUNT_ID}}:cluster:$RDS_MYSQL_CLUSTER_IDENTIFIER']].Name | [0]" --output text)
+          RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME=$(aws secretsmanager list-secrets --region ${{inputs.aws-region}} --query "SecretList[?Tags[?Value=='arn:aws:rds:${{inputs.aws-region}}:${{env.ACCOUNT_ID}}:cluster:$RDS_MYSQL_CLUSTER_IDENTIFIER']].Name" --output text)
           echo RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME="$RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME" >> $GITHUB_ENV
 
       - name: Get RDS database credentials from SecretsManager

--- a/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
+++ b/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
@@ -114,6 +114,8 @@ public enum PredefinedExpectedTemplate implements FileConfig {
   PYTHON_EKS_CLIENT_CALL_METRIC("/expected-data-template/python/eks/client-call-metric.mustache"),
   PYTHON_EKS_CLIENT_CALL_TRACE("/expected-data-template/python/eks/client-call-trace.mustache"),
 
+  PYTHON_EKS_RDS_MYSQL_TRACE("/expected-data-template/python/eks/rds-mysql-trace.mustache"),
+
   /** Python EC2 Default Test Case Validations */
   PYTHON_EC2_DEFAULT_OUTGOING_HTTP_CALL_LOG("/expected-data-template/python/ec2/default/outgoing-http-call-log.mustache"),
   PYTHON_EC2_DEFAULT_OUTGOING_HTTP_CALL_METRIC("/expected-data-template/python/ec2/default/outgoing-http-call-metric.mustache"),

--- a/validator/src/main/resources/expected-data-template/python/eks/rds-mysql-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/python/eks/rds-mysql-trace.mustache
@@ -1,0 +1,76 @@
+[
+  {
+    "name": "^{{serviceName}}$",
+    "http": {
+      "request": {
+        "url": "^{{endpoint}}/mysql$",
+        "method": "^GET$"
+      },
+      "response": {
+        "status": 200
+      }
+    },
+    "aws": {
+      "account_id": "^{{accountId}}$",
+      "xray": {
+        "auto_instrumentation": true,
+        "sdk": "^opentelemetry for"
+      }
+    },
+    "annotations": {
+      "aws.local.service": "^{{serviceName}}$",
+      "aws.local.operation": "^GET mysql$",
+      "aws.local.environment": "^eks:{{platformInfo}}/{{appNamespace}}$"
+    },
+    "metadata": {
+      "default": {
+        "EC2.AutoScalingGroup": "^eks-.+",
+        "EKS.Cluster": "^{{platformInfo}}$",
+        "K8s.Namespace": "^{{appNamespace}}",
+        "otel.resource.K8s.Workload": "^python-app-deployment-{{testingId}}",
+        "otel.resource.K8s.Node": "^i-[A-Za-z0-9]{17}$",
+        "otel.resource.K8s.Pod": "^python-app-deployment-{{testingId}}(-[A-Za-z0-9]*)*$",
+        "otel.resource.host.name": "^ip(-[0-9]{1,3}){4}.*$",
+        "PlatformType": "^AWS::EKS$",
+        "aws.span.kind": "^LOCAL_ROOT$",
+        "http.route": "^mysql$"
+      }
+    },
+    "subsegments": [
+      {
+        "name": "^mysql$",
+        "aws": {
+          "account_id": "^{{accountId}}$",
+          "xray": {
+            "auto_instrumentation": true,
+            "sdk": "^opentelemetry for"
+          }
+        },
+        "sql": {
+          "url": "^SELECT$",
+          "sanitized_query": "SELECT \\* FROM tables LIMIT 1;",
+          "database_type": "^mysql$"
+        },
+        "annotations": {
+          "aws.remote.operation": "^SELECT$",
+          "aws.local.operation": "^GET mysql$",
+          "aws.remote.resource.type": "^DB::Connection$",
+          "aws.remote.resource.identifier": "^{{remoteResourceIdentifier}}$",
+          "aws.remote.service": "^mysql$",
+          "aws.local.service": "^{{serviceName}}$",
+          "aws.local.environment": "^eks:{{platformInfo}}/{{appNamespace}}$"
+        },
+        "metadata": {
+          "default": {
+            "EC2.AutoScalingGroup": "^eks-.+",
+            "EKS.Cluster": "^{{platformInfo}}$",
+            "K8s.Namespace": "^{{appNamespace}}$",
+            "PlatformType": "^AWS::EKS$",
+            "aws.span.kind": "^CLIENT$"
+          }
+        },
+        "namespace": "^remote$"
+      }
+    ]
+  }
+]

--- a/validator/src/main/resources/validations/python/eks/trace-validation.yml
+++ b/validator/src/main/resources/validations/python/eks/trace-validation.yml
@@ -22,3 +22,9 @@
   httpMethod: "get"
   callingType: "http"
   expectedTraceTemplate: "PYTHON_EKS_CLIENT_CALL_TRACE"
+-
+  validationType: "trace"
+  httpPath: "mysql"
+  httpMethod: "get"
+  callingType: "http"
+  expectedTraceTemplate: "PYTHON_EKS_RDS_MYSQL_TRACE"


### PR DESCRIPTION
*Issue description:* This commit reapplies tracing validation test for RDS database interactions for Python with a fix for [this issue in the workflow execution in us-east-1](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10219677752/job/28278422311)

*Description of changes:* Reapplied [this PR](https://github.com/aws-observability/aws-application-signals-test-framework/pull/128) and applied fix to avoid failure when retrieving the secrets.

*Rollback procedure:*

Can we safely revert this commit if needed? Yes, we can safely revert this commit.

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
