### PR TITLE
Uncomment K8s Cluster Cleanup

### DIFF
--- a/.github/workflows/util/clean/k8s_cluster_cleanup/cleaner.py
+++ b/.github/workflows/util/clean/k8s_cluster_cleanup/cleaner.py
@@ -196,6 +196,6 @@ if __name__ == '__main__':
         logging.error("Failed to prepare report and upload. Aborting resource clean up.")
         exit(1)
 
-#     if len(k8s_instances) > 0:
-#         logging.info("Terminating K8s instances...")
-#         _terminate_k8s_instances(k8s_instances)
+    if len(k8s_instances) > 0:
+        logging.info("Terminating K8s instances...")
+        _terminate_k8s_instances(k8s_instances)


### PR DESCRIPTION
*Issue description:*
Checked that the .json generated by the k8s cluster cleanup script holds the proper EC2s. Will now uncomment the terminate script so that the K8s clusters actually gets deleted

*Rollback procedure:*
Revert PR, then run the k8s automation script if the K8s clusters were deleted


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
