### PR TITLE
Adding Java EKS E2E log test for data base user attribute

### DIFF
--- a/.github/workflows/java-eks-e2e-test.yml
+++ b/.github/workflows/java-eks-e2e-test.yml
@@ -184,6 +184,12 @@ jobs:
           RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME=$(aws secretsmanager list-secrets --region ${{inputs.aws-region}} --query "SecretList[?Tags[?Value=='arn:aws:rds:${{inputs.aws-region}}:${{env.ACCOUNT_ID}}:cluster:$RDS_MYSQL_CLUSTER_IDENTIFIER']].Name" --output text)
           echo RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME="$RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME" >> $GITHUB_ENV
 
+      - name: Get RDS database instance metadata
+        run: |
+          INSTANCE_ID=$(aws rds describe-db-instances --query "DBInstances[0].DBInstanceIdentifier" --output text)
+          REMOTE_DB_USER=$(aws rds describe-db-instances --db-instance-identifier $INSTANCE_ID --query "DBInstances[0].MasterUsername" --output text)
+          echo REMOTE_DB_USER="$REMOTE_DB_USER" >> $GITHUB_ENV
+
       - name: Get RDS database credentials from SecretsManager
         continue-on-error: true
         uses: aws-actions/aws-secretsmanager-get-secrets@v1
@@ -358,6 +364,7 @@ jobs:
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
           --remote-resource-identifier "information_schema|${{env.RDS_MYSQL_CLUSTER_ENDPOINT}}|3306"
+          --remote-db-user ${{ env.REMOTE_DB_USER }}
           --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 

--- a/.github/workflows/java-eks-e2e-test.yml
+++ b/.github/workflows/java-eks-e2e-test.yml
@@ -184,12 +184,6 @@ jobs:
           RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME=$(aws secretsmanager list-secrets --region ${{inputs.aws-region}} --query "SecretList[?Tags[?Value=='arn:aws:rds:${{inputs.aws-region}}:${{env.ACCOUNT_ID}}:cluster:$RDS_MYSQL_CLUSTER_IDENTIFIER']].Name" --output text)
           echo RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME="$RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME" >> $GITHUB_ENV
 
-      - name: Get RDS database instance metadata
-        run: |
-          INSTANCE_ID=$(aws rds describe-db-instances --query "DBInstances[0].DBInstanceIdentifier" --output text)
-          REMOTE_DB_USER=$(aws rds describe-db-instances --db-instance-identifier $INSTANCE_ID --query "DBInstances[0].MasterUsername" --output text)
-          echo REMOTE_DB_USER="$REMOTE_DB_USER" >> $GITHUB_ENV
-
       - name: Get RDS database credentials from SecretsManager
         continue-on-error: true
         uses: aws-actions/aws-secretsmanager-get-secrets@v1
@@ -364,7 +358,7 @@ jobs:
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
           --remote-resource-identifier "information_schema|${{env.RDS_MYSQL_CLUSTER_ENDPOINT}}|3306"
-          --remote-db-user ${{ env.REMOTE_DB_USER }}
+          --remote-db-user ${{ env.RDS_MYSQL_CLUSTER_SECRETS_USERNAME }}
           --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 

--- a/validator/src/main/java/com/amazon/aoc/App.java
+++ b/validator/src/main/java/com/amazon/aoc/App.java
@@ -78,6 +78,9 @@ public class App implements Callable<Integer> {
   @CommandLine.Option(names = {"--remote-resource-identifier"})
   private String remoteResourceIdentifier;
 
+  @CommandLine.Option(names = {"--remote-db-user"})
+  private String remoteDbUser;
+
   @CommandLine.Option(names = {"--endpoint"})
   private String endpoint;
 
@@ -174,6 +177,7 @@ public class App implements Callable<Integer> {
     context.setRemoteServiceName(this.remoteServiceName);
     context.setRemoteServiceDeploymentName(this.remoteServiceDeploymentName);
     context.setRemoteResourceIdentifier(this.remoteResourceIdentifier);
+    context.setRemoteDbUser(this.remoteDbUser);
     context.setEndpoint(this.endpoint);
     context.setQueryString(this.queryString);
     context.setLogGroup(this.logGroup);

--- a/validator/src/main/java/com/amazon/aoc/models/Context.java
+++ b/validator/src/main/java/com/amazon/aoc/models/Context.java
@@ -51,6 +51,8 @@ public class Context {
 
   private String remoteResourceIdentifier;
 
+  private String remoteDbUser;
+
   private String endpoint;
 
   private String queryString;

--- a/validator/src/main/resources/expected-data-template/java/eks/rds-mysql-log.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks/rds-mysql-log.mustache
@@ -32,5 +32,6 @@
     "RemoteService": "mysql",
     "RemoteOperation": "SELECT",
     "RemoteResourceType": "DB::Connection",
-    "RemoteResourceIdentifier": "^{{remoteResourceIdentifier}}$"
+    "RemoteResourceIdentifier": "^{{remoteResourceIdentifier}}$",
+    "RemoteDbUser": "^{{remoteDbUser}}$"
 }]


### PR DESCRIPTION
*Issue description:*
Adding Java E2E EKS log, metric and trace test for data base user attribute.

E2E test workflow for us-east-1: https://github.com/ektabj/aws-application-signals-test-framework/actions/runs/10274607360/job/28431702593

---

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
