### PR TITLE
[Node/EC2] Canary/release test creation

### DIFF
--- a/.github/workflows/node-ec2-asg-test.yml
+++ b/.github/workflows/node-ec2-asg-test.yml
@@ -1,0 +1,303 @@
+## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+
+# This is a reusable workflow for running the E2E test for App Signals.
+# It is meant to be called from another workflow.
+# Read more about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview
+name: Node EC2 ASG Use Case
+on:
+  workflow_call:
+    inputs:
+      aws-region:
+        required: true
+        type: string
+      caller-workflow-name:
+        required: true
+        type: string
+      staging-instrumentation-name:
+        required: false
+        default: 'aws-opentelemetry-distro'
+        type: string
+    outputs:
+      job-started:
+        value: ${{ jobs.node-ec2-asg.outputs.job-started }}
+      validation-result:
+        value: ${{ jobs.node-ec2-asg.outputs.validation-result }}
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  E2E_TEST_AWS_REGION: ${{ inputs.aws-region }}
+  CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
+  ADOT_INSTRUMENTATION_NAME: ${{ inputs.staging-instrumentation-name }}
+  SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/node-sample-app.zip
+  E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
+  E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
+  METRIC_NAMESPACE: ApplicationSignals
+  LOG_GROUP_NAME: /aws/application-signals/data
+  TEST_RESOURCES_FOLDER: ${GITHUB_WORKSPACE}
+
+jobs:
+  node-ec2-asg:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      job-started: ${{ steps.job-started.outputs.job-started }}
+      validation-result: ${{ steps.validation-result.outputs.validation-result }}
+    steps:
+      - name: Check if the job started
+        id: job-started
+        run: echo "job-started=true" >> $GITHUB_OUTPUT
+
+      - name: Generate testing id
+        run: echo TESTING_ID="${{ github.job }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v4
+        with:
+          repository: 'aws-observability/aws-application-signals-test-framework'
+          ref: ${{ env.CALLER_WORKFLOW_NAME == 'main-build' && 'main' || github.ref }}
+          fetch-depth: 0
+
+      # We initialize Gradlew Daemon early on during the workflow because sometimes initialization
+      # fails due to transient issues. If it fails here, then we will try again later before the validators
+      - name: Initiate Gradlew Daemon
+        id: initiate-gradlew
+        uses: ./.github/workflows/actions/execute_and_retry
+        continue-on-error: true
+        with:
+          command: "./gradlew :validator:build"
+          cleanup: "./gradlew clean"
+          max_retry: 3
+          sleep_time: 60
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.E2E_TEST_ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
+          aws-region: us-east-1
+
+      - name: Retrieve account
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        with:
+          secret-ids: |
+            ACCOUNT_ID, region-account/${{ env.E2E_TEST_AWS_REGION }}
+
+      # If the workflow is running as a canary, then we want to log in to the aws account in the appropriate region
+      - name: Configure AWS Credentials
+        if: ${{ github.event.repository.name == 'aws-application-signals-test-framework' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
+          aws-region: ${{ env.E2E_TEST_AWS_REGION }}
+
+      # TODO: Remove the following step once release testing is ready
+      - name: TEMPORARY TEST CONFIGS
+        run: |
+          echo ADOT_INSTRUMENTATION_NAME="aws-aws-distro-opentelemetry-node-autoinstrumentation-0.0.1.tgz" >> $GITHUB_ENV
+
+      - name: Set Get ADOT Instrumentation command environment variable
+        run: |
+          echo GET_ADOT_INSTRUMENTATION_COMMAND="aws s3 cp s3://adot-autoinstrumentation-node-staging/${{ env.ADOT_INSTRUMENTATION_NAME }} ./${{ env.ADOT_INSTRUMENTATION_NAME }} && npm install ${{ env.ADOT_INSTRUMENTATION_NAME }}" >> $GITHUB_ENV
+        # TODO: Reintroduce release testing logic when artifacts are ready
+        # if [ "${{ github.event.repository.name }}" = "aws-otel-js-instrumentation" ]; then
+        #   echo GET_ADOT_INSTRUMENTATION_COMMAND="aws s3 cp s3://adot-autoinstrumentation-node-staging/${{ env.ADOT_INSTRUMENTATION_NAME }} ./${{ env.ADOT_INSTRUMENTATION_NAME }} && npm install ${{ env.ADOT_INSTRUMENTATION_NAME }}" >> $GITHUB_ENV
+        # else
+        #   echo GET_ADOT_INSTRUMENTATION_COMMAND="npm install ${{ env.ADOT_INSTRUMENTATION_NAME }}" >> $GITHUB_ENV
+        # fi
+
+      - name: Set Get CW Agent command environment variable
+        run: |
+          if [ "${{ github.event.repository.name }}" = "amazon-cloudwatch-agent" ]; then
+            echo GET_CW_AGENT_RPM_COMMAND="aws s3 cp s3://${{ secrets.S3_INTEGRATION_BUCKET }}/integration-test/binary/${{ github.sha }}/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm ./cw-agent.rpm" >> $GITHUB_ENV
+          else
+            echo GET_CW_AGENT_RPM_COMMAND="wget -O cw-agent.rpm https://amazoncloudwatch-agent-${{ env.E2E_TEST_AWS_REGION }}.s3.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm" >> $GITHUB_ENV
+          fi
+
+      - name: Set up terraform
+        uses: ./.github/workflows/actions/execute_and_retry
+        with:
+          command: "wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg"
+          post-command: 'echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+              && sudo apt update && sudo apt install terraform'
+          sleep_time: 60
+
+      - name: Initiate Terraform
+        uses: ./.github/workflows/actions/execute_and_retry
+        with:
+          command: "cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/node/ec2/asg && terraform init && terraform validate"
+          cleanup: "rm -rf .terraform && rm -rf .terraform.lock.hcl"
+          max_retry: 6
+          sleep_time: 60
+
+      - name: Deploy sample app via terraform and wait for endpoint to come online
+        working-directory: terraform/node/ec2/asg
+        run: |
+          # Attempt to deploy the sample app on an EC2 instance and wait for its endpoint to come online.
+          # There may be occasional failures due to transitivity issues, so try up to 2 times.
+          # deployment_failed of 0 indicates that both the terraform deployment and the endpoint are running, while 1 indicates
+          # that it failed at some point
+          retry_counter=0
+          max_retry=2
+          while [ $retry_counter -lt $max_retry ]; do
+            echo "Attempt $retry_counter"
+            deployment_failed=0
+            terraform apply -auto-approve \
+              -var="aws_region=${{ env.E2E_TEST_AWS_REGION }}" \
+              -var="test_id=${{ env.TESTING_ID }}" \
+              -var="sample_app_zip=${{ env.SAMPLE_APP_ZIP }}" \
+              -var="get_cw_agent_rpm_command=${{ env.GET_CW_AGENT_RPM_COMMAND }}" \
+              -var="get_adot_instrumentation_command=${{ env.GET_ADOT_INSTRUMENTATION_COMMAND }}" \
+            || deployment_failed=$?
+
+            if [ $deployment_failed -eq 1 ]; then
+              echo "Terraform deployment was unsuccessful. Will attempt to retry deployment."
+            fi
+
+            # If the success is 1 then either the terraform deployment or the endpoint connection failed, so first destroy the
+            # resources created from terraform and try again.
+            if [ $deployment_failed -eq 1 ]; then
+              echo "Destroying terraform"
+              terraform destroy -auto-approve \
+                -var="test_id=${{ env.TESTING_ID }}"
+
+              retry_counter=$(($retry_counter+1))
+            else
+              # If deployment succeeded, then exit the loop
+              break
+            fi
+
+            if [ $retry_counter -eq $max_retry ]; then
+              echo "Max retry reached, failed to deploy terraform and connect to the endpoint. Exiting code"
+              exit 1
+            fi
+          done
+
+      - name: Wait for ASG instance to be ready
+        run: |
+          # Wait for up to 15 minutes
+          retry_counter=0
+          max_retry=90
+          while [ $retry_counter -lt $max_retry ]; do
+            instance_id=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names ec2-single-asg-${{ env.TESTING_ID }} --region ${{ env.E2E_TEST_AWS_REGION }} --query "AutoScalingGroups[].Instances[0].InstanceId" --output text)
+            status_ok=$(aws ec2 describe-instance-status --instance-ids $instance_id | jq '(.InstanceStatuses[] | select(.InstanceStatus.Status == "ok" and .SystemStatus.Status == "ok")) != {}')
+
+            if [ "$status_ok" == "true" ]; then
+              echo "The instance $instance_id is ready."
+              echo "MAIN_SERVICE_INSTANCE_ID=$instance_id" >> $GITHUB_ENV
+              break
+            fi
+
+            if [ $retry_counter -eq $max_retry ]; then
+              echo "Instance Id $instance_id did not become ready with status $status_ok"
+              exit 1
+            fi
+
+            sleep 10
+          done
+
+      - name: Get the sample app and EC2 instance information
+        working-directory: terraform/node/ec2/asg
+        run: |
+          main_service_private_dns_name=$(aws ec2 describe-instances --instance-ids ${{ env.MAIN_SERVICE_INSTANCE_ID }} --region ${{ env.E2E_TEST_AWS_REGION }} --query "Reservations[].Instances[].PrivateDnsName" --output text)
+          echo "MAIN_SERVICE_ENDPOINT=localhost:8000" >> $GITHUB_ENV
+          echo "PRIVATE_DNS_NAME=$main_service_private_dns_name" >> $GITHUB_ENV
+          echo "EC2_INSTANCE_AMI=$(terraform output ec2_instance_ami)" >> $GITHUB_ENV
+          echo "REMOTE_SERVICE_IP=$(terraform output sample_app_remote_service_private_ip)" >> $GITHUB_ENV
+
+      - name: Initiate Gradlew Daemon
+        if: steps.initiate-gradlew == 'failure'
+        uses: ./.github/workflows/actions/execute_and_retry
+        continue-on-error: true
+        with:
+          command: "./gradlew :validator:build"
+          cleanup: "./gradlew clean"
+          max_retry: 3
+          sleep_time: 60
+
+      # Validation for pulse telemetry data
+      - name: Validate generated EMF logs
+        id: log-validation
+        run: ./gradlew validator:run --args='-c node/ec2/asg/log-validation.yml
+          --testing-id ${{ env.TESTING_ID }}
+          --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
+          --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8001
+          --region ${{ env.E2E_TEST_AWS_REGION }}
+          --account-id ${{ env.ACCOUNT_ID }}
+          --metric-namespace ${{ env.METRIC_NAMESPACE }}
+          --log-group ${{ env.LOG_GROUP_NAME }}
+          --service-name node-sample-application-${{ env.TESTING_ID }}
+          --remote-service-name node-sample-remote-application-${{ env.TESTING_ID }}
+          --instance-ami ${{ env.EC2_INSTANCE_AMI }}
+          --platform-info ec2-single-asg-${{ env.TESTING_ID }}
+          --instance-id ${{ env.MAIN_SERVICE_INSTANCE_ID }}
+          --private-dns-name ${{ env.PRIVATE_DNS_NAME }}
+          --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
+          --rollup'
+
+      - name: Validate generated metrics
+        id: metric-validation
+        if: (success() || steps.log-validation.outcome == 'failure') && !cancelled()
+        run: ./gradlew validator:run --args='-c node/ec2/asg/metric-validation.yml
+          --testing-id ${{ env.TESTING_ID }}
+          --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
+          --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8001
+          --region ${{ env.E2E_TEST_AWS_REGION }}
+          --account-id ${{ env.ACCOUNT_ID }}
+          --metric-namespace ${{ env.METRIC_NAMESPACE }}
+          --log-group ${{ env.LOG_GROUP_NAME }}
+          --service-name node-sample-application-${{ env.TESTING_ID }}
+          --remote-service-name node-sample-remote-application-${{ env.TESTING_ID }}
+          --instance-ami ${{ env.EC2_INSTANCE_AMI }}
+          --platform-info ec2-single-asg-${{ env.TESTING_ID }}
+          --instance-id ${{ env.MAIN_SERVICE_INSTANCE_ID }}
+          --private-dns-name ${{ env.PRIVATE_DNS_NAME }}
+          --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
+          --rollup'
+
+      - name: Validate generated traces
+        id: trace-validation
+        if: (success() || steps.log-validation.outcome == 'failure' || steps.metric-validation.outcome == 'failure') && !cancelled()
+        run: ./gradlew validator:run --args='-c node/ec2/asg/trace-validation.yml
+          --testing-id ${{ env.TESTING_ID }}
+          --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
+          --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}
+          --region ${{ env.E2E_TEST_AWS_REGION }}
+          --account-id ${{ env.ACCOUNT_ID }}
+          --metric-namespace ${{ env.METRIC_NAMESPACE }}
+          --log-group ${{ env.LOG_GROUP_NAME }}
+          --service-name node-sample-application-${{ env.TESTING_ID }}
+          --remote-service-name node-sample-remote-application-${{ env.TESTING_ID }}
+          --instance-ami ${{ env.EC2_INSTANCE_AMI }}
+          --platform-info ec2-single-asg-${{ env.TESTING_ID }}
+          --instance-id ${{ env.MAIN_SERVICE_INSTANCE_ID }}
+          --private-dns-name ${{ env.PRIVATE_DNS_NAME }}
+          --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
+          --rollup'
+
+      - name: Refresh AWS Credentials
+        if: ${{ github.event.repository.name == 'aws-application-signals-test-framework' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
+          aws-region: ${{ env.E2E_TEST_AWS_REGION }}
+
+      - name: Save test results
+        if: always()
+        id: validation-result
+        run: |
+          if [ "${{ steps.log-validation.outcome }}" = "success" ] && [ "${{ steps.metric-validation.outcome }}" = "success" ] && [ "${{ steps.trace-validation.outcome }}" = "success" ]; then
+            echo "validation-result=success" >> $GITHUB_OUTPUT
+          else
+            echo "validation-result=failure" >> $GITHUB_OUTPUT
+          fi
+
+      # Clean up Procedures
+      - name: Terraform destroy
+        if: always()
+        continue-on-error: true
+        working-directory: terraform/node/ec2/asg
+        run: |
+          terraform destroy -auto-approve \
+            -var="test_id=${{ env.TESTING_ID }}"

--- a/.github/workflows/node-ec2-canary.yml
+++ b/.github/workflows/node-ec2-canary.yml
@@ -1,0 +1,32 @@
+## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+
+## This workflow aims to run the Application Signals end-to-end tests as a canary to
+## test the artifacts for App Signals enablement. It will deploy a sample app and remote
+## service on two EC2 instances, call the APIs, and validate the generated telemetry,
+## including logs, metrics, and traces.
+name: Node EC2 Enablement Canary Testing
+on:
+  schedule:
+    - cron: '*/15 * * * *' # run the workflow every 15 minutes
+  workflow_dispatch: # be able to run the workflow on demand
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  default:
+    strategy:
+      fail-fast: false
+      matrix:
+        aws-region: [ 'us-east-1' ]
+        # aws-region: ['af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
+        #              'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
+        #              'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+        #              'us-east-1','us-east-2', 'us-west-1', 'us-west-2']
+    uses: ./.github/workflows/node-ec2-default-retry.yml
+    secrets: inherit
+    with:
+      aws-region: ${{ matrix.aws-region }}
+      caller-workflow-name: 'appsignals-node-e2e-ec2-canary-test'

--- a/.github/workflows/node-ec2-default-retry.yml
+++ b/.github/workflows/node-ec2-default-retry.yml
@@ -1,0 +1,57 @@
+## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+
+# This is a reusable workflow for running the Enablement test for App Signals.
+# It is meant to be called from another workflow.
+# Read more about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview
+name: Node EC2 default Retry
+on:
+  workflow_call:
+    inputs:
+      aws-region:
+        required: true
+        type: string
+      caller-workflow-name:
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  node-ec2-default-attempt-1:
+    uses: ./.github/workflows/node-ec2-default-test.yml
+    secrets: inherit
+    with:
+      aws-region: ${{ inputs.aws-region }}
+      caller-workflow-name: ${{ inputs.caller-workflow-name }}
+
+  node-ec2-default-attempt-2:
+    needs: [ node-ec2-default-attempt-1 ]
+    if: ${{ needs.node-ec2-default-attempt-1.outputs.job-started != 'true' }}
+    uses: ./.github/workflows/node-ec2-default-test.yml
+    secrets: inherit
+    with:
+      aws-region: ${{ inputs.aws-region }}
+      caller-workflow-name: ${{ inputs.caller-workflow-name }}
+
+  publish-metric-attempt-1:
+    needs: [ node-ec2-default-attempt-1, node-ec2-default-attempt-2 ]
+    if: always()
+    uses: ./.github/workflows/enablement-test-publish-result.yml
+    secrets: inherit
+    with:
+      aws-region: ${{ inputs.aws-region }}
+      caller-workflow-name: ${{ inputs.caller-workflow-name }}
+      validation-result: ${{ needs.node-ec2-default-attempt-1.outputs.validation-result || needs.node-ec2-default-attempt-2.outputs.validation-result }}
+
+  publish-metric-attempt-2:
+    needs: [ node-ec2-default-attempt-1, node-ec2-default-attempt-2, publish-metric-attempt-1 ]
+    if: ${{ always() && needs.publish-metric-attempt-1.outputs.job-started != 'true' }}
+    uses: ./.github/workflows/enablement-test-publish-result.yml
+    secrets: inherit
+    with:
+      aws-region: ${{ inputs.aws-region }}
+      caller-workflow-name: ${{ inputs.caller-workflow-name }}
+      validation-result: ${{ needs.node-ec2-default-attempt-1.outputs.validation-result || needs.node-ec2-default-attempt-2.outputs.validation-result }}

--- a/.github/workflows/node-ec2-default-test.yml
+++ b/.github/workflows/node-ec2-default-test.yml
@@ -1,0 +1,278 @@
+## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+
+# This is a reusable workflow for running the Enablement test for App Signals.
+# It is meant to be called from another workflow.
+# Read more about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview
+name: Node EC2 Default Use Case
+on:
+  workflow_call:
+    inputs:
+      aws-region:
+        required: true
+        type: string
+      caller-workflow-name:
+        required: true
+        type: string
+      staging-instrumentation-name:
+        required: false
+        default: 'aws-aws-distro-opentelemetry-node-autoinstrumentation-0.0.1.tgz'
+        type: string
+    outputs:
+      job-started:
+        value: ${{ jobs.node-ec2-default.outputs.job-started }}
+      validation-result:
+        value: ${{ jobs.node-ec2-default.outputs.validation-result }}
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  E2E_TEST_AWS_REGION: ${{ inputs.aws-region }}
+  CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
+  ADOT_INSTRUMENTATION_NAME: ${{ inputs.staging-instrumentation-name }}
+  SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/node-sample-app.zip
+  E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
+  E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
+  METRIC_NAMESPACE: ApplicationSignals
+  LOG_GROUP_NAME: /aws/application-signals/data
+  TEST_RESOURCES_FOLDER: ${GITHUB_WORKSPACE}
+
+jobs:
+  node-ec2-default:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      job-started: ${{ steps.job-started.outputs.job-started }}
+      validation-result: ${{ steps.validation-result.outputs.validation-result }}
+    steps:
+      - name: Check if the job started
+        id: job-started
+        run: echo "job-started=true" >> $GITHUB_OUTPUT
+
+      - name: Generate testing id
+        run: echo TESTING_ID="${{ github.job }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v4
+        with:
+          repository: 'aws-observability/aws-application-signals-test-framework'
+          ref: ${{ env.CALLER_WORKFLOW_NAME == 'main-build' && 'main' || github.ref }}
+          fetch-depth: 0
+
+      # We initialize Gradlew Daemon early on during the workflow because sometimes initialization
+      # fails due to transient issues. If it fails here, then we will try again later before the validators
+      - name: Initiate Gradlew Daemon
+        id: initiate-gradlew
+        uses: ./.github/workflows/actions/execute_and_retry
+        continue-on-error: true
+        with:
+          command: "./gradlew :validator:build"
+          cleanup: "./gradlew clean"
+          max_retry: 3
+          sleep_time: 60
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.E2E_TEST_ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
+          aws-region: us-east-1
+
+      - name: Retrieve account
+        uses: aws-actions/aws-secretsmanager-get-secrets@v1
+        with:
+          secret-ids: |
+            ACCOUNT_ID, region-account/${{ env.E2E_TEST_AWS_REGION }}
+
+      # If the workflow is running as a canary, then we want to log in to the aws account in the appropriate region
+      - name: Configure AWS Credentials
+        if: ${{ github.event.repository.name == 'aws-application-signals-test-framework' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
+          aws-region: ${{ env.E2E_TEST_AWS_REGION }}
+
+      # TODO: Remove the following step once release testing is ready
+      - name: TEMPORARY TEST CONFIGS
+        run: |
+          echo ADOT_INSTRUMENTATION_NAME="aws-aws-distro-opentelemetry-node-autoinstrumentation-0.0.1.tgz" >> $GITHUB_ENV
+
+      - name: Set Get ADOT Instrumentation command environment variable
+        run: |
+          echo GET_ADOT_INSTRUMENTATION_COMMAND="aws s3 cp s3://adot-autoinstrumentation-node-staging/${{ env.ADOT_INSTRUMENTATION_NAME }} ./${{ env.ADOT_INSTRUMENTATION_NAME }} && npm install ${{ env.ADOT_INSTRUMENTATION_NAME }}" >> $GITHUB_ENV
+        # TODO: Reintroduce release testing logic when artifacts are ready
+        # if [ "${{ github.event.repository.name }}" = "aws-otel-js-instrumentation" ]; then
+        #   echo GET_ADOT_INSTRUMENTATION_COMMAND="aws s3 cp s3://adot-autoinstrumentation-node-staging/${{ env.ADOT_INSTRUMENTATION_NAME }} ./${{ env.ADOT_INSTRUMENTATION_NAME }} && npm install ${{ env.ADOT_INSTRUMENTATION_NAME }}" >> $GITHUB_ENV
+        # else
+        #   echo GET_ADOT_INSTRUMENTATION_COMMAND="npm install ${{ env.ADOT_INSTRUMENTATION_NAME }}" >> $GITHUB_ENV
+        # fi
+
+      - name: Set Get CW Agent command environment variable
+        run: |
+          if [ "${{ github.event.repository.name }}" = "amazon-cloudwatch-agent" ]; then
+            echo GET_CW_AGENT_RPM_COMMAND="aws s3 cp s3://${{ secrets.S3_INTEGRATION_BUCKET }}/integration-test/binary/${{ github.sha }}/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm ./cw-agent.rpm" >> $GITHUB_ENV
+          else
+            echo GET_CW_AGENT_RPM_COMMAND="wget -O cw-agent.rpm https://amazoncloudwatch-agent-${{ env.E2E_TEST_AWS_REGION }}.s3.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/amazon_linux/amd64/latest/amazon-cloudwatch-agent.rpm" >> $GITHUB_ENV
+          fi
+
+      - name: Set up terraform
+        uses: ./.github/workflows/actions/execute_and_retry
+        with:
+          command: "wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg"
+          post-command: 'echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+              && sudo apt update && sudo apt install terraform'
+          sleep_time: 60
+
+      - name: Initiate Terraform
+        uses: ./.github/workflows/actions/execute_and_retry
+        with:
+          command: "cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/node/ec2/default && terraform init && terraform validate"
+          cleanup: "rm -rf .terraform && rm -rf .terraform.lock.hcl"
+          max_retry: 6
+          sleep_time: 60
+
+      - name: Deploy sample app via terraform and wait for endpoint to come online
+        working-directory: terraform/node/ec2/default
+        run: |
+          # Attempt to deploy the sample app on an EC2 instance and wait for its endpoint to come online.
+          # There may be occasional failures due to transitivity issues, so try up to 2 times.
+          # deployment_failed of 0 indicates that both the terraform deployment and the endpoint are running, while 1 indicates
+          # that it failed at some point
+          retry_counter=0
+          max_retry=2
+          while [ $retry_counter -lt $max_retry ]; do
+            echo "Attempt $retry_counter"
+            deployment_failed=0
+            terraform apply -auto-approve \
+              -var="aws_region=${{ env.E2E_TEST_AWS_REGION }}" \
+              -var="test_id=${{ env.TESTING_ID }}" \
+              -var="sample_app_zip=${{ env.SAMPLE_APP_ZIP }}" \
+              -var="get_cw_agent_rpm_command=${{ env.GET_CW_AGENT_RPM_COMMAND }}" \
+              -var="get_adot_instrumentation_command=${{ env.GET_ADOT_INSTRUMENTATION_COMMAND }}" \
+            || deployment_failed=$?
+
+            if [ $deployment_failed -eq 1 ]; then
+              echo "Terraform deployment was unsuccessful. Will attempt to retry deployment."
+            fi
+
+            # If the success is 1 then either the terraform deployment or the endpoint connection failed, so first destroy the
+            # resources created from terraform and try again.
+            if [ $deployment_failed -eq 1 ]; then
+              echo "Destroying terraform"
+              terraform destroy -auto-approve \
+                -var="test_id=${{ env.TESTING_ID }}"
+
+              retry_counter=$(($retry_counter+1))
+            else
+              # If deployment succeeded, then exit the loop
+              break
+            fi
+
+            if [ $retry_counter -eq $max_retry ]; then
+              echo "Max retry reached, failed to deploy terraform and connect to the endpoint. Exiting code"
+              exit 1
+            fi
+          done
+
+      - name: Get the ec2 instance ami id
+        working-directory: terraform/node/ec2/default
+        run: |
+          echo "EC2_INSTANCE_AMI=$(terraform output ec2_instance_ami)" >> $GITHUB_ENV
+
+      - name: Get the sample app and EC2 instance information
+        working-directory: terraform/node/ec2/default
+        run: |
+          echo "MAIN_SERVICE_ENDPOINT=localhost:8000" >> $GITHUB_ENV
+          echo "REMOTE_SERVICE_IP=$(terraform output sample_app_remote_service_private_ip)" >> $GITHUB_ENV
+          echo "MAIN_SERVICE_INSTANCE_ID=$(terraform output main_service_instance_id)" >> $GITHUB_ENV
+
+      - name: Initiate Gradlew Daemon
+        if: steps.initiate-gradlew == 'failure'
+        uses: ./.github/workflows/actions/execute_and_retry
+        continue-on-error: true
+        with:
+          command: "./gradlew :validator:build"
+          cleanup: "./gradlew clean"
+          max_retry: 3
+          sleep_time: 60
+
+      # Validation for pulse telemetry data
+      - name: Validate generated EMF logs
+        id: log-validation
+        run: ./gradlew validator:run --args='-c node/ec2/default/log-validation.yml
+          --testing-id ${{ env.TESTING_ID }}
+          --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
+          --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8001
+          --region ${{ inputs.aws-region }}
+          --account-id ${{ env.ACCOUNT_ID }}
+          --metric-namespace ${{ env.METRIC_NAMESPACE }}
+          --log-group ${{ env.LOG_GROUP_NAME }}
+          --service-name node-sample-application-${{ env.TESTING_ID }}
+          --remote-service-name node-sample-remote-application-${{ env.TESTING_ID }}
+          --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
+          --instance-ami ${{ env.EC2_INSTANCE_AMI }}
+          --instance-id ${{ env.MAIN_SERVICE_INSTANCE_ID }}
+          --rollup'
+
+      - name: Validate generated metrics
+        id: metric-validation
+        if: (success() || steps.log-validation.outcome == 'failure') && !cancelled()
+        run: ./gradlew validator:run --args='-c node/ec2/default/metric-validation.yml
+          --testing-id ${{ env.TESTING_ID }}
+          --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
+          --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8001
+          --region ${{ inputs.aws-region }}
+          --account-id ${{ env.ACCOUNT_ID }}
+          --metric-namespace ${{ env.METRIC_NAMESPACE }}
+          --log-group ${{ env.LOG_GROUP_NAME }}
+          --service-name node-sample-application-${{ env.TESTING_ID }}
+          --remote-service-name node-sample-remote-application-${{ env.TESTING_ID }}
+          --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
+          --instance-ami ${{ env.EC2_INSTANCE_AMI }}
+          --instance-id ${{ env.MAIN_SERVICE_INSTANCE_ID }}
+          --rollup'
+
+      - name: Validate generated traces
+        id: trace-validation
+        if: (success() || steps.log-validation.outcome == 'failure' || steps.metric-validation.outcome == 'failure') && !cancelled()
+        run: ./gradlew validator:run --args='-c node/ec2/default/trace-validation.yml
+          --testing-id ${{ env.TESTING_ID }}
+          --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
+          --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}
+          --region ${{ inputs.aws-region }}
+          --account-id ${{ env.ACCOUNT_ID }}
+          --metric-namespace ${{ env.METRIC_NAMESPACE }}
+          --log-group ${{ env.LOG_GROUP_NAME }}
+          --service-name node-sample-application-${{ env.TESTING_ID }}
+          --remote-service-name node-sample-remote-application-${{ env.TESTING_ID }}
+          --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
+          --instance-ami ${{ env.EC2_INSTANCE_AMI }}
+          --instance-id ${{ env.MAIN_SERVICE_INSTANCE_ID }}
+          --rollup'
+
+      - name: Refresh AWS Credentials
+        if: ${{ always() && github.event.repository.name == 'aws-application-signals-test-framework' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
+          aws-region: ${{ env.E2E_TEST_AWS_REGION }}
+
+      - name: Save test results
+        if: always()
+        id: validation-result
+        run: |
+          if [ "${{ steps.log-validation.outcome }}" = "success" ] && [ "${{ steps.metric-validation.outcome }}" = "success" ] && [ "${{ steps.trace-validation.outcome }}" = "success" ]; then
+            echo "validation-result=success" >> $GITHUB_OUTPUT
+          else
+            echo "validation-result=failure" >> $GITHUB_OUTPUT
+          fi
+
+      # Clean up Procedures
+      - name: Terraform destroy
+        if: always()
+        continue-on-error: true
+        working-directory: terraform/node/ec2/default
+        run: |
+          sleep 180 && \
+          terraform destroy -auto-approve \
+            -var="test_id=${{ env.TESTING_ID }}"

--- a/sample-apps/node/frontend-service/index.js
+++ b/sample-apps/node/frontend-service/index.js
@@ -77,19 +77,30 @@ app.get('/remote-service', (req, res) => {
   request.end();
 });
 
-app.get('/client-call', (req, res) => {
-  // Immediately respond to the client without waiting for the HTTP request to complete
-  res.status(202).send('/client-call called successfully');
-  console.log('/client-call called successfully')
+// The following logic serves as the async call made by the /client-call API
+let makeAsyncCall = false;
+setInterval(() => {
+  if (makeAsyncCall) {
+    makeAsyncCall = false;
+    console.log('Async call triggered by /client-call API');
 
-  const request = http.get('http://local-root-client-call', (rs) => {
-    rs.setEncoding('utf8');
-    rs.on('data', (result) => {
-      res.send(`/client-call response: ${result}`);
+    const request = http.get('http://local-root-client-call', (rs) => {
+      rs.setEncoding('utf8');
+      rs.on('data', (result) => {
+        res.send(`GET local-root-client-call response: ${result}`);
+      });
     });
-  });
-  request.on('error', (err) => {});
-  request.end();
+    request.on('error', (err) => {}); // Expected
+    request.end();
+  }
+}, 5000); // Check every 5 seconds
+
+app.get('/client-call', (req, res) => {
+  res.send('/client-call called successfully');
+  console.log('/client-call called successfully');
+
+  // Trigger async call to generate telemetry for InternalOperation use case
+  makeAsyncCall = true;
 });
 
 app.get('/mysql', (req, res) => {

--- a/terraform/node/ec2/asg/amazon-cloudwatch-agent.json
+++ b/terraform/node/ec2/asg/amazon-cloudwatch-agent.json
@@ -1,0 +1,16 @@
+{
+  "agent": {
+    "debug": true,
+    "region": "$REGION"
+  },
+  "traces": {
+    "traces_collected": {
+      "application_signals": {}
+    }
+  },
+  "logs": {
+    "metrics_collected": {
+      "application_signals": {}
+    }
+  }
+}

--- a/terraform/node/ec2/asg/main.tf
+++ b/terraform/node/ec2/asg/main.tf
@@ -1,0 +1,281 @@
+# ------------------------------------------------------------------------
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+# -------------------------------------------------------------------------
+
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+# Define the provider for AWS
+provider "aws" {}
+
+resource "aws_default_vpc" "default" {}
+
+data "aws_subnets" "default_subnets" {
+  filter {
+    name   = "vpc-id"
+    values = [aws_default_vpc.default.id]
+  }
+}
+
+resource "tls_private_key" "ssh_key" {
+  algorithm = "RSA"
+  rsa_bits = 4096
+}
+
+resource "aws_key_pair" "aws_ssh_key" {
+  key_name = "instance_key-${var.test_id}"
+  public_key = tls_private_key.ssh_key.public_key_openssh
+}
+
+locals {
+  ssh_key_name        = aws_key_pair.aws_ssh_key.key_name
+  private_key_content = tls_private_key.ssh_key.private_key_pem
+}
+
+data "aws_ami" "ami" {
+  owners = ["amazon"]
+  most_recent      = true
+  filter {
+    name   = "name"
+    values = ["al20*-ami-minimal-*-x86_64"]
+  }
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+  filter {
+    name   = "image-type"
+    values = ["machine"]
+  }
+
+  filter {
+    name   = "root-device-name"
+    values = ["/dev/xvda"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_launch_configuration" "launch_configuration" {
+  image_id      = data.aws_ami.ami.id
+  instance_type = "t3.micro"
+  key_name = local.ssh_key_name
+  associate_public_ip_address = true
+  iam_instance_profile = "APP_SIGNALS_EC2_TEST_ROLE"
+  security_groups = [aws_default_vpc.default.default_security_group_id]
+
+  user_data = <<-EOF
+    #!/bin/bash
+
+    # Set up environment
+    sudo yum install nodejs unzip wget tmux aws-cli -y
+
+    echo "Node version in use: $(node -v)"
+
+    # Copy in CW Agent configuration
+    agent_config='${replace(replace(file("./amazon-cloudwatch-agent.json"), "/\\s+/", ""), "$REGION", var.aws_region)}'
+    echo $agent_config > amazon-cloudwatch-agent.json
+
+    # Get and run CW agent rpm
+    ${var.get_cw_agent_rpm_command}
+    sudo rpm -U ./cw-agent.rpm
+    sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:./amazon-cloudwatch-agent.json
+
+    # Get and run the sample application with configuration
+    aws s3 cp ${var.sample_app_zip} ./node-sample-app.zip
+    unzip -o node-sample-app.zip
+
+    # Enter appropriate service folder
+    cd frontend-service
+
+    # Install sample application
+    npm install
+
+    # Get ADOT instrumentation and install it
+    ${var.get_adot_instrumentation_command}
+
+    # Set up application tmux screen so it keeps running after closing the SSH connection
+    tmux new-session -d -s frontend
+
+    # Export environment variables for instrumentation
+    tmux send-keys -t frontend 'export OTEL_METRICS_EXPORTER=none' C-m
+    tmux send-keys -t frontend 'export OTEL_TRACES_EXPORTER=otlp' C-m
+    tmux send-keys -t frontend 'export OTEL_AWS_APPLICATION_SIGNALS_ENABLED=true' C-m
+    tmux send-keys -t frontend 'export OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics' C-m
+    tmux send-keys -t frontend 'export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4316/v1/traces' C-m
+    tmux send-keys -t frontend 'export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf' C-m
+    tmux send-keys -t frontend 'export OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=http/protobuf' C-m
+    tmux send-keys -t frontend 'export OTEL_NODE_DISABLED_INSTRUMENTATIONS=fs,dns,express' C-m
+    tmux send-keys -t frontend 'export OTEL_SERVICE_NAME=node-sample-application-${var.test_id}' C-m
+    tmux send-keys -t frontend 'export OTEL_TRACES_SAMPLER=always_on' C-m
+    tmux send-keys -t frontend 'node --require "@aws/aws-distro-opentelemetry-node-autoinstrumentation/register" index.js' C-m
+
+    # Check if the application is up. If it is not up, then exit 1.
+    attempt_counter=0
+    max_attempts=30
+    until $(curl --output /dev/null --silent --head --fail --max-time 5 $(echo "http://localhost:8000/healthcheck" | tr -d '"')); do
+      if [ $attempt_counter -eq $max_attempts ];then
+        echo "Failed to connect to endpoint."
+        exit 1
+      fi
+      echo "Attempting to connect to the main endpoint. Tried $attempt_counter out of $max_attempts"
+      attempt_counter=$(($attempt_counter+1))
+      sleep 10
+    done
+
+    echo "Successfully connected to main endpoint"
+
+    # Bring in the traffic generator files to EC2 Instance
+    cd ..
+    aws s3 cp s3://aws-appsignals-sample-app-prod-${var.aws_region}/traffic-generator.zip ./traffic-generator.zip
+    unzip ./traffic-generator.zip -d ./
+
+    # Install the traffic generator dependencies
+    npm install
+
+    tmux new -s traffic-generator -d
+    tmux send-keys -t traffic-generator "export MAIN_ENDPOINT=\"localhost:8000\"" C-m
+    tmux send-keys -t traffic-generator "export REMOTE_ENDPOINT=\"${aws_instance.remote_service_instance.private_ip}\"" C-m
+    tmux send-keys -t traffic-generator "export ID=\"${var.test_id}\"" C-m
+    tmux send-keys -t traffic-generator "npm start" C-m
+
+    echo "Completed traffic generator set up commands"
+
+    EOF
+}
+
+resource "aws_autoscaling_group" "asg" {
+  name = "ec2-single-asg-${var.test_id}"
+  min_size = 1
+  max_size = 1
+  launch_configuration = aws_launch_configuration.launch_configuration.name
+  vpc_zone_identifier = [data.aws_subnets.default_subnets.ids.0]
+  health_check_type = "EC2"
+  health_check_grace_period = 180
+}
+
+resource "aws_instance" "remote_service_instance" {
+  ami                                   = data.aws_ami.ami.id # Amazon Linux 2 (free tier)
+  instance_type                         = "t3.micro"
+  key_name                              = local.ssh_key_name
+  iam_instance_profile                  = "APP_SIGNALS_EC2_TEST_ROLE"
+  vpc_security_group_ids                = [aws_default_vpc.default.default_security_group_id]
+  associate_public_ip_address           = true
+  instance_initiated_shutdown_behavior  = "terminate"
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  tags = {
+    Name = "remote-service-${var.test_id}"
+  }
+}
+
+resource "null_resource" "remote_service_setup" {
+  connection {
+    type = "ssh"
+    user = var.user
+    private_key = local.private_key_content
+    host = aws_instance.remote_service_instance.public_ip
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      <<-EOF
+      #!/bin/bash
+
+      # Set up environment
+      sudo yum install nodejs unzip wget tmux aws-cli -y
+
+      echo "Node version in use: $(node -v)"
+
+      # Copy in CW Agent configuration
+      agent_config='${replace(replace(file("./amazon-cloudwatch-agent.json"), "/\\s+/", ""), "$REGION", var.aws_region)}'
+      echo $agent_config > amazon-cloudwatch-agent.json
+
+      # Get and run CW Agent RPM
+      ${var.get_cw_agent_rpm_command}
+      sudo rpm -U ./cw-agent.rpm
+      sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:./amazon-cloudwatch-agent.json
+
+      # Get and run the sample application with configuration
+      aws s3 cp ${var.sample_app_zip} ./node-sample-app.zip
+      unzip -o node-sample-app.zip
+
+      # Enter appropriate service folder
+      cd remote-service
+
+      # Install sample application
+      npm install
+
+      # Get ADOT instrumentation and install it
+      ${var.get_adot_instrumentation_command}
+
+      # Set up application tmux screen so it keeps running after closing the SSH connection
+      tmux new-session -d -s remote
+
+      # Export environment variables for instrumentation
+      tmux send-keys -t remote 'export OTEL_METRICS_EXPORTER=none' C-m
+      tmux send-keys -t remote 'export OTEL_TRACES_EXPORTER=otlp' C-m
+      tmux send-keys -t remote 'export OTEL_AWS_APPLICATION_SIGNALS_ENABLED=true' C-m
+      tmux send-keys -t remote 'export OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics' C-m
+      tmux send-keys -t remote 'export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4316/v1/traces' C-m
+      tmux send-keys -t remote 'export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf' C-m
+      tmux send-keys -t remote 'export OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=http/protobuf' C-m
+      tmux send-keys -t remote 'export OTEL_NODE_DISABLED_INSTRUMENTATIONS=fs,dns,express' C-m
+      tmux send-keys -t remote 'export OTEL_SERVICE_NAME=node-sample-remote-application-${var.test_id}' C-m
+      tmux send-keys -t remote 'export OTEL_TRACES_SAMPLER=always_on' C-m
+      tmux send-keys -t remote 'node --require "@aws/aws-distro-opentelemetry-node-autoinstrumentation/register" index.js' C-m
+
+      # The application needs time to come up and reach a steady state, this should not take longer than 30 seconds
+      # sleep 30
+
+      # Check if the application is up. If it is not up, then exit 1.
+      attempt_counter=0
+      max_attempts=30
+      until $(curl --output /dev/null --silent --head --fail --max-time 5 $(echo "http://localhost:8001/healthcheck" | tr -d '"')); do
+        if [ $attempt_counter -eq $max_attempts ];then
+          echo "Failed to connect to the remote endpoint."
+          exit 1
+        fi
+        echo "Attempting to connect to the remote endpoint. Tried $attempt_counter out of $max_attempts"
+        attempt_counter=$(($attempt_counter+1))
+        sleep 10
+      done
+
+      echo "Successfully connected to remote endpoint"
+
+      EOF
+    ]
+  }
+
+  depends_on = [aws_instance.remote_service_instance]
+}

--- a/terraform/node/ec2/asg/main.tf
+++ b/terraform/node/ec2/asg/main.tf
@@ -126,6 +126,8 @@ resource "aws_launch_configuration" "launch_configuration" {
     tmux new-session -d -s frontend
 
     # Export environment variables for instrumentation
+    # Note: We use OTEL_NODE_DISABLED_INSTRUMENTATIONS=fs,dns,express to avoid
+    # having to validate around the telemetry generated for middleware
     tmux send-keys -t frontend 'export OTEL_METRICS_EXPORTER=none' C-m
     tmux send-keys -t frontend 'export OTEL_TRACES_EXPORTER=otlp' C-m
     tmux send-keys -t frontend 'export OTEL_AWS_APPLICATION_SIGNALS_ENABLED=true' C-m
@@ -243,6 +245,8 @@ resource "null_resource" "remote_service_setup" {
       tmux new-session -d -s remote
 
       # Export environment variables for instrumentation
+      # Note: We use OTEL_NODE_DISABLED_INSTRUMENTATIONS=fs,dns,express to avoid
+      # having to validate around the telemetry generated for middleware
       tmux send-keys -t remote 'export OTEL_METRICS_EXPORTER=none' C-m
       tmux send-keys -t remote 'export OTEL_TRACES_EXPORTER=otlp' C-m
       tmux send-keys -t remote 'export OTEL_AWS_APPLICATION_SIGNALS_ENABLED=true' C-m

--- a/terraform/node/ec2/asg/output.tf
+++ b/terraform/node/ec2/asg/output.tf
@@ -1,0 +1,22 @@
+# ------------------------------------------------------------------------
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+# -------------------------------------------------------------------------
+
+output "sample_app_remote_service_private_ip" {
+  value = aws_instance.remote_service_instance.private_ip
+}
+
+output "ec2_instance_ami" {
+  value = data.aws_ami.ami.id
+}

--- a/terraform/node/ec2/asg/variables.tf
+++ b/terraform/node/ec2/asg/variables.tf
@@ -1,0 +1,42 @@
+# ------------------------------------------------------------------------
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+# -------------------------------------------------------------------------
+
+variable "test_id" {
+  default = "dummy-123"
+}
+
+variable "aws_region" {
+  default = "<aws-region>"
+}
+
+variable "user" {
+  default = "ec2-user"
+}
+
+variable "sample_app_zip" {
+  default = "s3://<bucket-name>/<zip>"
+}
+
+variable "get_adot_instrumentation_command" {
+  default = "<get ADOT instrumentation command> && <install/prepare instrumentation command>"
+}
+
+variable "get_cw_agent_rpm_command" {
+  default = "<command> s3://<bucket-name>/<RPM>"
+}
+
+variable "canary_type" {
+  default = "node-ec2-default"
+}

--- a/terraform/node/ec2/default/amazon-cloudwatch-agent.json
+++ b/terraform/node/ec2/default/amazon-cloudwatch-agent.json
@@ -1,0 +1,16 @@
+{
+  "agent": {
+    "debug": true,
+    "region": "$REGION"
+  },
+  "traces": {
+    "traces_collected": {
+      "application_signals": {}
+    }
+  },
+  "logs": {
+    "metrics_collected": {
+      "application_signals": {}
+    }
+  }
+}

--- a/terraform/node/ec2/default/main.tf
+++ b/terraform/node/ec2/default/main.tf
@@ -1,0 +1,304 @@
+# ------------------------------------------------------------------------
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+# -------------------------------------------------------------------------
+
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+# Define the provider for AWS
+provider "aws" {}
+
+resource "aws_default_vpc" "default" {}
+
+resource "tls_private_key" "ssh_key" {
+  algorithm = "RSA"
+  rsa_bits = 4096
+}
+
+resource "aws_key_pair" "aws_ssh_key" {
+  key_name = "instance_key-${var.test_id}"
+  public_key = tls_private_key.ssh_key.public_key_openssh
+}
+
+locals {
+  ssh_key_name        = aws_key_pair.aws_ssh_key.key_name
+  private_key_content = tls_private_key.ssh_key.private_key_pem
+}
+
+data "aws_ami" "ami" {
+  owners = ["amazon"]
+  most_recent      = true
+  filter {
+    name = "name"
+    values = ["al20*-ami-minimal-*-x86_64"]
+  }
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+  filter {
+    name   = "image-type"
+    values = ["machine"]
+  }
+
+  filter {
+    name   = "root-device-name"
+    values = ["/dev/xvda"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_instance" "main_service_instance" {
+  ami                                   = data.aws_ami.ami.id # Amazon Linux 2 (free tier)
+  instance_type                         = "t3.small"
+  key_name                              = local.ssh_key_name
+  iam_instance_profile                  = "APP_SIGNALS_EC2_TEST_ROLE"
+  vpc_security_group_ids                = [aws_default_vpc.default.default_security_group_id]
+  associate_public_ip_address           = true
+  instance_initiated_shutdown_behavior  = "terminate"
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  tags = {
+    Name = "main-service-${var.test_id}"
+  }
+}
+
+resource "null_resource" "main_service_setup" {
+  connection {
+    type = "ssh"
+    user = var.user
+    private_key = local.private_key_content
+    host = aws_instance.main_service_instance.public_ip
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      <<-EOF
+      #!/bin/bash
+
+      # Set up environment
+      sudo yum install nodejs unzip wget tmux aws-cli -y
+
+      echo "Node version in use: $(node -v)"
+
+      # Copy in CW Agent configuration
+      agent_config='${replace(replace(file("./amazon-cloudwatch-agent.json"), "/\\s+/", ""), "$REGION", var.aws_region)}'
+      echo $agent_config > amazon-cloudwatch-agent.json
+
+      # Get and run CW agent rpm
+      ${var.get_cw_agent_rpm_command}
+      sudo rpm -U ./cw-agent.rpm
+      sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:./amazon-cloudwatch-agent.json
+
+      # Get and run the sample application with configuration
+      aws s3 cp ${var.sample_app_zip} ./node-sample-app.zip
+      unzip -o node-sample-app.zip
+
+      # Enter appropriate service folder
+      cd frontend-service
+
+      # Install sample application
+      npm install
+
+      # Get ADOT instrumentation and install it
+      ${var.get_adot_instrumentation_command}
+
+      # Set up application tmux screen so it keeps running after closing the SSH connection
+      tmux new-session -d -s frontend
+
+      # Export environment variables for instrumentation
+      tmux send-keys -t frontend 'export OTEL_METRICS_EXPORTER=none' C-m
+      tmux send-keys -t frontend 'export OTEL_TRACES_EXPORTER=otlp' C-m
+      tmux send-keys -t frontend 'export OTEL_AWS_APPLICATION_SIGNALS_ENABLED=true' C-m
+      tmux send-keys -t frontend 'export OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics' C-m
+      tmux send-keys -t frontend 'export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4316/v1/traces' C-m
+      tmux send-keys -t frontend 'export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf' C-m
+      tmux send-keys -t frontend 'export OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=http/protobuf' C-m
+      tmux send-keys -t frontend 'export OTEL_NODE_DISABLED_INSTRUMENTATIONS=fs,dns,express' C-m
+      tmux send-keys -t frontend 'export OTEL_SERVICE_NAME=node-sample-application-${var.test_id}' C-m
+      tmux send-keys -t frontend 'export OTEL_TRACES_SAMPLER=always_on' C-m
+      tmux send-keys -t frontend 'node --require "@aws/aws-distro-opentelemetry-node-autoinstrumentation/register" index.js' C-m
+
+      # Check if the application is up. If it is not up, then exit 1.
+      attempt_counter=0
+      max_attempts=30
+      until $(curl --output /dev/null --silent --head --fail --max-time 5 $(echo "http://localhost:8000/healthcheck" | tr -d '"')); do
+        if [ $attempt_counter -eq $max_attempts ];then
+          echo "Failed to connect to endpoint."
+          exit 1
+        fi
+        echo "Attempting to connect to the main endpoint. Tried $attempt_counter out of $max_attempts"
+        attempt_counter=$(($attempt_counter+1))
+        sleep 10
+      done
+
+      echo "Successfully connected to main endpoint"
+
+      EOF
+    ]
+  }
+
+  depends_on = [aws_instance.main_service_instance]
+}
+
+resource "aws_instance" "remote_service_instance" {
+  ami                                   = data.aws_ami.ami.id # Amazon Linux 2 (free tier)
+  instance_type                         = "t3.small"
+  key_name                              = local.ssh_key_name
+  iam_instance_profile                  = "APP_SIGNALS_EC2_TEST_ROLE"
+  vpc_security_group_ids                = [aws_default_vpc.default.default_security_group_id]
+  associate_public_ip_address           = true
+  instance_initiated_shutdown_behavior  = "terminate"
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  tags = {
+    Name = "remote-service-${var.test_id}"
+  }
+}
+
+resource "null_resource" "remote_service_setup" {
+  connection {
+    type = "ssh"
+    user = var.user
+    private_key = local.private_key_content
+    host = aws_instance.remote_service_instance.public_ip
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      <<-EOF
+      #!/bin/bash
+
+      # Set up environment
+      sudo yum install nodejs unzip wget tmux aws-cli -y
+
+      echo "Node version in use: $(node -v)"
+
+      # Copy in CW Agent configuration
+      agent_config='${replace(replace(file("./amazon-cloudwatch-agent.json"), "/\\s+/", ""), "$REGION", var.aws_region)}'
+      echo $agent_config > amazon-cloudwatch-agent.json
+
+      # Get and run CW Agent RPM
+      ${var.get_cw_agent_rpm_command}
+      sudo rpm -U ./cw-agent.rpm
+      sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:./amazon-cloudwatch-agent.json
+
+      # Get and run the sample application with configuration
+      aws s3 cp ${var.sample_app_zip} ./node-sample-app.zip
+      unzip -o node-sample-app.zip
+
+      # Enter appropriate service folder
+      cd remote-service
+
+      # Install sample application
+      npm install
+
+      # Get ADOT instrumentation and install it
+      ${var.get_adot_instrumentation_command}
+
+      # Set up application tmux screen so it keeps running after closing the SSH connection
+      tmux new-session -d -s remote
+
+      # Export environment variables for instrumentation
+      tmux send-keys -t remote 'export OTEL_METRICS_EXPORTER=none' C-m
+      tmux send-keys -t remote 'export OTEL_TRACES_EXPORTER=otlp' C-m
+      tmux send-keys -t remote 'export OTEL_AWS_APPLICATION_SIGNALS_ENABLED=true' C-m
+      tmux send-keys -t remote 'export OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics' C-m
+      tmux send-keys -t remote 'export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4316/v1/traces' C-m
+      tmux send-keys -t remote 'export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf' C-m
+      tmux send-keys -t remote 'export OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=http/protobuf' C-m
+      tmux send-keys -t remote 'export OTEL_NODE_DISABLED_INSTRUMENTATIONS=fs,dns,express' C-m
+      tmux send-keys -t remote 'export OTEL_SERVICE_NAME=node-sample-remote-application-${var.test_id}' C-m
+      tmux send-keys -t remote 'export OTEL_TRACES_SAMPLER=always_on' C-m
+      tmux send-keys -t remote 'node --require "@aws/aws-distro-opentelemetry-node-autoinstrumentation/register" index.js' C-m
+
+      # The application needs time to come up and reach a steady state, this should not take longer than 30 seconds
+      # sleep 30
+
+      # Check if the application is up. If it is not up, then exit 1.
+      attempt_counter=0
+      max_attempts=30
+      until $(curl --output /dev/null --silent --head --fail --max-time 5 $(echo "http://localhost:8001/healthcheck" | tr -d '"')); do
+        if [ $attempt_counter -eq $max_attempts ];then
+          echo "Failed to connect to endpoint."
+          exit 1
+        fi
+        echo "Attempting to connect to the remote endpoint. Tried $attempt_counter out of $max_attempts"
+        attempt_counter=$(($attempt_counter+1))
+        sleep 10
+      done
+
+      echo "Successfully connected to remote endpoint"
+
+      EOF
+    ]
+  }
+
+  depends_on = [aws_instance.remote_service_instance]
+}
+
+resource "null_resource" "traffic_generator_setup" {
+  connection {
+    type = "ssh"
+    user = var.user
+    private_key = local.private_key_content
+    host = aws_instance.main_service_instance.public_ip
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      <<-EOF
+        # Bring in the traffic generator files to EC2 Instance
+        aws s3 cp s3://aws-appsignals-sample-app-prod-${var.aws_region}/traffic-generator.zip ./traffic-generator.zip
+        unzip ./traffic-generator.zip -d ./
+
+        # Install the traffic generator dependencies
+        npm install
+
+        tmux new -s traffic-generator -d
+        tmux send-keys -t traffic-generator "export MAIN_ENDPOINT=\"localhost:8000\"" C-m
+        tmux send-keys -t traffic-generator "export REMOTE_ENDPOINT=\"${aws_instance.remote_service_instance.private_ip}\"" C-m
+        tmux send-keys -t traffic-generator "export ID=\"${var.test_id}\"" C-m
+        tmux send-keys -t traffic-generator "npm start" C-m
+
+        echo "Completed traffic generator set up commands"
+
+      EOF
+    ]
+  }
+
+  depends_on = [null_resource.main_service_setup, null_resource.remote_service_setup]
+}

--- a/terraform/node/ec2/default/main.tf
+++ b/terraform/node/ec2/default/main.tf
@@ -138,6 +138,8 @@ resource "null_resource" "main_service_setup" {
       tmux new-session -d -s frontend
 
       # Export environment variables for instrumentation
+      # Note: We use OTEL_NODE_DISABLED_INSTRUMENTATIONS=fs,dns,express to avoid
+      # having to validate around the telemetry generated for middleware
       tmux send-keys -t frontend 'export OTEL_METRICS_EXPORTER=none' C-m
       tmux send-keys -t frontend 'export OTEL_TRACES_EXPORTER=otlp' C-m
       tmux send-keys -t frontend 'export OTEL_AWS_APPLICATION_SIGNALS_ENABLED=true' C-m
@@ -233,6 +235,8 @@ resource "null_resource" "remote_service_setup" {
       tmux new-session -d -s remote
 
       # Export environment variables for instrumentation
+      # Note: We use OTEL_NODE_DISABLED_INSTRUMENTATIONS=fs,dns,express to avoid
+      # having to validate around the telemetry generated for middleware
       tmux send-keys -t remote 'export OTEL_METRICS_EXPORTER=none' C-m
       tmux send-keys -t remote 'export OTEL_TRACES_EXPORTER=otlp' C-m
       tmux send-keys -t remote 'export OTEL_AWS_APPLICATION_SIGNALS_ENABLED=true' C-m

--- a/terraform/node/ec2/default/output.tf
+++ b/terraform/node/ec2/default/output.tf
@@ -1,0 +1,26 @@
+# ------------------------------------------------------------------------
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+# -------------------------------------------------------------------------
+
+output "sample_app_remote_service_private_ip" {
+  value = aws_instance.remote_service_instance.private_ip
+}
+
+output "main_service_instance_id" {
+  value = aws_instance.main_service_instance.id
+}
+
+output "ec2_instance_ami" {
+  value = data.aws_ami.ami.id
+}

--- a/terraform/node/ec2/default/variables.tf
+++ b/terraform/node/ec2/default/variables.tf
@@ -1,0 +1,42 @@
+# ------------------------------------------------------------------------
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+# -------------------------------------------------------------------------
+
+variable "test_id" {
+  default = "dummy-123"
+}
+
+variable "aws_region" {
+  default = "<aws-region>"
+}
+
+variable "user" {
+  default = "ec2-user"
+}
+
+variable "sample_app_zip" {
+  default = "s3://<bucket-name>/<zip>"
+}
+
+variable "get_adot_instrumentation_command" {
+  default = "<get ADOT instrumentation command> && <install/prepare instrumentation command>"
+}
+
+variable "get_cw_agent_rpm_command" {
+  default = "<command> s3://<bucket-name>/<RPM>"
+}
+
+variable "canary_type" {
+  default = "node-ec2-default"
+}

--- a/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
+++ b/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
@@ -210,6 +210,39 @@ public enum PredefinedExpectedTemplate implements FileConfig {
   DOTNET_EC2_ASG_CLIENT_CALL_LOG("/expected-data-template/dotnet/ec2/asg/client-call-log.mustache"),
   DOTNET_EC2_ASG_CLIENT_CALL_METRIC("/expected-data-template/dotnet/ec2/asg/client-call-metric.mustache"),
   DOTNET_EC2_ASG_CLIENT_CALL_TRACE("/expected-data-template/dotnet/ec2/asg/client-call-trace.mustache"),
+  /** Node EC2 Default Test Case Validations */
+  NODE_EC2_DEFAULT_OUTGOING_HTTP_CALL_LOG("/expected-data-template/node/ec2/default/outgoing-http-call-log.mustache"),
+  NODE_EC2_DEFAULT_OUTGOING_HTTP_CALL_METRIC("/expected-data-template/node/ec2/default/outgoing-http-call-metric.mustache"),
+  NODE_EC2_DEFAULT_OUTGOING_HTTP_CALL_TRACE("/expected-data-template/node/ec2/default/outgoing-http-call-trace.mustache"),
+
+  NODE_EC2_DEFAULT_AWS_SDK_CALL_LOG("/expected-data-template/node/ec2/default/aws-sdk-call-log.mustache"),
+  NODE_EC2_DEFAULT_AWS_SDK_CALL_METRIC("/expected-data-template/node/ec2/default/aws-sdk-call-metric.mustache"),
+  NODE_EC2_DEFAULT_AWS_SDK_CALL_TRACE("/expected-data-template/node/ec2/default/aws-sdk-call-trace.mustache"),
+
+  NODE_EC2_DEFAULT_REMOTE_SERVICE_LOG("/expected-data-template/node/ec2/default/remote-service-log.mustache"),
+  NODE_EC2_DEFAULT_REMOTE_SERVICE_METRIC("/expected-data-template/node/ec2/default/remote-service-metric.mustache"),
+  NODE_EC2_DEFAULT_REMOTE_SERVICE_TRACE("/expected-data-template/node/ec2/default/remote-service-trace.mustache"),
+
+  NODE_EC2_DEFAULT_CLIENT_CALL_LOG("/expected-data-template/node/ec2/default/client-call-log.mustache"),
+  NODE_EC2_DEFAULT_CLIENT_CALL_METRIC("/expected-data-template/node/ec2/default/client-call-metric.mustache"),
+  NODE_EC2_DEFAULT_CLIENT_CALL_TRACE("/expected-data-template/node/ec2/default/client-call-trace.mustache"),
+
+  /** Node EC2 ASG Test Case Validations */
+  NODE_EC2_ASG_OUTGOING_HTTP_CALL_LOG("/expected-data-template/node/ec2/asg/outgoing-http-call-log.mustache"),
+  NODE_EC2_ASG_OUTGOING_HTTP_CALL_METRIC("/expected-data-template/node/ec2/asg/outgoing-http-call-metric.mustache"),
+  NODE_EC2_ASG_OUTGOING_HTTP_CALL_TRACE("/expected-data-template/node/ec2/asg/outgoing-http-call-trace.mustache"),
+
+  NODE_EC2_ASG_AWS_SDK_CALL_LOG("/expected-data-template/node/ec2/asg/aws-sdk-call-log.mustache"),
+  NODE_EC2_ASG_AWS_SDK_CALL_METRIC("/expected-data-template/node/ec2/asg/aws-sdk-call-metric.mustache"),
+  NODE_EC2_ASG_AWS_SDK_CALL_TRACE("/expected-data-template/node/ec2/asg/aws-sdk-call-trace.mustache"),
+
+  NODE_EC2_ASG_REMOTE_SERVICE_LOG("/expected-data-template/node/ec2/asg/remote-service-log.mustache"),
+  NODE_EC2_ASG_REMOTE_SERVICE_METRIC("/expected-data-template/node/ec2/asg/remote-service-metric.mustache"),
+  NODE_EC2_ASG_REMOTE_SERVICE_TRACE("/expected-data-template/node/ec2/asg/remote-service-trace.mustache"),
+
+  NODE_EC2_ASG_CLIENT_CALL_LOG("/expected-data-template/node/ec2/asg/client-call-log.mustache"),
+  NODE_EC2_ASG_CLIENT_CALL_METRIC("/expected-data-template/node/ec2/asg/client-call-metric.mustache"),
+  NODE_EC2_ASG_CLIENT_CALL_TRACE("/expected-data-template/node/ec2/asg/client-call-trace.mustache"),
   ;
 
   private String path;

--- a/validator/src/main/java/com/amazon/aoc/validators/TraceValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/TraceValidator.java
@@ -109,10 +109,11 @@ public class TraceValidator implements IValidator {
                       Matcher matcher = pattern.matcher(actual.toString());
 
                       if (!matcher.find()) {
-                        log.error("data model validation failed");
-                        log.info("mismatched data model field list");
-                        log.info("value of stored trace map: {}", entry.getValue());
-                        log.info("value of retrieved map: {}", retrievedTrace.get(targetKey));
+                        log.error("Data model validation failed");
+                        log.info("Mismatched data model field list");
+                        log.info("Mismatched data for key: {}", targetKey);
+                        log.info("Value of stored trace map: {}", entry.getValue());
+                        log.info("Value of retrieved map: {}", retrievedTrace.get(targetKey));
                         log.info("==========================================");
                         throw new BaseException(ExceptionCode.DATA_MODEL_NOT_MATCHED);
                       }

--- a/validator/src/main/resources/expected-data-template/node/ec2/asg/aws-sdk-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/asg/aws-sdk-call-log.mustache
@@ -1,0 +1,24 @@
+[{
+  "EC2.AutoScalingGroup": "^{{platformInfo}}$",
+  "EC2.InstanceId": "^{{instanceId}}$",
+  "Environment": "^ec2:{{platformInfo}}$",
+  "PlatformType": "^AWS::EC2$",
+  "Operation": "GET /aws-sdk-call",
+  "Version": "^1$",
+  "Telemetry.Source": "^LocalRootSpan$",
+  "Host": "^{{privateDnsName}}$"
+},
+{
+  "EC2.AutoScalingGroup": "^{{platformInfo}}$",
+  "EC2.InstanceId": "^{{instanceId}}$",
+  "Environment": "^ec2:{{platformInfo}}$",
+  "PlatformType": "^AWS::EC2$",
+  "Operation": "GET /aws-sdk-call",
+  "Version": "^1$",
+  "RemoteService": "AWS::S3",
+  "RemoteOperation": "GetBucketLocation",
+  "RemoteResourceIdentifier": "^e2e-test-bucket-name-{{testingId}}$",
+  "RemoteResourceType": "^AWS::S3::Bucket$",
+  "Telemetry.Source": "^ClientSpan$",
+  "Host": "^{{privateDnsName}}$"
+}]

--- a/validator/src/main/resources/expected-data-template/node/ec2/asg/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/asg/aws-sdk-call-metric.mustache
@@ -1,0 +1,374 @@
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: e2e-test-bucket-name-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: e2e-test-bucket-name-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: e2e-test-bucket-name-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: e2e-test-bucket-name-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: e2e-test-bucket-name-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: e2e-test-bucket-name-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket

--- a/validator/src/main/resources/expected-data-template/node/ec2/asg/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/asg/aws-sdk-call-trace.mustache
@@ -1,0 +1,54 @@
+[{
+  "name": "^{{serviceName}}$",
+  "http": {
+    "request": {
+      "url": "^{{endpoint}}/aws-sdk-call\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
+      "method": "^GET$"
+    }
+  },
+  "aws": {
+    "account_id": "^{{accountId}}$"
+  },
+  "annotations": {
+    "aws.local.service": "^{{serviceName}}$",
+    "aws.local.operation": "^GET /aws-sdk-call$",
+    "aws.local.environment": "^ec2:{{platformInfo}}$"
+  },
+  "metadata": {
+    "default": {
+      "EC2.AutoScalingGroup": "^{{platformInfo}}$",
+      "EC2.InstanceId": "^{{instanceId}}$",
+      "otel.resource.ec2.tag.aws:autoscaling:groupName": "^{{platformInfo}}$",
+      "otel.resource.host.id": "^{{instanceId}}$",
+      "PlatformType": "^AWS::EC2$",
+      "otel.resource.host.image.id": "^{{instanceAmi}}$",
+      "otel.resource.host.type": "^t3.micro$",
+      "aws.span.kind": "^LOCAL_ROOT$",
+      "otel.resource.host.name": "^{{privateDnsName}}$"
+    }
+  },
+  "subsegments": [
+    {
+      "name": "^S3$",
+      "annotations": {
+        "aws.local.service": "^{{serviceName}}$",
+        "aws.local.operation": "^GET /aws-sdk-call$",
+        "aws.remote.service": "^AWS::S3$",
+        "aws.remote.operation": "^GetBucketLocation$",
+        "aws.remote.resource.type": "^AWS::S3::Bucket$",
+        "aws.remote.resource.identifier": "^e2e-test-bucket-name-{{testingId}}$",
+        "aws.local.environment": "^ec2:{{platformInfo}}$"
+      },
+      "metadata": {
+        "default": {
+          "EC2.AutoScalingGroup": "^{{platformInfo}}$",
+          "EC2.InstanceId": "^{{instanceId}}$",
+          "PlatformType": "^AWS::EC2$",
+          "aws.span.kind": "^CLIENT$",
+          "aws.s3.bucket": "^e2e-test-bucket-name-{{testingId}}$"
+        }
+      },
+      "namespace": "^aws$"
+    }
+  ]
+}]

--- a/validator/src/main/resources/expected-data-template/node/ec2/asg/client-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/asg/client-call-log.mustache
@@ -1,0 +1,22 @@
+[{
+  "EC2.AutoScalingGroup": "^{{platformInfo}}$",
+  "EC2.InstanceId": "^{{instanceId}}$",
+  "Environment": "^ec2:{{platformInfo}}$",
+  "PlatformType": "^AWS::EC2$",
+  "Operation": "InternalOperation",
+  "Version": "^1$",
+  "Telemetry.Source": "^LocalRootSpan$",
+  "Host": "^{{privateDnsName}}$"
+},
+{
+  "EC2.AutoScalingGroup": "^{{platformInfo}}$",
+  "EC2.InstanceId": "^{{instanceId}}$",
+  "Environment": "^ec2:{{platformInfo}}$",
+  "PlatformType": "^AWS::EC2$",
+  "Operation": "InternalOperation",
+  "Version": "^1$",
+  "RemoteService": "local-root-client-call",
+  "RemoteOperation": "GET /",
+  "Telemetry.Source": "^ClientSpan$",
+  "Host": "^{{privateDnsName}}$"
+}]

--- a/validator/src/main/resources/expected-data-template/node/ec2/asg/client-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/asg/client-call-metric.mustache
@@ -1,0 +1,227 @@
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteService
+      value: local-root-client-call
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteService
+      value: local-root-client-call
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteService
+      value: local-root-client-call

--- a/validator/src/main/resources/expected-data-template/node/ec2/asg/client-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/asg/client-call-trace.mustache
@@ -1,0 +1,60 @@
+[{
+  "name": "^{{serviceName}}$",
+  "annotations": {
+    "aws.local.service": "^{{serviceName}}$",
+    "aws.local.operation": "^InternalOperation$",
+    "aws.local.environment": "^ec2:{{platformInfo}}$"
+  },
+  "metadata": {
+    "default": {
+      "otel.resource.ec2.tag.aws:autoscaling:groupName": "^{{platformInfo}}$",
+      "otel.resource.host.id": "^{{instanceId}}$",
+      "otel.resource.host.image.id": "^{{instanceAmi}}$",
+      "otel.resource.host.type": "^t3.micro$",
+      "otel.resource.host.name": "^{{privateDnsName}}$"
+    }
+  },
+  "subsegments": [
+    {
+      "name": "^local-root-client-call$",
+      "http": {
+        "request": {
+          "url": "^http://local-root-client-call/$",
+          "method": "^GET$"
+        }
+      },
+      "annotations": {
+        "aws.local.service": "^{{serviceName}}$",
+        "aws.local.operation": "^InternalOperation$",
+        "aws.remote.service": "^local-root-client-call$",
+        "aws.remote.operation": "GET /",
+        "aws.local.environment": "^ec2:{{platformInfo}}$"
+      },
+      "metadata": {
+        "default": {
+          "EC2.AutoScalingGroup": "^{{platformInfo}}$",
+          "EC2.InstanceId": "^{{instanceId}}$",
+          "PlatformType": "^AWS::EC2$",
+          "aws.span.kind": "^LOCAL_ROOT$"
+        }
+      },
+      "namespace": "^remote$"
+    }
+  ]
+},
+{
+  "name": "^local-root-client-call$",
+  "http": {
+    "request": {
+      "url": "^http://local-root-client-call/$",
+      "method": "^GET$"
+    },
+    "response": {
+      "content_length": 0
+    }
+  },
+  "annotations": {
+    "aws.local.service": "^local-root-client-call$",
+    "aws.local.operation": "^GET /$"
+  }
+}]

--- a/validator/src/main/resources/expected-data-template/node/ec2/asg/outgoing-http-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/asg/outgoing-http-call-log.mustache
@@ -1,0 +1,22 @@
+[{
+  "EC2.AutoScalingGroup": "^{{platformInfo}}$",
+  "EC2.InstanceId": "^{{instanceId}}$",
+  "Environment": "^ec2:{{platformInfo}}$",
+  "PlatformType": "^AWS::EC2$",
+  "Operation": "GET /outgoing-http-call",
+  "Version": "^1$",
+  "Telemetry.Source": "^LocalRootSpan$",
+  "Host": "^{{privateDnsName}}$"
+},
+{
+  "EC2.AutoScalingGroup": "^{{platformInfo}}$",
+  "EC2.InstanceId": "^{{instanceId}}$",
+  "Environment": "^ec2:{{platformInfo}}$",
+  "PlatformType": "^AWS::EC2$",
+  "Operation": "GET /outgoing-http-call",
+  "Version": "^1$",
+  "RemoteService": "www.amazon.com:80",
+  "RemoteOperation": "GET /",
+  "Telemetry.Source": "^ClientSpan$",
+  "Host": "^{{privateDnsName}}$"
+}]

--- a/validator/src/main/resources/expected-data-template/node/ec2/asg/outgoing-http-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/asg/outgoing-http-call-metric.mustache
@@ -1,0 +1,227 @@
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /outgoing-http-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /outgoing-http-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /outgoing-http-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /outgoing-http-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /outgoing-http-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /outgoing-http-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteService
+      value: www.amazon.com:80

--- a/validator/src/main/resources/expected-data-template/node/ec2/asg/outgoing-http-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/asg/outgoing-http-call-trace.mustache
@@ -1,0 +1,64 @@
+[{
+  "name": "^{{serviceName}}$",
+  "http": {
+    "request": {
+      "url": "^{{endpoint}}/outgoing-http-call$",
+      "method": "^GET$"
+    }
+  },
+  "aws": {
+    "account_id": "^{{accountId}}$"
+  },
+  "annotations": {
+    "aws.local.service": "^{{serviceName}}$",
+    "aws.local.operation": "^GET /outgoing-http-call$",
+    "aws.local.environment": "^ec2:{{platformInfo}}$"
+  },
+  "metadata": {
+    "default": {
+      "EC2.AutoScalingGroup": "^{{platformInfo}}$",
+      "EC2.InstanceId": "^{{instanceId}}$",
+      "otel.resource.ec2.tag.aws:autoscaling:groupName": "^{{platformInfo}}$",
+      "otel.resource.host.id": "^{{instanceId}}$",
+      "PlatformType": "^AWS::EC2$",
+      "otel.resource.host.image.id": "^{{instanceAmi}}$",
+      "otel.resource.host.type": "^t3.micro$",
+      "otel.resource.host.name": "^{{privateDnsName}}$",
+      "aws.span.kind": "^LOCAL_ROOT$"
+    }
+  },
+  "subsegments": [
+    {
+      "name": "^www.amazon.com:80$",
+      "annotations": {
+        "aws.local.service": "^{{serviceName}}$",
+        "aws.local.operation": "^GET /outgoing-http-call$",
+        "aws.remote.service": "^www.amazon.com:80$",
+        "aws.remote.operation": "^GET /$",
+        "aws.local.environment": "^ec2:{{platformInfo}}$"
+      },
+      "metadata": {
+        "default": {
+          "EC2.InstanceId": "^{{instanceId}}$",
+          "PlatformType": "^AWS::EC2$",
+          "aws.span.kind": "^CLIENT$"
+        }
+      },
+      "http": {
+        "request": {
+          "url": "^http://www.amazon.com/$",
+          "method": "^GET$"
+        }
+      },
+      "subsegments": [
+        {
+          "name": "^www.amazon.com$"
+        }
+      ],
+      "namespace": "^remote$"
+    }
+  ]
+},
+{
+  "name": "^www.amazon.com:80$"
+}]

--- a/validator/src/main/resources/expected-data-template/node/ec2/asg/remote-service-log.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/asg/remote-service-log.mustache
@@ -1,0 +1,22 @@
+[{
+  "EC2.AutoScalingGroup": "^{{platformInfo}}$",
+  "EC2.InstanceId": "^{{instanceId}}$",
+  "Environment": "^ec2:{{platformInfo}}$",
+  "PlatformType": "^AWS::EC2$",
+  "Operation": "GET /remote-service",
+  "Version": "^1$",
+  "Telemetry.Source": "^LocalRootSpan$",
+  "Host": "^{{privateDnsName}}$"
+},
+{
+  "EC2.AutoScalingGroup": "^{{platformInfo}}$",
+  "EC2.InstanceId": "^{{instanceId}}$",
+  "Environment": "^ec2:{{platformInfo}}$",
+  "PlatformType": "^AWS::EC2$",
+  "Operation": "GET /remote-service",
+  "Version": "^1$",
+  "RemoteService": "{{remoteServiceDeploymentName}}",
+  "RemoteOperation": "GET /healthcheck",
+  "Telemetry.Source": "^ClientSpan$",
+  "Host": "^{{privateDnsName}}$"
+}]

--- a/validator/src/main/resources/expected-data-template/node/ec2/asg/remote-service-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/asg/remote-service-metric.mustache
@@ -1,0 +1,326 @@
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: Operation
+      value: GET /healthcheck
+    -
+      name: Service
+      value: {{remoteServiceName}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{remoteServiceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: Operation
+      value: GET /healthcheck
+    -
+      name: Service
+      value: {{remoteServiceName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{remoteServiceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: Operation
+      value: GET /healthcheck
+    -
+      name: Service
+      value: {{remoteServiceName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{remoteServiceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}

--- a/validator/src/main/resources/expected-data-template/node/ec2/asg/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/asg/remote-service-trace.mustache
@@ -1,0 +1,83 @@
+[{
+  "name": "^{{serviceName}}$",
+  "http": {
+    "request": {
+      "url": "^{{endpoint}}/remote-service\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
+      "method": "^GET$"
+    }
+  },
+  "aws": {
+    "account_id": "^{{accountId}}$"
+  },
+  "annotations": {
+    "aws.local.service": "^{{serviceName}}$",
+    "aws.local.operation": "^GET /remote-service$",
+    "aws.local.environment": "^ec2:{{platformInfo}}$"
+  },
+  "metadata": {
+    "default": {
+      "EC2.AutoScalingGroup": "^{{platformInfo}}$",
+      "EC2.InstanceId": "^{{instanceId}}$",
+      "PlatformType": "^AWS::EC2$",
+      "otel.resource.ec2.tag.aws:autoscaling:groupName": "^{{platformInfo}}$",
+      "otel.resource.host.id": "^{{instanceId}}$",
+      "otel.resource.host.image.id": "^{{instanceAmi}}$",
+      "otel.resource.host.type": "^t3.micro$",
+      "otel.resource.host.name": "^{{privateDnsName}}$",
+      "aws.span.kind": "^LOCAL_ROOT$"
+    }
+  },
+  "subsegments": [
+    {
+      "annotations": {
+        "aws.local.service": "^{{serviceName}}$",
+        "aws.local.operation": "^GET /remote-service$",
+        "aws.remote.service": "^{{remoteServiceDeploymentName}}:8001$",
+        "aws.remote.operation": "^GET /healthcheck$",
+        "aws.local.environment": "^ec2:{{platformInfo}}$"
+      },
+      "metadata": {
+        "default": {
+          "EC2.AutoScalingGroup": "^{{platformInfo}}$",
+          "EC2.InstanceId": "^{{instanceId}}$",
+          "PlatformType": "^AWS::EC2$",
+          "aws.span.kind": "^CLIENT$"
+        }
+      },
+      "namespace": "^remote$",
+      "subsegments": [
+        {
+          "name": "^{{remoteServiceDeploymentName}}$",
+          "http": {
+            "request": {
+              "url": "^http://(([0-9]{1,3}.){3}[0-9]{1,3}):8001/$"
+            }
+          }
+        }
+      ]
+    }
+  ]
+},
+{
+  "name": "^{{remoteServiceName}}$",
+  "http": {
+    "request": {
+      "url": "^http://(([0-9]{1,3}.){3}[0-9]{1,3}):8001/healthcheck$",
+      "method": "^GET$"
+    }
+  },
+  "annotations": {
+    "aws.local.service": "^{{remoteServiceName}}$",
+    "aws.local.operation": "^GET /healthcheck$",
+    "aws.local.environment": "^ec2:default$"
+  },
+  "metadata": {
+    "default": {
+      "EC2.InstanceId": "^i-[A-Za-z0-9]{17}$",
+      "PlatformType": "^AWS::EC2$",
+      "otel.resource.host.image.id": "^{{instanceAmi}}$",
+      "otel.resource.host.type": "^t3.micro$",
+      "aws.span.kind": "^LOCAL_ROOT$"
+    }
+  }
+}]

--- a/validator/src/main/resources/expected-data-template/node/ec2/default/aws-sdk-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/default/aws-sdk-call-log.mustache
@@ -1,0 +1,22 @@
+[{
+  "EC2.InstanceId": "^{{instanceId}}$",
+  "Environment": "^ec2:default$",
+  "PlatformType": "^AWS::EC2$",
+  "Operation": "GET /aws-sdk-call",
+  "Version": "^1$",
+  "Telemetry.Source": "^LocalRootSpan$",
+  "Host": "^ip(-[0-9]{1,3}){4}.*$"
+},
+{
+  "EC2.InstanceId": "^{{instanceId}}$",
+  "Environment": "^ec2:default$",
+  "PlatformType": "^AWS::EC2$",
+  "Operation": "GET /aws-sdk-call",
+  "Version": "^1$",
+  "RemoteService": "AWS::S3",
+  "RemoteOperation": "GetBucketLocation",
+  "RemoteResourceIdentifier": "^e2e-test-bucket-name-{{testingId}}$",
+  "RemoteResourceType": "^AWS::S3::Bucket$",
+  "Telemetry.Source": "^ClientSpan$",
+  "Host": "^ip(-[0-9]{1,3}){4}.*$"
+}]

--- a/validator/src/main/resources/expected-data-template/node/ec2/default/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/default/aws-sdk-call-metric.mustache
@@ -1,0 +1,376 @@
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: e2e-test-bucket-name-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: e2e-test-bucket-name-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: e2e-test-bucket-name-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: e2e-test-bucket-name-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: e2e-test-bucket-name-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: e2e-test-bucket-name-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket
+
+

--- a/validator/src/main/resources/expected-data-template/node/ec2/default/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/default/aws-sdk-call-trace.mustache
@@ -1,0 +1,49 @@
+[{
+  "name": "^{{serviceName}}$",
+  "http": {
+    "request": {
+      "url": "^{{endpoint}}/aws-sdk-call\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
+      "method": "^GET$"
+    }
+  },
+  "aws": {
+    "account_id": "^{{accountId}}$"
+  },
+  "annotations": {
+    "aws.local.service": "^{{serviceName}}$",
+    "aws.local.operation": "^GET /aws-sdk-call$",
+    "aws.local.environment": "^ec2:default$"
+  },
+  "metadata": {
+    "default": {
+      "EC2.InstanceId": "^{{instanceId}}$",
+      "PlatformType": "^AWS::EC2$",
+      "otel.resource.host.image.id": "^{{instanceAmi}}$",
+      "otel.resource.host.type": "^t3.small$",
+      "aws.span.kind": "^LOCAL_ROOT$"
+    }
+  },
+  "subsegments": [
+    {
+      "name": "^S3$",
+      "annotations": {
+        "aws.local.service": "^{{serviceName}}$",
+        "aws.local.operation": "^GET /aws-sdk-call$",
+        "aws.remote.service": "^AWS::S3$",
+        "aws.remote.operation": "^GetBucketLocation$",
+        "aws.remote.resource.type": "^AWS::S3::Bucket$",
+        "aws.remote.resource.identifier": "^e2e-test-bucket-name-{{testingId}}$",
+        "aws.local.environment": "^ec2:default$"
+      },
+      "metadata": {
+        "default": {
+          "EC2.InstanceId": "^{{instanceId}}$",
+          "PlatformType": "^AWS::EC2$",
+          "aws.span.kind": "^CLIENT$",
+          "aws.s3.bucket": "^e2e-test-bucket-name-{{testingId}}$"
+        }
+      },
+      "namespace": "^aws$"
+    }
+  ]
+}]

--- a/validator/src/main/resources/expected-data-template/node/ec2/default/client-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/default/client-call-log.mustache
@@ -1,0 +1,20 @@
+[{
+  "EC2.InstanceId": "^{{instanceId}}$",
+  "Environment": "^ec2:default$",
+  "PlatformType": "^AWS::EC2$",
+  "Operation": "InternalOperation",
+  "Version": "^1$",
+  "Telemetry.Source": "^LocalRootSpan$",
+  "Host": "^ip(-[0-9]{1,3}){4}.*$"
+},
+{
+  "EC2.InstanceId": "^{{instanceId}}$",
+  "Environment": "^ec2:default$",
+  "PlatformType": "^AWS::EC2$",
+  "Operation": "InternalOperation",
+  "Version": "^1$",
+  "RemoteService": "local-root-client-call",
+  "RemoteOperation": "GET /",
+  "Telemetry.Source": "^ClientSpan$",
+  "Host": "^ip(-[0-9]{1,3}){4}.*$"
+}]

--- a/validator/src/main/resources/expected-data-template/node/ec2/default/client-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/default/client-call-metric.mustache
@@ -1,0 +1,227 @@
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: local-root-client-call
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: local-root-client-call
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: local-root-client-call

--- a/validator/src/main/resources/expected-data-template/node/ec2/default/client-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/default/client-call-trace.mustache
@@ -1,0 +1,56 @@
+[{
+  "name": "^{{serviceName}}$",
+  "annotations": {
+    "aws.local.service": "^{{serviceName}}$",
+    "aws.local.operation": "^InternalOperation$",
+    "aws.local.environment": "^ec2:default$"
+  },
+  "metadata": {
+    "default": {
+      "otel.resource.host.image.id": "^{{instanceAmi}}$",
+      "otel.resource.host.type": "^t3.small$"
+    }
+  },
+  "subsegments": [
+    {
+      "name": "^local-root-client-call$",
+      "http": {
+          "request": {
+              "url": "^http://local-root-client-call/$",
+              "method": "^GET$"
+          }
+      },
+      "annotations": {
+        "aws.local.service": "^{{serviceName}}$",
+        "aws.local.operation": "^InternalOperation$",
+        "aws.remote.service": "^local-root-client-call$",
+        "aws.remote.operation": "GET /",
+        "aws.local.environment": "^ec2:default$"
+      },
+      "metadata": {
+        "default": {
+          "EC2.InstanceId": "^{{instanceId}}$",
+          "PlatformType": "^AWS::EC2$",
+          "aws.span.kind": "^LOCAL_ROOT$"
+        }
+      },
+      "namespace": "^remote$"
+    }
+  ]
+},
+{
+    "name": "^local-root-client-call$",
+    "http": {
+        "request": {
+            "url": "^http://local-root-client-call/$",
+            "method": "^GET$"
+        },
+        "response": {
+            "content_length": 0
+        }
+    },
+    "annotations": {
+        "aws.local.service": "^local-root-client-call$",
+        "aws.local.operation": "^GET /$"
+    }
+}]

--- a/validator/src/main/resources/expected-data-template/node/ec2/default/outgoing-http-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/default/outgoing-http-call-log.mustache
@@ -1,0 +1,21 @@
+[{
+  "EC2.InstanceId": "^{{instanceId}}$",
+  "Environment": "^ec2:default$",
+  "PlatformType": "^AWS::EC2$",
+  "Operation": "GET /outgoing-http-call",
+  "Version": "^1$",
+  "Telemetry.Source": "^LocalRootSpan$",
+  "Host": "^ip(-[0-9]{1,3}){4}.*$"
+},
+{
+  "EC2.InstanceId": "^{{instanceId}}$",
+  "Environment": "^ec2:default$",
+  "PlatformType": "^AWS::EC2$",
+  "Operation": "GET /outgoing-http-call",
+  "Version": "^1$",
+  "RemoteService": "www.amazon.com:80",
+  "RemoteOperation": "GET /",
+  "Telemetry.Source": "^ClientSpan$",
+  "Host": "^ip(-[0-9]{1,3}){4}.*$"
+}]
+

--- a/validator/src/main/resources/expected-data-template/node/ec2/default/outgoing-http-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/default/outgoing-http-call-metric.mustache
@@ -1,0 +1,227 @@
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /outgoing-http-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /outgoing-http-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /outgoing-http-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /outgoing-http-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /outgoing-http-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /outgoing-http-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: www.amazon.com:80

--- a/validator/src/main/resources/expected-data-template/node/ec2/default/outgoing-http-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/default/outgoing-http-call-trace.mustache
@@ -1,0 +1,60 @@
+[{
+  "name": "^{{serviceName}}$",
+  "http": {
+    "request": {
+      "url": "^{{endpoint}}/outgoing-http-call$",
+      "method": "^GET$"
+    }
+  },
+  "aws": {
+    "account_id": "^{{accountId}}$"
+  },
+  "annotations": {
+    "aws.local.service": "^{{serviceName}}$",
+    "aws.local.operation": "^GET /outgoing-http-call$",
+    "aws.local.environment": "^ec2:default$"
+  },
+  "metadata": {
+    "default": {
+      "EC2.InstanceId": "^{{instanceId}}$",
+      "PlatformType": "^AWS::EC2$",
+      "otel.resource.host.image.id": "^{{instanceAmi}}$",
+      "otel.resource.host.type": "^t3.small$",
+      "aws.span.kind": "^LOCAL_ROOT$"
+    }
+  },
+  "subsegments": [
+    {
+      "name": "^www.amazon.com:80$",
+      "annotations": {
+        "aws.local.service": "^{{serviceName}}$",
+        "aws.local.operation": "^GET /outgoing-http-call$",
+        "aws.remote.service": "^www.amazon.com:80$",
+        "aws.remote.operation": "^GET /$",
+        "aws.local.environment": "^ec2:default$"
+      },
+      "metadata": {
+        "default": {
+          "EC2.InstanceId": "^{{instanceId}}$",
+          "PlatformType": "^AWS::EC2$",
+          "aws.span.kind": "^CLIENT$"
+        }
+      },
+      "http": {
+        "request": {
+          "url": "^http://www.amazon.com/$",
+          "method": "^GET$"
+        }
+      },
+      "subsegments": [
+        {
+          "name": "^www.amazon.com$"
+        }
+      ],
+      "namespace": "^remote$"
+    }
+  ]
+},
+{
+  "name": "^www.amazon.com:80$"
+}]

--- a/validator/src/main/resources/expected-data-template/node/ec2/default/remote-service-log.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/default/remote-service-log.mustache
@@ -1,0 +1,20 @@
+[{
+  "EC2.InstanceId": "^{{instanceId}}$",
+  "Environment": "^ec2:default$",
+  "PlatformType": "^AWS::EC2$",
+  "Operation": "GET /remote-service",
+  "Version": "^1$",
+  "Telemetry.Source": "^LocalRootSpan$",
+  "Host": "^ip(-[0-9]{1,3}){4}.*$"
+},
+{
+  "EC2.InstanceId": "^{{instanceId}}$",
+  "Environment": "^ec2:default$",
+  "PlatformType": "^AWS::EC2$",
+  "Operation": "GET /remote-service",
+  "Version": "^1$",
+  "RemoteService": "{{remoteServiceDeploymentName}}",
+  "RemoteOperation": "GET /healthcheck",
+  "Telemetry.Source": "^ClientSpan$",
+  "Host": "^ip(-[0-9]{1,3}){4}.*$"
+}]

--- a/validator/src/main/resources/expected-data-template/node/ec2/default/remote-service-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/default/remote-service-metric.mustache
@@ -1,0 +1,326 @@
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: Operation
+      value: GET /healthcheck
+    -
+      name: Service
+      value: {{remoteServiceName}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{remoteServiceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: Operation
+      value: GET /healthcheck
+    -
+      name: Service
+      value: {{remoteServiceName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{remoteServiceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: Operation
+      value: GET /healthcheck
+    -
+      name: Service
+      value: {{remoteServiceName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{remoteServiceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}

--- a/validator/src/main/resources/expected-data-template/node/ec2/default/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/default/remote-service-trace.mustache
@@ -1,0 +1,78 @@
+[{
+  "name": "^{{serviceName}}$",
+  "http": {
+    "request": {
+      "url": "^{{endpoint}}/remote-service\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
+      "method": "^GET$"
+    }
+  },
+  "aws": {
+    "account_id": "^{{accountId}}$"
+  },
+  "annotations": {
+    "aws.local.service": "^{{serviceName}}$",
+    "aws.local.operation": "^GET /remote-service$",
+    "aws.local.environment": "^ec2:default$"
+  },
+  "metadata": {
+    "default": {
+      "EC2.InstanceId": "^{{instanceId}}$",
+      "PlatformType": "^AWS::EC2$",
+      "otel.resource.host.image.id": "^{{instanceAmi}}$",
+      "otel.resource.host.type": "^t3.small$",
+      "aws.span.kind": "^LOCAL_ROOT$"
+    }
+  },
+  "subsegments": [
+    {
+      "annotations": {
+        "aws.local.service": "^{{serviceName}}$",
+        "aws.local.operation": "^GET /remote-service$",
+        "aws.remote.service": "^{{remoteServiceDeploymentName}}:8001$",
+        "aws.remote.operation": "^GET /healthcheck$",
+        "aws.local.environment": "^ec2:default$"
+      },
+      "metadata": {
+        "default": {
+          "EC2.InstanceId": "^{{instanceId}}$",
+          "PlatformType": "^AWS::EC2$",
+          "aws.span.kind": "^CLIENT$"
+        }
+      },
+      "namespace": "^remote$",
+      "subsegments": [
+        {
+          "name": "^{{remoteServiceDeploymentName}}$",
+          "http": {
+            "request": {
+              "url": "^http://(([0-9]{1,3}.){3}[0-9]{1,3}):8001/$"
+            }
+          }
+        }
+      ]
+    }
+  ]
+},
+{
+  "name": "^{{remoteServiceName}}$",
+  "http": {
+    "request": {
+      "url": "^http://(([0-9]{1,3}.){3}[0-9]{1,3}):8001/healthcheck$",
+      "method": "^GET$"
+    }
+  },
+  "annotations": {
+    "aws.local.service": "^{{remoteServiceName}}$",
+    "aws.local.operation": "^GET /healthcheck$",
+    "aws.local.environment": "^ec2:default$"
+  },
+  "metadata": {
+    "default": {
+      "EC2.InstanceId": "^i-[A-Za-z0-9]{17}$",
+      "PlatformType": "^AWS::EC2$",
+      "otel.resource.host.image.id": "^{{instanceAmi}}$",
+      "otel.resource.host.type": "^t3.small$",
+      "aws.span.kind": "^LOCAL_ROOT$"
+    }
+  }
+}]

--- a/validator/src/main/resources/validations/node/ec2/asg/log-validation.yml
+++ b/validator/src/main/resources/validations/node/ec2/asg/log-validation.yml
@@ -1,0 +1,25 @@
+-
+  validationType: "cw-log"
+  httpPath: "/outgoing-http-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedLogStructureTemplate: "NODE_EC2_ASG_OUTGOING_HTTP_CALL_LOG"
+-
+  validationType: "cw-log"
+  httpPath: "/aws-sdk-call"
+  httpMethod: "get"
+  callingType: "http-with-query"
+  expectedLogStructureTemplate: "NODE_EC2_ASG_AWS_SDK_CALL_LOG"
+-
+  validationType: "cw-log"
+  httpPath: "/remote-service"
+  httpMethod: "get"
+  callingType: "http-with-query"
+  expectedLogStructureTemplate: "NODE_EC2_ASG_REMOTE_SERVICE_LOG"
+-
+  validationType: "cw-log"
+  httpPath: "/client-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedLogStructureTemplate: "NODE_EC2_ASG_CLIENT_CALL_LOG"
+

--- a/validator/src/main/resources/validations/node/ec2/asg/metric-validation.yml
+++ b/validator/src/main/resources/validations/node/ec2/asg/metric-validation.yml
@@ -1,0 +1,25 @@
+-
+  validationType: "cw-metric"
+  httpPath: "/outgoing-http-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedMetricTemplate: "NODE_EC2_ASG_OUTGOING_HTTP_CALL_METRIC"
+-
+  validationType: "cw-metric"
+  httpPath: "/aws-sdk-call"
+  httpMethod: "get"
+  callingType: "http-with-query"
+  expectedMetricTemplate: "NODE_EC2_ASG_AWS_SDK_CALL_METRIC"
+-
+  validationType: "cw-metric"
+  httpPath: "/remote-service"
+  httpMethod: "get"
+  callingType: "http-with-query"
+  expectedMetricTemplate: "NODE_EC2_ASG_REMOTE_SERVICE_METRIC"
+-
+  validationType: "cw-metric"
+  httpPath: "/client-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedMetricTemplate: "NODE_EC2_ASG_CLIENT_CALL_METRIC"
+

--- a/validator/src/main/resources/validations/node/ec2/asg/trace-validation.yml
+++ b/validator/src/main/resources/validations/node/ec2/asg/trace-validation.yml
@@ -1,0 +1,24 @@
+-
+  validationType: "trace"
+  httpPath: "/outgoing-http-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedTraceTemplate: "NODE_EC2_ASG_OUTGOING_HTTP_CALL_TRACE"
+-
+  validationType: "trace"
+  httpPath: "/aws-sdk-call"
+  httpMethod: "get"
+  callingType: "http-with-query"
+  expectedTraceTemplate: "NODE_EC2_ASG_AWS_SDK_CALL_TRACE"
+-
+  validationType: "trace"
+  httpPath: "/remote-service"
+  httpMethod: "get"
+  callingType: "http-with-query"
+  expectedTraceTemplate: "NODE_EC2_ASG_REMOTE_SERVICE_TRACE"
+-
+  validationType: "trace"
+  httpPath: "/client-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedTraceTemplate: "NODE_EC2_ASG_CLIENT_CALL_TRACE"

--- a/validator/src/main/resources/validations/node/ec2/default/log-validation.yml
+++ b/validator/src/main/resources/validations/node/ec2/default/log-validation.yml
@@ -1,0 +1,25 @@
+-
+  validationType: "cw-log"
+  httpPath: "/outgoing-http-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedLogStructureTemplate: "NODE_EC2_DEFAULT_OUTGOING_HTTP_CALL_LOG"
+-
+  validationType: "cw-log"
+  httpPath: "/aws-sdk-call"
+  httpMethod: "get"
+  callingType: "http-with-query"
+  expectedLogStructureTemplate: "NODE_EC2_DEFAULT_AWS_SDK_CALL_LOG"
+-
+  validationType: "cw-log"
+  httpPath: "/remote-service"
+  httpMethod: "get"
+  callingType: "http-with-query"
+  expectedLogStructureTemplate: "NODE_EC2_DEFAULT_REMOTE_SERVICE_LOG"
+-
+  validationType: "cw-log"
+  httpPath: "/client-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedLogStructureTemplate: "NODE_EC2_DEFAULT_CLIENT_CALL_LOG"
+

--- a/validator/src/main/resources/validations/node/ec2/default/metric-validation.yml
+++ b/validator/src/main/resources/validations/node/ec2/default/metric-validation.yml
@@ -1,0 +1,25 @@
+-
+  validationType: "cw-metric"
+  httpPath: "/outgoing-http-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedMetricTemplate: "NODE_EC2_DEFAULT_OUTGOING_HTTP_CALL_METRIC"
+-
+  validationType: "cw-metric"
+  httpPath: "/aws-sdk-call"
+  httpMethod: "get"
+  callingType: "http-with-query"
+  expectedMetricTemplate: "NODE_EC2_DEFAULT_AWS_SDK_CALL_METRIC"
+-
+  validationType: "cw-metric"
+  httpPath: "/remote-service"
+  httpMethod: "get"
+  callingType: "http-with-query"
+  expectedMetricTemplate: "NODE_EC2_DEFAULT_REMOTE_SERVICE_METRIC"
+-
+  validationType: "cw-metric"
+  httpPath: "/client-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedMetricTemplate: "NODE_EC2_DEFAULT_CLIENT_CALL_METRIC"
+

--- a/validator/src/main/resources/validations/node/ec2/default/trace-validation.yml
+++ b/validator/src/main/resources/validations/node/ec2/default/trace-validation.yml
@@ -1,0 +1,24 @@
+-
+  validationType: "trace"
+  httpPath: "/outgoing-http-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedTraceTemplate: "NODE_EC2_DEFAULT_OUTGOING_HTTP_CALL_TRACE"
+-
+  validationType: "trace"
+  httpPath: "/aws-sdk-call"
+  httpMethod: "get"
+  callingType: "http-with-query"
+  expectedTraceTemplate: "NODE_EC2_DEFAULT_AWS_SDK_CALL_TRACE"
+-
+  validationType: "trace"
+  httpPath: "/remote-service"
+  httpMethod: "get"
+  callingType: "http-with-query"
+  expectedTraceTemplate: "NODE_EC2_DEFAULT_REMOTE_SERVICE_TRACE"
+-
+  validationType: "trace"
+  httpPath: "/client-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedTraceTemplate: "NODE_EC2_DEFAULT_CLIENT_CALL_TRACE"


### PR DESCRIPTION
### Issue description
Introduce first iteration of EC2 canary and EC2/ASG release tests. Release tests are not yet created, as the first release needs to be completed for the mechanisms to be ready for the test to test them effectively.

Notes:
- ASG will not be run as a canary, but was included in the PR for review as a release test and both it and the EC2 default case will be finalized later as we continue the release of JS support. As such, it was included in the canary/cronjob workflow file during testing and removed for the purpose of the PR, hence the mismatch in commit IDs between the test runs and the PR.
- The canary only runs in IAD, as we have not currently released the instrumentation into a publicly accessible/regionally accessible distribution. It is only accessible by our IAD account at this point. Again, we will come back and update this as part of our canary/release testing finalization.

### Description of changes
- New EC2/ASG test covering log, metric, and trace validation
- Modified NodeJS sample app to properly generate InternalOperation code
- Update trace validator to provide extra, useful information regarding which key failed to match when there is a mismatch

### Rollback procedure
Revert PR

### Testing
- Test run showing both EC2 default and EC2 ASG pass: [link](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10710109928)
- Test run 2: [link](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10710723264/job/29698040394)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
