### PR TITLE
[Java/EKS] Upgrade get secrets action to v2 + increase time limit

### DIFF
--- a/.github/workflows/java-eks-e2e-test.yml
+++ b/.github/workflows/java-eks-e2e-test.yml
@@ -96,7 +96,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Retrieve account
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
             ACCOUNT_ID, region-account/${{ env.E2E_TEST_AWS_REGION }}
@@ -186,7 +186,9 @@ jobs:
 
       - name: Get RDS database credentials from SecretsManager
         continue-on-error: true
-        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        env:
+          NODE_OPTIONS: "--network-family-autoselection-attempt-timeout=1000"
         with:
           secret-ids:
             RDS_MYSQL_CLUSTER_SECRETS, ${{env.RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME}}

--- a/.github/workflows/python-eks-e2e-test.yml
+++ b/.github/workflows/python-eks-e2e-test.yml
@@ -57,8 +57,8 @@ jobs:
           
       - uses: actions/checkout@v4
         with:
-          repository: 'aws-observability/aws-application-signals-test-framework'
-          ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
+          #repository: 'aws-observability/aws-application-signals-test-framework'
+          #ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
           fetch-depth: 0
 
         # We initialize Gradlew Daemon early on during the workflow because sometimes initialization

--- a/.github/workflows/python-eks-e2e-test.yml
+++ b/.github/workflows/python-eks-e2e-test.yml
@@ -57,8 +57,8 @@ jobs:
           
       - uses: actions/checkout@v4
         with:
-          #repository: 'aws-observability/aws-application-signals-test-framework'
-          #ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
+          repository: 'aws-observability/aws-application-signals-test-framework'
+          ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
           fetch-depth: 0
 
         # We initialize Gradlew Daemon early on during the workflow because sometimes initialization


### PR DESCRIPTION
*Issue description:* This commit reapplies the same changes we did for Python [here](https://github.com/aws-observability/aws-application-signals-test-framework/pull/164), but for the Java EKS E2E test. NodeJS 20 enabled by default the auto select (IP v or v6) family by default, although the default timeout is 250ms. We wanted to change the default to a higher value to avoid timing out when reaching out regions that are far away. This commit increases the auto select family timeout to 1s to avoid flakiness when running the GitHub Workflow like in [me-central-1](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10184143706/job/28170770924) or [af-south-1](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10184771400/job/28172854158).

*Rollback procedure:*

Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.

Yes, the changes can be reverted.

*Ensure you've run the following tests on your changes and include the link below:*

[Successful run](https://github.com/georgeboc/aws-application-signals-test-framework/actions/runs/10349473178/job/28644765027) for a fork of this repository with these changes applied.

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
