### PR TITLE
[DotNet/Node|K8s] Set up infra for canaries/release tests

### DIFF
--- a/.github/workflows/k8s-patch-os-jobs.yml
+++ b/.github/workflows/k8s-patch-os-jobs.yml
@@ -112,9 +112,31 @@ jobs:
       caller-workflow-name: 'k8s-os-patching'
       caller-repository: ${{ inputs.repo_name }}
 
+  # TODO: Update to use dotnet-k8s-test once it's available
+  run-dotnet-k8s-test:
+    if: ${{ inputs.LANGUAGE == 'dotnet' }}
+    needs: create-k8s-on-ec2
+    uses: ./.github/workflows/java-k8s-test.yml
+    secrets: inherit
+    with:
+      aws-region: 'us-east-1'
+      caller-workflow-name: 'k8s-os-patching'
+      caller-repository: ${{ inputs.repo_name }}
+
+  # TODO: Update to use node-k8s-test once it's available
+  run-node-k8s-test:
+    if: ${{ inputs.LANGUAGE == 'node' }}
+    needs: create-k8s-on-ec2
+    uses: ./.github/workflows/java-k8s-test.yml
+    secrets: inherit
+    with:
+      aws-region: 'us-east-1'
+      caller-workflow-name: 'k8s-os-patching'
+      caller-repository: ${{ inputs.repo_name }}
+
   update-secrets:
-    needs: [ run-java-k8s-test, run-python-k8s-test ]
-    if: ${{ always() && (needs.run-java-k8s-test.result == 'success' || needs.run-python-k8s-test.result == 'success') }}
+    needs: [ run-java-k8s-test, run-python-k8s-test, run-dotnet-k8s-test, run-node-k8s-test ]
+    if: ${{ always() && (needs.run-java-k8s-test.result == 'success' || needs.run-python-k8s-test.result == 'success' || needs.run-dotnet-k8s-test.result == 'success'  || needs.run-node-k8s-test.result == 'success') }}
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
@@ -170,8 +192,8 @@ jobs:
       validation-result: ${{ needs.update-secrets.result }}
 
   cleanup-if-failed:
-    needs: [ run-java-k8s-test, run-python-k8s-test ]
-    if: ${{ always() && (needs.run-java-k8s-test.result != 'success' && needs.run-python-k8s-test.result != 'success') }}
+    needs: [ run-java-k8s-test, run-python-k8s-test, run-dotnet-k8s-test, run-node-k8s-test ]
+    if: ${{ always() && (needs.run-java-k8s-test.result != 'success' && needs.run-python-k8s-test.result != 'success' && needs.run-dotnet-k8s-test.result != 'success' && needs.run-node-k8s-test.result != 'success') }}
     runs-on: ubuntu-latest
     steps:
       - name: Delete Key Pair and EC2 Instance

--- a/.github/workflows/k8s-patch-os-matrix.yml
+++ b/.github/workflows/k8s-patch-os-matrix.yml
@@ -19,12 +19,20 @@ jobs:
         instance: [
           { repo_name: 'amazon-cloudwatch-agent-operator', ec2_name: 'cw-agent-operator-release', language: 'java' },
           { repo_name: 'amazon-cloudwatch-agent-operator', ec2_name: 'cw-agent-operator-release', language: 'python' },
+          { repo_name: 'amazon-cloudwatch-agent-operator', ec2_name: 'cw-agent-operator-release', language: 'dotnet' },
+          { repo_name: 'amazon-cloudwatch-agent-operator', ec2_name: 'cw-agent-operator-release', language: 'node' },
           { repo_name: 'amazon-cloudwatch-agent', ec2_name: 'cw-agent-release', language: 'java' },
           { repo_name: 'amazon-cloudwatch-agent', ec2_name: 'cw-agent-release', language: 'python' },
-          { repo_name: 'aws-otel-python-instrumentation', ec2_name: 'adot-python-release', language: 'python' },
+          { repo_name: 'amazon-cloudwatch-agent', ec2_name: 'cw-agent-release', language: 'dotnet' },
+          { repo_name: 'amazon-cloudwatch-agent', ec2_name: 'cw-agent-release', language: 'node' },
           { repo_name: 'aws-otel-java-instrumentation', ec2_name: 'adot-java-release', language: 'java' },
+          { repo_name: 'aws-otel-python-instrumentation', ec2_name: 'adot-python-release', language: 'python' },
+          { repo_name: 'aws-otel-dotnet-instrumentation', ec2_name: 'adot-dotnet-release', language: 'dotnet' },
+          { repo_name: 'aws-otel-js-instrumentation', ec2_name: 'adot-node-release', language: 'node' },
+          { repo_name: 'aws-application-signals-test-framework', ec2_name: 'java-canary', language: 'java' },
           { repo_name: 'aws-application-signals-test-framework', ec2_name: 'python-canary', language: 'python' },
-          { repo_name: 'aws-application-signals-test-framework', ec2_name: 'java-canary', language: 'java' } ]
+          { repo_name: 'aws-application-signals-test-framework', ec2_name: 'dotnet-canary', language: 'dotnet' },
+          { repo_name: 'aws-application-signals-test-framework', ec2_name: 'node-canary', language: 'node' } ]
     uses: ./.github/workflows/k8s-patch-os-jobs.yml
     secrets: inherit
     with:


### PR DESCRIPTION
## Issue description
Need k8s infrastructure for release testing and canary testing of .NET and JS instrumentations

## Description of changes
- Add .NET and Node/JS to matrix of k8s cluster definitions
- Ensure we test the new clusters in some form before they are created

## Rollback procedure
Revert and rerun the k8s automation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
