### PR TITLE
Reapplies "Adds E2E tracing test for RDS database interactions for Python (#128)"

### DIFF
--- a/.github/workflows/python-eks-e2e-test.yml
+++ b/.github/workflows/python-eks-e2e-test.yml
@@ -57,8 +57,8 @@ jobs:
           
       - uses: actions/checkout@v4
         with:
-          repository: 'aws-observability/aws-application-signals-test-framework'
-          ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
+          #repository: 'aws-observability/aws-application-signals-test-framework'
+          #ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
           fetch-depth: 0
 
         # We initialize Gradlew Daemon early on during the workflow because sometimes initialization

--- a/.github/workflows/python-eks-e2e-test.yml
+++ b/.github/workflows/python-eks-e2e-test.yml
@@ -397,6 +397,7 @@ jobs:
           --platform-info ${{ env.CLUSTER_NAME }}
           --service-name python-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
+          --remote-resource-identifier "information_schema|${{env.RDS_MYSQL_CLUSTER_ENDPOINT}}|3306"
           --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 

--- a/.github/workflows/python-eks-e2e-test.yml
+++ b/.github/workflows/python-eks-e2e-test.yml
@@ -57,8 +57,8 @@ jobs:
           
       - uses: actions/checkout@v4
         with:
-          #repository: 'aws-observability/aws-application-signals-test-framework'
-          #ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
+          repository: 'aws-observability/aws-application-signals-test-framework'
+          ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
           fetch-depth: 0
 
         # We initialize Gradlew Daemon early on during the workflow because sometimes initialization

--- a/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
+++ b/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
@@ -114,6 +114,8 @@ public enum PredefinedExpectedTemplate implements FileConfig {
   PYTHON_EKS_CLIENT_CALL_METRIC("/expected-data-template/python/eks/client-call-metric.mustache"),
   PYTHON_EKS_CLIENT_CALL_TRACE("/expected-data-template/python/eks/client-call-trace.mustache"),
 
+  PYTHON_EKS_RDS_MYSQL_TRACE("/expected-data-template/python/eks/rds-mysql-trace.mustache"),
+
   /** Python EC2 Default Test Case Validations */
   PYTHON_EC2_DEFAULT_OUTGOING_HTTP_CALL_LOG("/expected-data-template/python/ec2/default/outgoing-http-call-log.mustache"),
   PYTHON_EC2_DEFAULT_OUTGOING_HTTP_CALL_METRIC("/expected-data-template/python/ec2/default/outgoing-http-call-metric.mustache"),

--- a/validator/src/main/resources/expected-data-template/python/eks/rds-mysql-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/python/eks/rds-mysql-trace.mustache
@@ -1,0 +1,76 @@
+[
+  {
+    "name": "^{{serviceName}}$",
+    "http": {
+      "request": {
+        "url": "^{{endpoint}}/mysql$",
+        "method": "^GET$"
+      },
+      "response": {
+        "status": 200
+      }
+    },
+    "aws": {
+      "account_id": "^{{accountId}}$",
+      "xray": {
+        "auto_instrumentation": true,
+        "sdk": "^opentelemetry for"
+      }
+    },
+    "annotations": {
+      "aws.local.service": "^{{serviceName}}$",
+      "aws.local.operation": "^GET mysql$",
+      "aws.local.environment": "^eks:{{platformInfo}}/{{appNamespace}}$"
+    },
+    "metadata": {
+      "default": {
+        "EC2.AutoScalingGroup": "^eks-.+",
+        "EKS.Cluster": "^{{platformInfo}}$",
+        "K8s.Namespace": "^{{appNamespace}}",
+        "otel.resource.K8s.Workload": "^python-app-deployment-{{testingId}}",
+        "otel.resource.K8s.Node": "^i-[A-Za-z0-9]{17}$",
+        "otel.resource.K8s.Pod": "^python-app-deployment-{{testingId}}(-[A-Za-z0-9]*)*$",
+        "otel.resource.host.name": "^ip(-[0-9]{1,3}){4}.*$",
+        "PlatformType": "^AWS::EKS$",
+        "aws.span.kind": "^LOCAL_ROOT$",
+        "http.route": "^mysql$"
+      }
+    },
+    "subsegments": [
+      {
+        "name": "^mysql$",
+        "aws": {
+          "account_id": "^{{accountId}}$",
+          "xray": {
+            "auto_instrumentation": true,
+            "sdk": "^opentelemetry for"
+          }
+        },
+        "sql": {
+          "url": "^SELECT$",
+          "sanitized_query": "SELECT \\* FROM tables LIMIT 1;",
+          "database_type": "^mysql$"
+        },
+        "annotations": {
+          "aws.remote.operation": "^SELECT$",
+          "aws.local.operation": "^GET mysql$",
+          "aws.remote.resource.type": "^DB::Connection$",
+          "aws.remote.resource.identifier": "^{{remoteResourceIdentifier}}$",
+          "aws.remote.service": "^mysql$",
+          "aws.local.service": "^{{serviceName}}$",
+          "aws.local.environment": "^eks:{{platformInfo}}/{{appNamespace}}$"
+        },
+        "metadata": {
+          "default": {
+            "EC2.AutoScalingGroup": "^eks-.+",
+            "EKS.Cluster": "^{{platformInfo}}$",
+            "K8s.Namespace": "^{{appNamespace}}$",
+            "PlatformType": "^AWS::EKS$",
+            "aws.span.kind": "^CLIENT$"
+          }
+        },
+        "namespace": "^remote$"
+      }
+    ]
+  }
+]

--- a/validator/src/main/resources/validations/python/eks/trace-validation.yml
+++ b/validator/src/main/resources/validations/python/eks/trace-validation.yml
@@ -22,3 +22,9 @@
   httpMethod: "get"
   callingType: "http"
   expectedTraceTemplate: "PYTHON_EKS_CLIENT_CALL_TRACE"
+-
+  validationType: "trace"
+  httpPath: "mysql"
+  httpMethod: "get"
+  callingType: "http"
+  expectedTraceTemplate: "PYTHON_EKS_RDS_MYSQL_TRACE"


### PR DESCRIPTION
*Issue description:* We reapply "Adds E2E tracing test for RDS database interactions for Python (#128)" as part of this PR, after validating that the secrets retrieval won't be flaky anymore. We checked the latest 31 runs and none of them timed out in the secrets credential retrieval:
- [2421] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10348745481
- [2420] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10348569732
- [2419] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10348392026
- [2418] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10348135172
- [2417] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10347914458
- [2416] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10347733955
- [2415] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10347585223
- [2414] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10347371880
- [2413] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10347193099
- [2412] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10347075695
- [2411] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10346928253
- [2410] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10346719984
- [2409] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10346573066
- [2408] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10346460309
- [2407] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10346347392
- [2406] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10346177674
- [2405] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10346056052
- [2404] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10345953529
- [2403] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10345856891
- [2402] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10345702224
- [2401] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10345588121
- [2400] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10345487569
- [2399] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10345384516
- [2398] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10345225205
- [2397] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10345145778
- [2396] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10345067015
- [2395] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10344871161
- [2394] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10344601125
- [2393] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10344301144
- [2392] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10344003249
- [2391] https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10343840248

*Description of changes:* This commit reverts [this PR](https://github.com/aws-observability/aws-application-signals-test-framework/pull/157), reapplying the tracing test for the RDS database interactions for Python.

*Rollback procedure:*

Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.

Yes, we can safely revert this commit.

*Ensure you've run the following tests on your changes and include the link below:*

[Successful run](https://github.com/georgeboc/aws-application-signals-test-framework/actions/runs/10360422728) in a fork of this repository.

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
