### PR TITLE
Improve logging for patch mechanism

### DIFF
--- a/.github/workflows/actions/patch_image_and_check_diff/action.yml
+++ b/.github/workflows/actions/patch_image_and_check_diff/action.yml
@@ -73,7 +73,8 @@ runs:
         sleep 10
 
     - name: Log CW Agent Operator spec container args before patching
-      id: default-cw-agent-operator-image
+      id: log-args-before-patch
+      continue-on-error: true
       shell: bash
       run: |
         kubectl get pods -n amazon-cloudwatch -l app.kubernetes.io/name=amazon-cloudwatch-observability -o json | \
@@ -130,8 +131,9 @@ runs:
         kubectl wait --for=condition=Ready pod --all -n ${{ inputs.sample-app-namespace }}
 
     # Log artifacts being used to verify whether the correct versions are being used
-    - name: Log CW Agent Operator spec container args before patching
-      id: default-cw-agent-operator-image
+    - name: Log CW Agent Operator spec container args after patching
+      id: log-args-after-patch
+      continue-on-error: true
       shell: bash
       run: |
         kubectl get pods -n amazon-cloudwatch -l app.kubernetes.io/name=amazon-cloudwatch-observability -o json | \

--- a/.github/workflows/actions/patch_image_and_check_diff/action.yml
+++ b/.github/workflows/actions/patch_image_and_check_diff/action.yml
@@ -72,6 +72,13 @@ runs:
         
         sleep 10
 
+    - name: Log CW Agent Operator spec container args before patching
+      id: default-cw-agent-operator-image
+      shell: bash
+      run: |
+        kubectl get pods -n amazon-cloudwatch -l app.kubernetes.io/name=amazon-cloudwatch-observability -o json | \
+        jq '.items[0].spec.containers[0].args'
+
     - name: Patch the Python ADOT image and restart CloudWatch pods
       if: ${{ inputs.repository == 'aws-otel-python-instrumentation' }}
       shell: bash
@@ -123,6 +130,13 @@ runs:
         kubectl wait --for=condition=Ready pod --all -n ${{ inputs.sample-app-namespace }}
 
     # Log artifacts being used to verify whether the correct versions are being used
+    - name: Log CW Agent Operator spec container args before patching
+      id: default-cw-agent-operator-image
+      shell: bash
+      run: |
+        kubectl get pods -n amazon-cloudwatch -l app.kubernetes.io/name=amazon-cloudwatch-observability -o json | \
+        jq '.items[0].spec.containers[0].args'
+    
     - name: Log pod Adot image ID and save image to the environment
       id: latest-adot-image
       shell: bash


### PR DESCRIPTION
Log operator spec container args before and after as that's whats actually being modified.

### Testing done:
Ran workflow [here](https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/10532909893), and while it was running, I ran the following:

```
 kubectl get pods -n amazon-cloudwatch -l app.kubernetes.io/name=amazon-cloudwatch-observability -o json | \
        jq '.items[0].spec.containers[0].args'
[
  "--auto-instrumentation-config={\"dotnet\":{\"limits\":{\"cpu\":\"500m\",\"memory\":\"128Mi\"},\"requests\":{\"cpu\":\"50m\",\"memory\":\"128Mi\"}},\"java\":{\"limits\":{\"cpu\":\"500m\",\"memory\":\"64Mi\"},\"requests\":{\"cpu\":\"50m\",\"memory\":\"64Mi\"}},\"python\":{\"limits\":{\"cpu\":\"500m\",\"memory\":\"32Mi\"},\"requests\":{\"cpu\":\"50m\",\"memory\":\"32Mi\"}}}",
  "--auto-annotation-config={\"dotnet\":{\"daemonsets\":[],\"deployments\":[],\"namespaces\":[],\"statefulsets\":[]},\"java\":{\"daemonsets\":[],\"deployments\":[],\"namespaces\":[],\"statefulsets\":[]},\"python\":{\"daemonsets\":[],\"deployments\":[],\"namespaces\":[],\"statefulsets\":[]}}",
  "--auto-instrumentation-java-image=602401143452.dkr.ecr.us-east-1.amazonaws.com/eks/observability/adot-autoinstrumentation-java:v1.32.3",
  "--auto-instrumentation-python-image=637423224110.dkr.ecr.us-east-1.amazonaws.com/aws-observability/adot-autoinstrumentation-python-staging:0.3.0.dev0-e4f5b28",
  "--auto-instrumentation-dotnet-image=%!s(<nil>)/eks/observability/adot-autoinstrumentation-dotnet:v1.2.0",
  "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
