### PR TITLE
Reduce Traffic Generator Polling

### DIFF
--- a/sample-apps/traffic-generator/index.js
+++ b/sample-apps/traffic-generator/index.js
@@ -50,6 +50,6 @@ const trafficGenerator = async (interval) => {
     setInterval(() => sendRequests(urls), interval);
 }
 
-const interval = 60 * 1000;
-// Start sending GET requests every minute (60,000 milliseconds)
+const interval = 15 * 1000;
+// Start sending GET requests every 15 seconds (60,000 milliseconds)
 trafficGenerator(interval);


### PR DESCRIPTION
*Issue description:*
Validation steps are failing due to missing log/metric/trace. We are suspecting the traffic generator is failing to send the appropriate metrics. 

*Description of changes:*
Reduce polling time to 15 second

*Rollback procedure:*
Revert PR

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
