### PR TITLE
Enhance Logs E2E test and bump up MySQL library to 8.4

### DIFF
--- a/sample-apps/springboot/build.gradle.kts
+++ b/sample-apps/springboot/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
   implementation("io.opentelemetry:opentelemetry-api:1.34.1")
   implementation("software.amazon.awssdk:s3")
   implementation("software.amazon.awssdk:sts")
-  implementation("com.mysql:mysql-connector-j:8.0.33")
+  implementation("com.mysql:mysql-connector-j:8.4.0")
 }
 
 jib {

--- a/validator/src/main/java/com/amazon/aoc/validators/CWLogValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/CWLogValidator.java
@@ -66,9 +66,11 @@ public class CWLogValidator implements IValidator {
           String operation = (String) expectedAttributes.get("Operation");
           String remoteService = (String) expectedAttributes.get("RemoteService");
           String remoteOperation = (String) expectedAttributes.get("RemoteOperation");
+          String remoteResourceType = (String) expectedAttributes.get("RemoteResourceType");
+          String remoteResourceIdentifier = (String) expectedAttributes.get("RemoteResourceIdentifier");
 
           Map<String, Object> actualLog =
-                  this.getActualLog(operation, remoteService, remoteOperation);
+                  this.getActualLog(operation, remoteService, remoteOperation, remoteResourceType, remoteResourceIdentifier);
           log.info("Value of an actual log: {}", actualLog);
 
           if (actualLog == null) throw new BaseException(ExceptionCode.EXPECTED_LOG_NOT_FOUND);
@@ -126,7 +128,7 @@ public class CWLogValidator implements IValidator {
   }
 
   private Map<String, Object> getActualLog(
-      String operation, String remoteService, String remoteOperation) throws Exception {
+    String operation, String remoteService, String remoteOperation, String remoteResourceType, String remoteResourceIdentifier) throws Exception {
     String dependencyFilter = null;
 
     // Dependency calls will have the remoteService and remoteOperation attribute, but service calls
@@ -137,6 +139,10 @@ public class CWLogValidator implements IValidator {
       dependencyFilter = "&& ($.RemoteService NOT EXISTS) && ($.RemoteOperation NOT EXISTS)";
     } else {
       dependencyFilter = String.format("&& ($.RemoteService = \"%s\") && ($.RemoteOperation = \"%s\")", remoteService, remoteOperation);
+    }
+
+    if (remoteResourceType != null && remoteResourceIdentifier != null) {
+      dependencyFilter += String.format(" && ($.RemoteResourceType = %%%s%%) && ($.RemoteResourceIdentifier = %%%s%%)", remoteResourceType, remoteResourceIdentifier);
     }
 
     String filterPattern = String.format("{ ($.Service = %s) && ($.Operation = \"%s\") %s }", context.getServiceName(), operation, dependencyFilter);


### PR DESCRIPTION
*Issue description:*

In this PR:
- Supports remoteResourceType and remoteResourceIdentifier filter when fetching from Logs.
- Migrating MySQL to 8.4.

E2E test run: https://github.com/ektabj/aws-application-signals-test-framework/actions/runs/10726494758

Issue description:

When we assert `RemoteResourceType` and `RemoteResourceIdentifier` attributes in [EMF logs](https://github.com/aws-observability/aws-application-signals-test-framework/blob/main/validator/src/main/resources/expected-data-template/java/eks/aws-sdk-call-log.mustache#L30-L33), we are using Logs filter: `RemoteService` and `RemoteOperation` filter to fetch logs. However, it's not guaranteed that EMF log with `RemoteService` and `RemoteOperation` attributes will have `RemoteResourceType` and `RemoteResourceIdentifier`. The logs fetched with this generic filter might get more logs than expected and only asserting the first log event in the result.

Description of changes:

This change enhances the log filter by appending  `&& ($.RemoteResourceType = %EXAMPLE%) && ($.RemoteResourceIdentifier = %EXAMPLE%)` to the filter if they present in the template to get more specific log events.

Log Filter doc: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html#regex-expressions

Log Filter used before this change (From E2E testing log):
```
2024-07-02T13:41:46.9400277Z 13:41:46.840 [main] INFO  com.amazon.aoc.validators.CWLogValidator - Filter Pattern for Log Search: { ($.Service = sample-application-eu-west-1-9762031914-112) && ($.Operation = "GET /aws-sdk-call") && ($.RemoteService = "AWS::S3") && ($.RemoteOperation = "GetBucketLocation") }
```
Log Filter used after this change (From E2E testing log):
```
2024-07-02T13:49:00.6162597Z 13:49:00.510 [main] INFO  com.amazon.aoc.validators.CWLogValidator - Filter Pattern for Log Search: { ($.Service = sample-application-eu-west-1-9762033464-113) && ($.Operation = "GET /aws-sdk-call") && ($.RemoteService = "AWS::S3") && ($.RemoteOperation = "GetBucketLocation") && ($.RemoteResourceType = %^AWS::S3::Bucket$%) && ($.RemoteResourceIdentifier = %^e2e-test-bucket-name-eu-west-1-9762033464-113$%) }
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.