### PR TITLE
Add cleanup step for k8s

### DIFF
--- a/.github/workflows/k8s-outdated-cleanup.yml
+++ b/.github/workflows/k8s-outdated-cleanup.yml
@@ -1,0 +1,69 @@
+# The EC2 AMI for K8s needs to be updated to prevent it from becoming outdated. This workflow will run in the beginning of every month to replace the existing
+# instances with new ones
+name: Update K8s EC2 Instance
+
+on:
+  schedule:
+    - cron: '0 0 7 * *' # run the workflow beginning of every month
+  workflow_dispatch: # be able to run the workflow on demand
+#  push:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  clean-up-old-k8s:
+    strategy:
+      fail-fast: false
+      matrix:
+        instance: [
+          { repo: 'amazon-cloudwatch-agent-operator', ec2_name: 'cw-agent-operator-release', language: 'java' },
+          { repo: 'amazon-cloudwatch-agent-operator', ec2_name: 'cw-agent-operator-release', language: 'python' },
+          { repo: 'amazon-cloudwatch-agent', ec2_name: 'cw-agent-release', language: 'java' },
+          { repo: 'amazon-cloudwatch-agent', ec2_name: 'cw-agent-release', language: 'python' },
+          { repo: 'aws-otel-python-instrumentation', ec2_name: 'adot-python-release', language: 'python' },
+          { repo: 'aws-otel-java-instrumentation', ec2_name: 'adot-java-release', language: 'java' },
+          { repo: 'aws-application-signals-test-framework', ec2_name: 'python-canary', language: 'python' },
+          { repo: 'aws-application-signals-test-framework', ec2_name: 'java-canary', language: 'java' } ]
+    runs-on: ubuntu
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.E2E_TEST_ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
+          aws-region: us-east-1
+
+      - name: Delete Key Pair and EC2 Instance
+        run: |
+          STORAGE_SECRET_KEYS=(
+            "e2e-test/${{ env.REPO }}/${{ env.LANGUAGE }}-k8s-master-node-endpoint-temporary-storage"
+          )
+
+          endpoint_secret=$(aws secretsmanager get-secret-value --secret-id "${CURRENT_SECRET_KEYS[0]}" --query SecretString --output text)
+
+          instance_name=$(aws ec2 describe-instances \
+            --filters "Name=ip-address,Values=$public_ip" \
+            --query "Reservations[*].Instances[*].{Name:Tags[?Key=='Name']|[0].Value}" \
+            --output text)
+
+          prev_testing_id=$(echo $instance_name | awk -F'-' '{print $(NF-1)"-"$NF}')
+          
+          aws ec2 delete-key-pair --key-name "k8s-on-ec2-${{ matrix.instance.ec2_name }}-${{ matrix.instance.language }}-key-pair-$prev_testing_id"
+          
+          main_instance_name=k8s-on-ec2-${{ matrix.instance.ec2_name }}-${{ matrix.instance.language }}-master-$prev_testing_id
+          worker_instance_name=k8s-on-ec2-${{ matrix.instance.ec2_name }}-${{ matrix.instance.language }}-worker-$prev_testing_id
+
+          main_instance_id=$(aws ec2 describe-instances \
+          --filters "Name=tag:Name,Values=$main_instance_name" \
+          --query "Reservations[*].Instances[*].InstanceId" \
+          --output text)
+          
+          worker_instance_id=$(aws ec2 describe-instances \
+          --filters "Name=tag:Name,Values=$worker_instance_name" \
+          --query "Reservations[*].Instances[*].InstanceId" \
+          --output text)
+          
+          aws ec2 terminate-instances --instance-ids $main_instance_id
+          aws ec2 terminate-instances --instance-ids $worker_instance_id
+


### PR DESCRIPTION
*Issue description:*
The EC2 AMI has an expiry date. Since our K8s on EC2 are designed to last indefinitely, eventually we will have the update the AMI. This PR aims to automate updating the AMIs without any manual interference. This will involve creating a new EC2 instance and taking down the old one

[Part 1](https://github.com/aws-observability/aws-application-signals-test-framework/pull/191): Create a new K8s on EC2 and test it
[Part 2](https://github.com/aws-observability/aws-application-signals-test-framework/compare/k8s-automation-part-2?expand=1): Verify that the instances were created properly and no impact on existing K8s, then replace the K8s
[Part 3](https://github.com/aws-observability/aws-application-signals-test-framework/compare/k8s-automation-part-3?expand=1): Clean up the old K8s

*Description of changes:*
Added a workflow that will run on the 7th of every month. In case of issues with K8s due to the new instances, this will give on-call enough bandwidth to fix the issue and also revert the secrets back to the original values if necessary. 

This will delete the EC2 key pair and also old EC2 instances

*Rollback procedure:*
If the EC2 key pair and EC2 instances are deleted, this is not revertible

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
