### PR TITLE
Patch K8s on EC2 OS Part 1

### DIFF
--- a/.github/workflows/java-k8s-test.yml
+++ b/.github/workflows/java-k8s-test.yml
@@ -14,6 +14,9 @@ on:
       caller-workflow-name:
         required: true
         type: string
+      caller-repository:
+        required: false
+        type: string
       adot-image-name:
         required: false
         type: string
@@ -33,6 +36,7 @@ permissions:
 env:
   E2E_TEST_AWS_REGION: ${{ inputs.aws-region }}
   CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
+  CALLER_REPOSITORY: ${{ inputs.caller-repository }}
   ADOT_IMAGE_NAME: ${{ inputs.adot-image-name }}
   CW_AGENT_OPERATOR_TAG: ${{ inputs.cw-agent-operator-tag }}
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
@@ -55,7 +59,7 @@ jobs:
         run: echo "job-started=true" >> $GITHUB_OUTPUT
 
       - name: Generate testing id
-        run: echo TESTING_ID="${{ env.E2E_TEST_AWS_REGION }}-${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
+        run: echo TESTING_ID="${{ github.run_id }}-${{ github.run_number }}-${RANDOM}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v4
         with:
@@ -81,7 +85,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ env.E2E_TEST_ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
           aws-region: us-east-1
 
-      - name: Retrieve account
+      - name: Retrieve Secrets
         uses: aws-actions/aws-secretsmanager-get-secrets@v1
         with:
           secret-ids: |
@@ -89,8 +93,22 @@ jobs:
             JAVA_MAIN_SAMPLE_APP_IMAGE, e2e-test/java-main-sample-app-image
             JAVA_REMOTE_SAMPLE_APP_IMAGE, e2e-test/java-remote-sample-app-image
             RELEASE_TESTING_ECR_ACCOUNT, e2e-test/${{ github.event.repository.name }}/java-k8s-release-testing-account
+
+      - name: Retrieve K8s EC2 Secrets
+        if: ${{ env.CALLER_WORKFLOW_NAME != 'k8s-os-patching' }}
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        with:
+          secret-ids: |
             MAIN_SERVICE_ENDPOINT, e2e-test/${{ github.event.repository.name }}/java-k8s-master-node-endpoint
             MASTER_NODE_SSH_KEY, e2e-test/${{ github.event.repository.name }}/java-k8s-ssh-key
+
+      - name: Retrieve K8s EC2 OS Patching Secrets
+        if: ${{ env.CALLER_WORKFLOW_NAME == 'k8s-os-patching' }}
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        with:
+          secret-ids: |
+            MAIN_SERVICE_ENDPOINT, e2e-test/${{ env.CALLER_REPOSITORY }}/java-k8s-master-node-endpoint-pending-value
+            MASTER_NODE_SSH_KEY, e2e-test/${{ env.CALLER_REPOSITORY }}/java-k8s-ssh-key-pending-value
 
       - name: Prepare and upload sample app deployment files
         working-directory: terraform/java/k8s/deploy/resources
@@ -99,8 +117,8 @@ jobs:
           sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.JAVA_MAIN_SAMPLE_APP_IMAGE }}#' frontend-service-depl.yaml
           sed -i 's#\${TESTING_ID}#${{ env.TESTING_ID }}#' remote-service-depl.yaml
           sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.JAVA_REMOTE_SAMPLE_APP_IMAGE }}#' remote-service-depl.yaml
-          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key frontend-service-depl-${{ github.event.repository.name }}.yaml --body frontend-service-depl.yaml
-          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key remote-service-depl-${{ github.event.repository.name }}.yaml --body remote-service-depl.yaml
+          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key frontend-service-depl-${{ env.TESTING_ID }}.yaml --body frontend-service-depl.yaml
+          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key remote-service-depl-${{ env.TESTING_ID }}.yaml --body remote-service-depl.yaml
 
       - name: Set up terraform
         uses: ./.github/workflows/actions/execute_and_retry

--- a/.github/workflows/k8s-patch-os-jobs.yml
+++ b/.github/workflows/k8s-patch-os-jobs.yml
@@ -1,11 +1,11 @@
 # The EC2 AMI for K8s needs to be updated to prevent it from becoming outdated. This workflow will run in the beginning of every month to replace the existing
 # instances with new ones
-name: Update K8s EC2 Instance
+name: K8s Patch OS Job
 
 on:
   workflow_call:
     inputs:
-      repo:
+      repo_name:
         required: true
         type: string
       ec2_name:
@@ -20,7 +20,7 @@ permissions:
   contents: read
 
 env:
-  REPO: ${{ inputs.repo }}
+  REPO: ${{ inputs.repo_name }}
   EC2_NAME: ${{ inputs.ec2_name }}
   LANGUAGE:  ${{ inputs.language }}
   E2E_TEST_AWS_REGION: us-east-1
@@ -65,9 +65,9 @@ jobs:
 
 
             if aws secretsmanager describe-secret --secret-id $SECRET_NAME; then
-              echo "Success: The secret exists."
+              echo "Secret $SECRET_NAME already exists."
             else
-              echo "Secret does not exist. Creating new secret"
+              echo "Secret $SECRET_NAME does not exist. Creating it now"
               aws secretsmanager create-secret --name $SECRET_NAME --secret-string "empty"
             fi
           done
@@ -100,7 +100,7 @@ jobs:
     with:
       aws-region: 'us-east-1'
       caller-workflow-name: 'k8s-os-patching'
-      caller-repository: ${{ inputs.repo }}
+      caller-repository: ${{ inputs.repo_name }}
 
   run-python-k8s-test:
     if: ${{ inputs.LANGUAGE == 'python' }}
@@ -110,7 +110,7 @@ jobs:
     with:
       aws-region: 'us-east-1'
       caller-workflow-name: 'k8s-os-patching'
-      caller-repository: ${{ inputs.repo }}
+      caller-repository: ${{ inputs.repo_name }}
 
   update-secrets:
     needs: [ run-java-k8s-test, run-python-k8s-test ]

--- a/.github/workflows/k8s-patch-os-jobs.yml
+++ b/.github/workflows/k8s-patch-os-jobs.yml
@@ -114,7 +114,7 @@ jobs:
 
   update-secrets:
     needs: [ run-java-k8s-test, run-python-k8s-test ]
-    if: ${{ always() }} && (needs.run-java-k8s-test.result == 'success' || needs.run-python-k8s-test.result == 'success')
+    if: ${{ always() && (needs.run-java-k8s-test.result == 'success' || needs.run-python-k8s-test.result == 'success') }}
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
@@ -161,4 +161,13 @@ jobs:
 #
 #          aws secretsmanager update-secret --secret-id "${CURRENT_SECRET_KEYS[0]}" --secret-string $endpoint_secret
 #          aws secretsmanager update-secret --secret-id "${CURRENT_SECRET_KEYS[1]}" --secret-string "$ssh_secret"
-          
+
+  publish-metric:
+    needs: [ update-secrets ]
+    if: always()
+    uses: ./.github/workflows/enablement-test-publish-result.yml
+    secrets: inherit
+    with:
+      aws-region: 'us-east-1'
+      caller-workflow-name: 'enablement-test-k8s-patch-os'
+      validation-result: ${{ needs.update-secrets.result }}

--- a/.github/workflows/k8s-patch-os-jobs.yml
+++ b/.github/workflows/k8s-patch-os-jobs.yml
@@ -1,0 +1,164 @@
+# The EC2 AMI for K8s needs to be updated to prevent it from becoming outdated. This workflow will run in the beginning of every month to replace the existing
+# instances with new ones
+name: Update K8s EC2 Instance
+
+on:
+  workflow_call:
+    inputs:
+      repo:
+        required: true
+        type: string
+      ec2_name:
+        required: true
+        type: string
+      language:
+        required: true
+        type: string      
+      
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  REPO: ${{ inputs.repo }}
+  EC2_NAME: ${{ inputs.ec2_name }}
+  LANGUAGE:  ${{ inputs.language }}
+  E2E_TEST_AWS_REGION: us-east-1
+  E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
+  E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
+
+jobs:
+  create-k8s-on-ec2:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Testing ID
+        run: |
+          echo TESTING_ID="${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.E2E_TEST_ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
+          aws-region: us-east-1
+
+      - name: Create New K8s on EC2
+        working-directory: .github/workflows/util
+        run: |
+          ./setup-k8s.sh ${{ env.TESTING_ID }} ${{ env.EC2_NAME }}-${{ env.LANGUAGE }} ${{ env.E2E_TEST_AWS_REGION }}
+
+      - name: Check if Secret Key Already Exist and If Not Create New Ones
+        run: |
+          SECRET_NAMES=(
+            "e2e-test/${{ env.REPO }}/${{ env.LANGUAGE }}-k8s-master-node-endpoint-pending-value"
+            "e2e-test/${{ env.REPO }}/${{ env.LANGUAGE }}-k8s-ssh-key-pending-value"
+            "e2e-test/${{ env.REPO }}/${{ env.LANGUAGE }}-k8s-master-node-endpoint"
+            "e2e-test/${{ env.REPO }}/${{ env.LANGUAGE }}-k8s-ssh-key"
+            "e2e-test/${{ env.REPO }}/${{ env.LANGUAGE }}-k8s-master-node-endpoint-temporary-storage"
+            "e2e-test/${{ env.REPO }}/${{ env.LANGUAGE }}-k8s-ssh-key-temporary-storage"
+          )
+
+          for SECRET_NAME in "${SECRET_NAMES[@]}"; do
+            echo "Checking secret: $SECRET_NAME"
+
+
+            if aws secretsmanager describe-secret --secret-id $SECRET_NAME; then
+              echo "Success: The secret exists."
+            else
+              echo "Secret does not exist. Creating new secret"
+              aws secretsmanager create-secret --name $SECRET_NAME --secret-string "empty"
+            fi
+          done
+
+
+      - name: Save Private Key and Master Public Endpoint to Secret Manager
+        working-directory: .github/workflows/util
+        run: |
+          SECRET_NAMES=(
+            "e2e-test/${{ env.REPO }}/${{ env.LANGUAGE }}-k8s-master-node-endpoint-pending-value"
+            "e2e-test/${{ env.REPO }}/${{ env.LANGUAGE }}-k8s-ssh-key-pending-value"
+          )
+
+          private_key_file=k8s-on-ec2-${{ env.EC2_NAME }}-${{ env.LANGUAGE }}-key-pair-${{ env.TESTING_ID }}.pem
+          private_key_content=$(<"$private_key_file")
+
+          master_public_ip=$(aws ec2 describe-instances \
+            --filters "Name=tag:Name,Values=k8s-on-ec2-${{ env.EC2_NAME }}-${{ env.LANGUAGE }}-master-${{ env.TESTING_ID }}" "Name=instance-state-name,Values=running" \
+            --query "Reservations[*].Instances[*].PublicIpAddress" \
+            --output text)
+
+          aws secretsmanager update-secret --secret-id "${SECRET_NAMES[0]}" --secret-string $master_public_ip
+          aws secretsmanager update-secret --secret-id "${SECRET_NAMES[1]}" --secret-string "$private_key_content"
+  
+  run-java-k8s-test:
+    if: ${{ inputs.LANGUAGE == 'java' || inputs.LANGUAGE == 'all' }}
+    needs: create-k8s-on-ec2
+    uses: ./.github/workflows/java-k8s-e2e-test.yml
+    secrets: inherit
+    with:
+      aws-region: 'us-east-1'
+      caller-workflow-name: 'k8s-os-patching'
+      caller-repository: ${{ inputs.repo }}
+
+  run-python-k8s-test:
+    if: ${{ inputs.LANGUAGE == 'python' }}
+    needs: create-k8s-on-ec2
+    uses: ./.github/workflows/python-k8s-e2e-test.yml
+    secrets: inherit
+    with:
+      aws-region: 'us-east-1'
+      caller-workflow-name: 'k8s-os-patching'
+      caller-repository: ${{ inputs.repo }}
+
+  update-secrets:
+    needs: [ run-java-k8s-test, run-python-k8s-test ]
+    if: ${{ always() }} && (needs.run-java-k8s-test.result == 'success' || needs.run-python-k8s-test.result == 'success')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.E2E_TEST_ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
+          aws-region: us-east-1
+
+      - name: Copy the current endpoint and ssh key to storage
+        run: |         
+          STORAGE_SECRET_KEYS=(
+            "e2e-test/${{ env.REPO }}/${{ env.LANGUAGE }}-k8s-master-node-endpoint-temporary-storage"
+            "e2e-test/${{ env.REPO }}/${{ env.LANGUAGE }}-k8s-ssh-key-temporary-storage"
+          )
+          
+          CURRENT_SECRET_KEYS=(
+            "e2e-test/${{ env.REPO }}/${{ env.LANGUAGE }}-k8s-master-node-endpoint"
+            "e2e-test/${{ env.REPO }}/${{ env.LANGUAGE }}-k8s-ssh-key"
+          )
+          
+          endpoint_secret=$(aws secretsmanager get-secret-value --secret-id "${CURRENT_SECRET_KEYS[0]}" --query SecretString --output text)
+          ssh_secret=$(aws secretsmanager get-secret-value --secret-id "${CURRENT_SECRET_KEYS[1]}" --query SecretString --output text)
+          
+          aws secretsmanager update-secret --secret-id "${STORAGE_SECRET_KEYS[0]}" --secret-string $endpoint_secret
+          aws secretsmanager update-secret --secret-id "${STORAGE_SECRET_KEYS[1]}" --secret-string "$ssh_secret"
+
+#      - name: Replace current endpoint and ssh key with the newly created ones
+#        run: |
+#          PENDING_SECRET_KEYS=(
+#            "e2e-test/${{ env.REPO }}/${{ env.LANGUAGE }}-k8s-master-node-endpoint-pending-value"
+#            "e2e-test/${{ env.REPO }}/${{ env.LANGUAGE }}-k8s-ssh-key-pending-value"
+#          )
+#
+#          CURRENT_SECRET_KEYS=(
+#            "e2e-test/${{ env.REPO }}/${{ env.LANGUAGE }}-k8s-master-node-endpoint"
+#            "e2e-test/${{ env.REPO }}/${{ env.LANGUAGE }}-k8s-ssh-key"
+#          )
+#
+#          endpoint_secret=$(aws secretsmanager get-secret-value --secret-id "${PENDING_SECRET_KEYS[0]}" --query SecretString --output text)
+#          ssh_secret=$(aws secretsmanager get-secret-value --secret-id "${PENDING_SECRET_KEYS[1]}" --query SecretString --output text)
+#
+#          echo $endpoint_secret
+#          echo "$ssh_secret"
+#
+#          aws secretsmanager update-secret --secret-id "${CURRENT_SECRET_KEYS[0]}" --secret-string $endpoint_secret
+#          aws secretsmanager update-secret --secret-id "${CURRENT_SECRET_KEYS[1]}" --secret-string "$ssh_secret"
+          

--- a/.github/workflows/k8s-patch-os-matrix.yml
+++ b/.github/workflows/k8s-patch-os-matrix.yml
@@ -1,0 +1,35 @@
+# The EC2 AMI for K8s needs to be updated to prevent it from becoming outdated. This workflow will run in the beginning of every month to replace the existing
+# instances with new ones
+name: Update K8s EC2 Instance
+
+on:
+  schedule:
+    - cron: '0 0 1 * *' # run the workflow beginning of every month
+  workflow_dispatch: # be able to run the workflow on demand
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  k8s-patch-os:
+    strategy:
+      fail-fast: false
+      matrix:
+        instance: [
+          { repo: 'amazon-cloudwatch-agent-operator', ec2_name: 'cw-agent-operator-release', language: 'java' },
+          { repo: 'amazon-cloudwatch-agent-operator', ec2_name: 'cw-agent-operator-release', language: 'python' },
+          { repo: 'amazon-cloudwatch-agent', ec2_name: 'cw-agent-release', language: 'java' },
+          { repo: 'amazon-cloudwatch-agent', ec2_name: 'cw-agent-release', language: 'python' },
+          { repo: 'aws-otel-python-instrumentation', ec2_name: 'adot-python-release', language: 'python' },
+          { repo: 'aws-otel-java-instrumentation', ec2_name: 'adot-java-release', language: 'java' },
+          { repo: 'aws-application-signals-test-framework', ec2_name: 'python-canary', language: 'python' },
+          { repo: 'aws-application-signals-test-framework', ec2_name: 'java-canary', language: 'java' },
+          { repo: 'aws-application-signals-test-framework', ec2_name: 'e2e-playground', language: 'all' } ]
+    uses: ./.github/workflows/k8s-patch-os-jobs.yml
+    secrets: inherit
+    with:
+      repo: ${{ matrix.instance.repo }}
+      ec2_name: ${{ matrix.instance.ec2_name }}
+      language: ${{ matrix.instance.language }}
+

--- a/.github/workflows/k8s-patch-os-matrix.yml
+++ b/.github/workflows/k8s-patch-os-matrix.yml
@@ -1,6 +1,6 @@
 # The EC2 AMI for K8s needs to be updated to prevent it from becoming outdated. This workflow will run in the beginning of every month to replace the existing
 # instances with new ones
-name: Update K8s EC2 Instance
+name: K8s Patch OS Matrix
 
 on:
   schedule:

--- a/.github/workflows/python-k8s-test.yml
+++ b/.github/workflows/python-k8s-test.yml
@@ -14,6 +14,9 @@ on:
       caller-workflow-name:
         required: true
         type: string
+      caller-repository:
+        required: false
+        type: string
       adot-image-name:
         required: false
         type: string
@@ -33,6 +36,7 @@ permissions:
 env:
   E2E_TEST_AWS_REGION: ${{ inputs.aws-region }}
   CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
+  CALLER_REPOSITORY: ${{ inputs.caller-repository }}
   ADOT_IMAGE_NAME: ${{ inputs.adot-image-name }}
   CW_AGENT_OPERATOR_TAG: ${{ inputs.cw-agent-operator-tag }}
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
@@ -55,7 +59,7 @@ jobs:
         run: echo "job-started=true" >> $GITHUB_OUTPUT
 
       - name: Generate testing id
-        run: echo TESTING_ID="${{ env.E2E_TEST_AWS_REGION }}-${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
+        run: echo TESTING_ID="${{ github.run_id }}-${{ github.run_number }}-${RANDOM}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v4
         with:
@@ -81,7 +85,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ env.E2E_TEST_ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
           aws-region: us-east-1
 
-      - name: Retrieve account
+      - name: Retrieve Secrets
         uses: aws-actions/aws-secretsmanager-get-secrets@v1
         with:
           secret-ids: |
@@ -89,8 +93,22 @@ jobs:
             PYTHON_MAIN_SAMPLE_APP_IMAGE, e2e-test/python-main-sample-app-image
             PYTHON_REMOTE_SAMPLE_APP_IMAGE, e2e-test/python-remote-sample-app-image
             RELEASE_TESTING_ECR_ACCOUNT, e2e-test/${{ github.event.repository.name }}/python-k8s-release-testing-account
+
+      - name: Retrieve K8s EC2 Secrets
+        if: ${{ env.CALLER_WORKFLOW_NAME != 'k8s-os-patching' }}
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        with:
+          secret-ids: |
             MAIN_SERVICE_ENDPOINT, e2e-test/${{ github.event.repository.name }}/python-k8s-master-node-endpoint
             MASTER_NODE_SSH_KEY, e2e-test/${{ github.event.repository.name }}/python-k8s-ssh-key
+
+      - name: Retrieve K8s EC2 OS Patching Secrets
+        if: ${{ env.CALLER_WORKFLOW_NAME == 'k8s-os-patching' }}
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        with:
+          secret-ids: |
+            MAIN_SERVICE_ENDPOINT, e2e-test/${{ env.CALLER_REPOSITORY }}/python-k8s-master-node-endpoint-pending-value
+            MASTER_NODE_SSH_KEY, e2e-test/${{ env.CALLER_REPOSITORY }}/python-k8s-ssh-key-pending-value
 
       - name: Prepare and upload sample app deployment files
         working-directory: terraform/python/k8s/deploy/resources
@@ -99,8 +117,8 @@ jobs:
           sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.PYTHON_MAIN_SAMPLE_APP_IMAGE }}#' python-frontend-service-depl.yaml
           sed -i 's#\${TESTING_ID}#${{ env.TESTING_ID }}#' python-remote-service-depl.yaml
           sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.PYTHON_REMOTE_SAMPLE_APP_IMAGE }}#' python-remote-service-depl.yaml
-          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key python-frontend-service-depl-${{ github.event.repository.name }}.yaml --body python-frontend-service-depl.yaml
-          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key python-remote-service-depl-${{ github.event.repository.name }}.yaml --body python-remote-service-depl.yaml
+          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key python-frontend-service-depl-${{ env.TESTING_ID }}.yaml --body python-frontend-service-depl.yaml
+          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key python-remote-service-depl-${{ env.TESTING_ID }}.yaml --body python-remote-service-depl.yaml
 
       - name: Set up terraform
         uses: ./.github/workflows/actions/execute_and_retry
@@ -257,3 +275,10 @@ jobs:
         run: |
           terraform destroy -auto-approve \
             -var="test_id=${{ env.TESTING_ID }}"
+
+      - name: Delete deployment files
+        if: always()
+        continue-on-error: true
+        run: |
+          aws s3api delete-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key python-frontend-service-depl-${{ env.TESTING_ID }}.yaml
+          aws s3api delete-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key python-remote-service-depl-${{ env.TESTING_ID }}.yaml

--- a/.github/workflows/util/setup-k8s.sh
+++ b/.github/workflows/util/setup-k8s.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+set -ex 
+
+TESTING_ID=$1
+EC2_NAME=$2
+REGION=$3
+
+INSTANCE_PROFILE="APP_SIGNALS_EC2_TEST_ROLE"
+MASTER_INSTANCE_NAME="k8s-on-ec2-${EC2_NAME}-master-${TESTING_ID}"
+WORKER_INSTANCE_NAME="k8s-on-ec2-${EC2_NAME}-worker-${TESTING_ID}"
+KEY_NAME="k8s-on-ec2-${EC2_NAME}-key-pair-${TESTING_ID}"
+
+function create_resources() {
+    echo "Creating Key Pair"
+    aws ec2 create-key-pair --key-name "${KEY_NAME}" --query 'KeyMaterial' --output text > "${KEY_NAME}.pem"
+    chmod 400  "${KEY_NAME}.pem"
+
+    # Fetch the latest Amazon Linux 2 AMI ID
+    echo "Fetching Latest Image Id"
+    image_id=$(aws ec2 describe-images \
+      --region $REGION \
+      --owners amazon \
+      --filters "Name=name,Values=al2023-ami-minimal-*-x86_64" "Name=state,Values=available" \
+      --query 'Images | sort_by(@, &CreationDate) | [-1].ImageId' \
+      --output text)
+
+    default_vpc_id=$(aws ec2 describe-vpcs --filters Name=isDefault,Values=true --query 'Vpcs[0].VpcId' --output text)
+    security_group_id=$(aws ec2 describe-security-groups --filters "Name=vpc-id,Values=$default_vpc_id" "Name=group-name,Values=default" --query "SecurityGroups[0].GroupId" --output text)
+
+    # Create Master EC2 Instance
+    echo "Creating Master Instance"
+    master_instance_id=$(aws ec2 run-instances \
+      --image-id $image_id \
+      --count 1 \
+      --instance-type m5.xlarge \
+      --key-name $KEY_NAME \
+      --security-group-ids $security_group_id \
+      --iam-instance-profile Name=$INSTANCE_PROFILE \
+      --associate-public-ip-address \
+      --block-device-mappings 'DeviceName=/dev/xvda,Ebs={VolumeSize=80,VolumeType=gp3}' \
+      --metadata-options 'HttpPutResponseHopLimit=3,HttpEndpoint=enabled' \
+      --query 'Instances[0].InstanceId' \
+      --output text)
+
+    aws ec2 create-tags --resources $master_instance_id --tags Key=Name,Value=$MASTER_INSTANCE_NAME Key=k8s-on-ec2-node,Value=true
+
+    echo "Creating Worker Instance"
+    worker_instance_id=$(aws ec2 run-instances \
+      --image-id $image_id \
+      --count 1 \
+      --instance-type m5.xlarge \
+      --key-name $KEY_NAME \
+      --security-group-ids $security_group_id \
+      --iam-instance-profile Name=$INSTANCE_PROFILE \
+      --associate-public-ip-address \
+      --block-device-mappings 'DeviceName=/dev/xvda,Ebs={VolumeSize=80,VolumeType=gp3}' \
+      --metadata-options 'HttpPutResponseHopLimit=3,HttpEndpoint=enabled' \
+      --query 'Instances[0].InstanceId' \
+      --output text)
+
+    aws ec2 create-tags --resources $worker_instance_id --tags Key=Name,Value=$WORKER_INSTANCE_NAME Key=k8s-on-ec2-node,Value=true
+
+    echo "Wait for Master Instance $master_instance_id and Worker Instance $worker_instance_id to be ready"
+    aws ec2 wait instance-status-ok --instance-ids $master_instance_id
+    aws ec2 wait instance-status-ok --instance-ids $worker_instance_id
+    echo "All instances are up and running."
+}
+
+
+function run_k8s_master() {
+  # Retrieve public IP of k8s master node
+  master_ip=$(aws ec2 describe-instances \
+      --filters "Name=tag:Name,Values=$MASTER_INSTANCE_NAME" "Name=instance-state-name,Values=running" \
+      --query "Reservations[*].Instances[*].PublicIpAddress" \
+      --output text)
+
+  # SSH and run commands on the master node
+  master_private_ip=$(aws ec2 describe-instances \
+      --filters "Name=tag:Name,Values=$MASTER_INSTANCE_NAME" "Name=instance-state-name,Values=running" \
+      --query "Reservations[*].Instances[*].PrivateIpAddress" \
+      --output text)
+
+  worker_private_ip=$(aws ec2 describe-instances \
+      --filters "Name=tag:Name,Values=$WORKER_INSTANCE_NAME" "Name=instance-state-name,Values=running" \
+      --query "Reservations[*].Instances[*].PrivateIpAddress" \
+      --output text)
+
+  # set up kubeadmin
+  ssh -o StrictHostKeyChecking=no -i "${KEY_NAME}.pem" ec2-user@$master_ip << EOF
+    sudo yum update -y && sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+    sudo yum install docker tmux git vim -y && sudo usermod -aG docker ec2-user
+    sudo systemctl enable docker && sudo systemctl start docker
+    sudo containerd config default > config.toml
+    sudo cp config.toml /etc/containerd/config.toml
+    sudo sed -i 's/SystemdCgroup \= false/SystemdCgroup \= true/' /etc/containerd/config.toml
+    sudo sed -i 's/systemd_cgroup \= true/systemd_cgroup \= true/' /etc/containerd/config.toml
+    sudo systemctl restart containerd && sleep 20
+    sudo setenforce 0 && sudo sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
+    echo -e "[kubernetes]\nname=Kubernetes\nbaseurl=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/\nenabled=1\ngpgcheck=1\ngpgkey=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/repodata/repomd.xml.key\nexclude=kubelet kubeadm kubectl cri-tools kubernetes-cni" | sudo tee /etc/yum.repos.d/kubernetes.repo
+    sudo yum install -y kubelet kubeadm kubectl --disableexcludes=kubernetes
+    sudo systemctl enable --now kubelet && sudo systemctl restart kubelet && sleep 30
+    sudo kubeadm init --pod-network-cidr=192.168.0.0/16 --apiserver-advertise-address=$master_private_ip --apiserver-cert-extra-sans=$worker_private_ip
+    mkdir -p \$HOME/.kube
+    sudo cp -i /etc/kubernetes/admin.conf \$HOME/.kube/config
+    sudo chown \$(id -u):\$(id -g) \$HOME/.kube/config
+    sleep 120
+    curl https://raw.githubusercontent.com/projectcalico/calico/v3.27.2/manifests/calico.yaml -O
+    kubectl apply -f calico.yaml && sleep 60
+    sudo cd \$HOME
+    sudo cp /etc/kubernetes/pki/apiserver.crt apiserver.crt
+    sudo cp /etc/kubernetes/pki/apiserver.key apiserver.key
+    sudo chmod +r apiserver.key
+    sudo kubeadm token create --print-join-command > join-cluster.sh
+    sudo chmod +x join-cluster.sh
+    echo "tlsCertFile: /etc/kubernetes/pki/apiserver.crt" | sudo tee -a /var/lib/kubelet/config.yaml
+    echo "tlsPrivateKeyFile: /etc/kubernetes/pki/apiserver.key" | sudo tee -a /var/lib/kubelet/config.yaml
+    sudo systemctl restart kubelet
+EOF
+
+  scp -o StrictHostKeyChecking=no -i "${KEY_NAME}.pem" ec2-user@$master_ip:~/apiserver.crt . 
+  scp -o StrictHostKeyChecking=no -i "${KEY_NAME}.pem" ec2-user@$master_ip:~/apiserver.key . 
+  scp -o StrictHostKeyChecking=no -i "${KEY_NAME}.pem" ec2-user@$master_ip:~/join-cluster.sh . 
+
+}
+
+function run_k8s_worker() {
+  # Retrieve public IP of worker node
+  worker_ip=$(aws ec2 describe-instances \
+      --filters "Name=tag:Name,Values=$WORKER_INSTANCE_NAME" "Name=instance-state-name,Values=running" \
+      --query "Reservations[*].Instances[*].PublicIpAddress" \
+      --output text)
+
+  scp -o StrictHostKeyChecking=no -i "${KEY_NAME}.pem" apiserver.crt ec2-user@$worker_ip:~
+  scp -o StrictHostKeyChecking=no -i "${KEY_NAME}.pem" apiserver.key ec2-user@$worker_ip:~
+  scp -o StrictHostKeyChecking=no -i "${KEY_NAME}.pem" join-cluster.sh ec2-user@$worker_ip:~
+
+  # set up kubeadmin
+  ssh -o StrictHostKeyChecking=no -i "${KEY_NAME}.pem" ec2-user@$worker_ip << EOF
+    sudo yum update -y && sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+    sudo yum install docker tmux git vim -y && sudo usermod -aG docker ec2-user
+    sudo systemctl enable docker && sudo systemctl start docker &&  \
+    sudo containerd config default > config.toml
+    sudo cp config.toml /etc/containerd/config.toml
+    sudo sed -i 's/SystemdCgroup \= false/SystemdCgroup \= true/' /etc/containerd/config.toml
+    sudo sed -i 's/systemd_cgroup \= true/systemd_cgroup \= true/' /etc/containerd/config.toml
+    sudo systemctl restart containerd
+    sudo setenforce 0 && sudo sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
+    echo -e "[kubernetes]\nname=Kubernetes\nbaseurl=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/\nenabled=1\ngpgcheck=1\ngpgkey=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/repodata/repomd.xml.key\nexclude=kubelet kubeadm kubectl cri-tools kubernetes-cni" | sudo tee /etc/yum.repos.d/kubernetes.repo
+    sleep 60
+    sudo yum install -y kubelet kubeadm kubectl --disableexcludes=kubernetes
+    sudo mkdir -p /etc/kubernetes/pki/
+    sudo cp apiserver.crt /etc/kubernetes/pki/apiserver.crt
+    sudo cp apiserver.key /etc/kubernetes/pki/apiserver.key
+    sudo bash join-cluster.sh && sleep 30
+    echo "tlsCertFile: /etc/kubernetes/pki/apiserver.crt" | sudo tee -a /var/lib/kubelet/config.yaml
+    echo "tlsPrivateKeyFile: /etc/kubernetes/pki/apiserver.key" | sudo tee -a /var/lib/kubelet/config.yaml
+    sudo systemctl restart kubelet
+EOF
+
+sleep 300
+}
+
+function install_helm() {
+  # Retrieve public IP of master node
+  master_ip=$(aws ec2 describe-instances \
+      --filters "Name=tag:Name,Values=$MASTER_INSTANCE_NAME" "Name=instance-state-name,Values=running" \
+      --query "Reservations[*].Instances[*].PublicIpAddress" \
+      --output text)
+
+  ssh -o StrictHostKeyChecking=no -i "${KEY_NAME}.pem" ec2-user@$master_ip << EOF
+    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.yaml
+    curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+    chmod 700 get_helm.sh
+    ./get_helm.sh && sleep 30
+    sudo yum install wget -y && \
+    sudo wget https://github.com/mikefarah/yq/releases/download/v4.31.2/yq_linux_amd64 -O /usr/bin/yq && \
+    sudo chmod +x /usr/bin/yq
+EOF
+
+}
+
+create_resources
+run_k8s_master
+run_k8s_worker
+install_helm


### PR DESCRIPTION
*Issue description:*
The EC2 AMI has an expiry date. Since our K8s on EC2 are designed to last indefinitely, eventually we will have the update the AMI. This PR aims to automate updating the AMIs without any manual interference. This will involve creating a new EC2 instance and taking down the old one

[Part 1](https://github.com/aws-observability/aws-application-signals-test-framework/pull/191): Create a new K8s on EC2 and test it
[Part 2](https://github.com/aws-observability/aws-application-signals-test-framework/compare/k8s-automation-part-2?expand=1): Verify that the instances were created properly and no impact on existing K8s, then replace the K8s

*Description of changes:*
**k8s-patch-os-matrix.yml**
Define all K8s on EC2s instances including the ones for canary as well as release testing. Any new K8s on EC2s will be defined here. It will update the AMI every month

**k8s-patch-os-jobs.yml**
1. Run a script that was copied and modified from [here](https://github.com/aws-observability/application-signals-demo/blob/main/scripts/k8s/appsignals/setup-k8s-demo.sh). Creates new key pair and two ec2 instances, which will have kubernetes installed
2. Store the newly created public ip and private ssh key in a secret key called `-pending-value`. Do not store it in the main secret yet because we want to make sure that our K8s test passes before updating the main secret key. 
3. Run K8s E2E test on newly created instance and verify it succeeds. All tests have been figured to use the release artifacts, including the ones for release testing since we don't want the test to fail due to invalid staging artifacts
4. Save main secret values onto a key called `-temporary-storage` then replace the main secret values with the newly created ones. This is so that in case of issues with the new k8s, we can find the original values and revert it back

Testing Id for K8s was updated to give a random value because all the K8s tests run under the same run id and job id is not retrievable in Github Action. Needed a way to distinguish between different runs or the validators will not be able to tell which telemetry to retrieve

Updated the ssm parameter key to use testing id instead of repository to make it unique to each run

*Rollback procedure:*
Revert PR, newly created EC2 instances will not affect canary. Make sure that the main secret keys were not altered. 

*Test*
Test run: https://github.com/harrryr/aws-application-signals-test-framework/actions/runs/10574639963
Test run on canary k8s: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10593567350

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
