### PR TITLE
Revert "[Java/EKS] Remove /mysql validations temporarily (#152)"

### DIFF
--- a/validator/src/main/resources/validations/java/eks/log-validation.yml
+++ b/validator/src/main/resources/validations/java/eks/log-validation.yml
@@ -22,3 +22,9 @@
   httpMethod: "get"
   callingType: "http"
   expectedLogStructureTemplate: "JAVA_EKS_CLIENT_CALL_LOG"
+-
+  validationType: "cw-log"
+  httpPath: "/mysql"
+  httpMethod: "get"
+  callingType: "http"
+  expectedLogStructureTemplate: "JAVA_EKS_RDS_MYSQL_LOG"

--- a/validator/src/main/resources/validations/java/eks/metric-validation.yml
+++ b/validator/src/main/resources/validations/java/eks/metric-validation.yml
@@ -22,3 +22,9 @@
   httpMethod: "get"
   callingType: "http"
   expectedMetricTemplate: "JAVA_EKS_CLIENT_CALL_METRIC"
+-
+  validationType: "cw-metric"
+  httpPath: "/mysql"
+  httpMethod: "get"
+  callingType: "http"
+  expectedMetricTemplate: "JAVA_EKS_RDS_MYSQL_METRIC"

--- a/validator/src/main/resources/validations/java/eks/trace-validation.yml
+++ b/validator/src/main/resources/validations/java/eks/trace-validation.yml
@@ -22,3 +22,9 @@
   httpMethod: "get"
   callingType: "http"
   expectedTraceTemplate: "JAVA_EKS_CLIENT_CALL_TRACE"
+-
+  validationType: "trace"
+  httpPath: "/mysql"
+  httpMethod: "get"
+  callingType: "http"
+  expectedTraceTemplate: "JAVA_EKS_RDS_MYSQL_TRACE"


### PR DESCRIPTION
*Issue description:*
This reverts commit 61bc44a52a8de7eb5b15c13c151cf62ed7a57aef.

*Description of changes:*
Adding `/mysql` validations for EKS Java

Java EKS E2E workflow: https://github.com/ektabj/aws-application-signals-test-framework/actions/runs/10408659429/job/28826557046

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
