### PR TITLE
[Java/ASG] Fix validation step ID references

### DIFF
--- a/.github/workflows/java-ec2-asg-e2e-test.yml
+++ b/.github/workflows/java-ec2-asg-e2e-test.yml
@@ -198,7 +198,7 @@ jobs:
 
       - name: Validate generated metrics
         id: metric-validation
-        if: (success() || steps.log-validation-1.outcome == 'failure') && !cancelled()
+        if: (success() || steps.log-validation.outcome == 'failure') && !cancelled()
         run: ./gradlew validator:run --args='-c java/ec2/asg/metric-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
@@ -218,7 +218,7 @@ jobs:
 
       - name: Validate generated traces
         id: trace-validation
-        if: (success() || steps.log-validation-1.outcome == 'failure' || steps.metric-validation-1.outcome == 'failure') && !cancelled()
+        if: (success() || steps.log-validation.outcome == 'failure' || steps.metric-validation.outcome == 'failure') && !cancelled()
         run: ./gradlew validator:run --args='-c java/ec2/asg/trace-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}


### PR DESCRIPTION
*Issue description:*
Step IDs for validation are wrong, causing metric and trace validation not to run in log validation failed

*Description of changes:*
- Fix step IDs

*Rollback procedure:*
Revert

*Testing*
No need, `success()` will maintain current behaviour and if new name still doesn't match correctly, current behaviour will be unchanged