### PR TITLE
Fix patching

### DIFF
--- a/.github/workflows/actions/patch_image_and_check_diff/action.yml
+++ b/.github/workflows/actions/patch_image_and_check_diff/action.yml
@@ -77,7 +77,7 @@ runs:
       shell: bash
       run: |
         kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' \
-        -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/2", "value": "--auto-instrumentation-python-image=${{ inputs.patch-image-arn }}"}]'
+        -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/3", "value": "--auto-instrumentation-python-image=${{ inputs.patch-image-arn }}"}]'
         kubectl delete pods --all -n amazon-cloudwatch
         sleep 10
         kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
@@ -91,7 +91,7 @@ runs:
       shell: bash
       run: |
         kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' \
-        -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/1", "value": "--auto-instrumentation-java-image=${{ inputs.patch-image-arn }}"}]'
+        -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/2", "value": "--auto-instrumentation-java-image=${{ inputs.patch-image-arn }}"}]'
         kubectl delete pods --all -n amazon-cloudwatch
         sleep 10
         kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch


### PR DESCRIPTION
CWAgent added more config to spec/containers/args, so update indexing.

It used to be:
```
"--auto-instrumentation-java-image=...",
"--auto-instrumentation-python-image=...",
...
```

Now its:
```
"--auto-instrumentation-config={...}",
"--auto-instrumentation-java-image=...",
"--auto-instrumentation-python-image=...",
...
```

So bump java and python index by 1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
