### PR TITLE
Remove sample app namespace in the beginning

### DIFF
--- a/.github/workflows/java-eks-e2e-test.yml
+++ b/.github/workflows/java-eks-e2e-test.yml
@@ -133,6 +133,12 @@ jobs:
         run: |
           echo "${{ github.workspace }}/eksctl" >> $GITHUB_PATH
 
+      # This step deletes lingering resources from previous test runs
+      - name: Delete all sample app namespaces
+        continue-on-error: true
+        timeout-minutes: 5
+        run: kubectl get namespace | awk '/^ns-[0-9]+-[0-9]+/{print $1}' | xargs kubectl delete namespace
+
       - name: Create role for AWS access from the sample app
         id: create_service_account
         uses: ./.github/workflows/actions/execute_and_retry

--- a/.github/workflows/java-metric-limiter-e2e-test.yml
+++ b/.github/workflows/java-metric-limiter-e2e-test.yml
@@ -135,6 +135,12 @@ jobs:
         run: |
           echo "${{ github.workspace }}/eksctl" >> $GITHUB_PATH
 
+      # This step deletes lingering resources from previous test runs
+      - name: Delete all sample app namespaces
+        continue-on-error: true
+        timeout-minutes: 5
+        run: kubectl get namespace | awk '/^ns-[0-9]+-[0-9]+/{print $1}' | xargs kubectl delete namespace
+
       - name: Create role for AWS access from the sample app
         id: create_service_account
         uses: ./.github/workflows/actions/execute_and_retry

--- a/.github/workflows/python-eks-e2e-test.yml
+++ b/.github/workflows/python-eks-e2e-test.yml
@@ -134,6 +134,12 @@ jobs:
         run: |
           echo "${{ github.workspace }}/eksctl" >> $GITHUB_PATH
 
+      # This step deletes lingering resources from previous test runs
+      - name: Delete all sample app namespaces
+        continue-on-error: true
+        timeout-minutes: 5
+        run: kubectl get namespace | awk '/^ns-[0-9]+-[0-9]+/{print $1}' | xargs kubectl delete namespace
+
       - name: Create role for AWS access from the sample app
         id: create_service_account
         uses: ./.github/workflows/actions/execute_and_retry


### PR DESCRIPTION
*Issue description:*
We had an issue where previous sample applications did not get deleted because a runner abruptly disconnected in the middle of the run. ([Link](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10437137885/job/28902975541)) This caused subsequent EKS runs to fail due to the port being occupied and had to be manually cleaned

*Description of changes:*
Clean up the EKS cluster namespace before deploying a new sample application

Test run:
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10532509683/job/29186804244
Also manually tried running the command

*Rollback procedure:*
Revert the PR

<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
