### PR TITLE
[EKS] Remove `/mysql` temporarily

### DIFF
--- a/sample-apps/traffic-generator/index.js
+++ b/sample-apps/traffic-generator/index.js
@@ -43,7 +43,6 @@ const trafficGenerator = async (interval) => {
         `http://${mainEndpoint}/aws-sdk-call?ip=${remoteEndpoint}&testingId=${id}`,
         `http://${mainEndpoint}/remote-service?ip=${remoteEndpoint}&testingId=${id}`,
         `http://${mainEndpoint}/client-call`,
-        `http://${mainEndpoint}/mysql`,
     ];
 
     await sendRequests(urls);


### PR DESCRIPTION
Checking the following test run, found that the only telemetry generated was for `/mysql`. This means that this test case may be impacting the ability of the sample app to move on to other endpoints. Since we don't test this case yet, removing it to see if there's an improvement to be seen

https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10333263032/job/28605408100

*Issue description:*
Testing if removing /mysql helps with canary failure rate since we don't validate the telemetry from this API anyways. The reason for this measure being taken is the following Python EKS run that was able to generate telemetry for the /mysql API but none of the others.
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10333263032/job/28605408100

My hunch is that the API call is freezing/taking very long/causing the sample application to enter a broken state. Not calling it should fix that

*Description of changes:*
- Remove `/mysql` API from traffic generator.

*Rollback procedure:*

Yes

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
