### PR TITLE
Fix AWS SDK Test Metrics for Dotnet E2E

### DIFF
--- a/.github/workflows/dotnet-ec2-canary.yml
+++ b/.github/workflows/dotnet-ec2-canary.yml
@@ -10,9 +10,6 @@ on:
   workflow_dispatch: # be able to run the workflow on demand
   schedule:
     - cron: '*/15 * * * *' # run the workflow every 15 minutes
-  push:
-    branches:
-      - "fix-metrics"
 
 permissions:
   id-token: write
@@ -32,17 +29,3 @@ jobs:
     with:
       aws-region: ${{ matrix.aws-region }}
       caller-workflow-name: 'appsignals-dotnet-e2e-ec2-canary-test'
-
-  asg:
-    strategy:
-      fail-fast: false
-      matrix:
-        aws-region: ['af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
-                     'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-                     'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
-                     'us-east-1','us-east-2', 'us-west-1', 'us-west-2']
-    uses: ./.github/workflows/dotnet-ec2-canary.yml
-    secrets: inherit
-    with:
-      aws-region: ${{ matrix.aws-region }}
-      caller-workflow-name: 'appsignals-dotnet-e2e-ec2-asg-canary-test'

--- a/.github/workflows/dotnet-ec2-canary.yml
+++ b/.github/workflows/dotnet-ec2-canary.yml
@@ -10,6 +10,9 @@ on:
   workflow_dispatch: # be able to run the workflow on demand
   schedule:
     - cron: '*/15 * * * *' # run the workflow every 15 minutes
+  push:
+    branches:
+      - "fix-metrics"
 
 permissions:
   id-token: write
@@ -29,3 +32,17 @@ jobs:
     with:
       aws-region: ${{ matrix.aws-region }}
       caller-workflow-name: 'appsignals-dotnet-e2e-ec2-canary-test'
+
+  asg:
+    strategy:
+      fail-fast: false
+      matrix:
+        aws-region: ['af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
+                     'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
+                     'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+                     'us-east-1','us-east-2', 'us-west-1', 'us-west-2']
+    uses: ./.github/workflows/dotnet-ec2-canary.yml
+    secrets: inherit
+    with:
+      aws-region: ${{ matrix.aws-region }}
+      caller-workflow-name: 'appsignals-dotnet-e2e-ec2-asg-canary-test'

--- a/.github/workflows/dotnet-ec2-canary.yml
+++ b/.github/workflows/dotnet-ec2-canary.yml
@@ -41,7 +41,7 @@ jobs:
                      'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
                      'us-east-1','us-east-2', 'us-west-1', 'us-west-2']
-    uses: ./.github/workflows/dotnet-ec2-asg-test.yml
+    uses: ./.github/workflows/dotnet-ec2-canary.yml
     secrets: inherit
     with:
       aws-region: ${{ matrix.aws-region }}

--- a/.github/workflows/dotnet-ec2-canary.yml
+++ b/.github/workflows/dotnet-ec2-canary.yml
@@ -41,7 +41,7 @@ jobs:
                      'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
                      'us-east-1','us-east-2', 'us-west-1', 'us-west-2']
-    uses: ./.github/workflows/dotnet-ec2-canary.yml
+    uses: ./.github/workflows/dotnet-ec2-asg-test.yml
     secrets: inherit
     with:
       aws-region: ${{ matrix.aws-region }}

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/aws-sdk-call-metric.mustache
@@ -95,7 +95,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-ec2-asg-{{testingId}}
+      value: {{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket
@@ -118,7 +118,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-ec2-asg-{{testingId}}
+      value: {{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket
@@ -220,7 +220,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-ec2-asg-{{testingId}}
+      value: {{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket
@@ -243,7 +243,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-ec2-asg-{{testingId}}
+      value: {{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket
@@ -345,7 +345,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-ec2-asg-{{testingId}}
+      value: {{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket
@@ -368,7 +368,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-ec2-asg-{{testingId}}
+      value: {{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/aws-sdk-call-metric.mustache
@@ -75,6 +75,55 @@
       value: AWS::S3
 
 -
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: dotnet-ec2-asg-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: dotnet-ec2-asg-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket
+
+-
   metricName: Error
   namespace: {{metricNamespace}}
   dimensions:
@@ -151,6 +200,55 @@
       value: AWS::S3
 
 -
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: dotnet-ec2-asg-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: dotnet-ec2-asg-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket
+
+-
   metricName: Fault
   namespace: {{metricNamespace}}
   dimensions:
@@ -226,3 +324,51 @@
       name: RemoteService
       value: AWS::S3
 
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: dotnet-ec2-asg-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:{{platformInfo}}
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: dotnet-ec2-asg-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-metric.mustache
@@ -95,7 +95,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-e2e-ec2-default-test-{{testingId}}
+      value: dotnet-ec2-default-test-{{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket
@@ -118,7 +118,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-e2e-ec2-default-test-{{testingId}}
+      value: dotnet-ec2-default-test-{{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket
@@ -220,7 +220,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-e2e-ec2-default-test-{{testingId}}
+      value: dotnet-ec2-default-test-{{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket
@@ -243,7 +243,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-e2e-ec2-default-test-{{testingId}}
+      value: dotnet-ec2-default-test-{{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket
@@ -346,7 +346,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-e2e-ec2-default-test-{{testingId}}
+      value: dotnet-ec2-default-test-{{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket
@@ -369,7 +369,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-e2e-ec2-default-test-{{testingId}}
+      value: dotnet-ec2-default-test-{{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-metric.mustache
@@ -75,6 +75,55 @@
       value: AWS::S3
 
 -
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: dotnet-e2e-ec2-default-test-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: dotnet-e2e-ec2-default-test-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket
+
+-
   metricName: Error
   namespace: {{metricNamespace}}
   dimensions:
@@ -151,6 +200,55 @@
       value: AWS::S3
 
 -
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: dotnet-e2e-ec2-default-test-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: dotnet-e2e-ec2-default-test-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket
+
+-
   metricName: Fault
   namespace: {{metricNamespace}}
   dimensions:
@@ -226,3 +324,52 @@
       name: RemoteService
       value: AWS::S3
 
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: dotnet-e2e-ec2-default-test-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+    -
+      name: RemoteResourceIdentifier
+      value: dotnet-e2e-ec2-default-test-{{testingId}}
+    -
+      name: RemoteResourceType
+      value: AWS::S3::Bucket

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-metric.mustache
@@ -95,7 +95,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-ec2-default-{{testingId}}
+      value: {{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket
@@ -118,7 +118,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-ec2-default-{{testingId}}
+      value: {{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket
@@ -220,7 +220,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-ec2-default-{{testingId}}
+      value: {{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket
@@ -243,7 +243,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-ec2-default-{{testingId}}
+      value: {{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket
@@ -346,7 +346,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-ec2-default-{{testingId}}
+      value: {{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket
@@ -369,7 +369,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-ec2-default-{{testingId}}
+      value: {{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-metric.mustache
@@ -95,7 +95,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-ec2-default-test-{{testingId}}
+      value: dotnet-ec2-default-{{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket
@@ -118,7 +118,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-ec2-default-test-{{testingId}}
+      value: dotnet-ec2-default-{{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket
@@ -220,7 +220,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-ec2-default-test-{{testingId}}
+      value: dotnet-ec2-default-{{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket
@@ -243,7 +243,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-ec2-default-test-{{testingId}}
+      value: dotnet-ec2-default-{{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket
@@ -346,7 +346,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-ec2-default-test-{{testingId}}
+      value: dotnet-ec2-default-{{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket
@@ -369,7 +369,7 @@
       value: AWS::S3
     -
       name: RemoteResourceIdentifier
-      value: dotnet-ec2-default-test-{{testingId}}
+      value: dotnet-ec2-default-{{testingId}}
     -
       name: RemoteResourceType
       value: AWS::S3::Bucket

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-metric.mustache
@@ -326,7 +326,7 @@
 
 
 -
-  metricName: Error
+  metricName: Fault
   namespace: {{metricNamespace}}
   dimensions:
     -
@@ -352,7 +352,7 @@
       value: AWS::S3::Bucket
 
 -
-  metricName: Error
+  metricName: Fault
   namespace: {{metricNamespace}}
   dimensions:
     -


### PR DESCRIPTION
*Issue description:*
After change the sample app the listbucketlocation, we miss some test metric
*Description of changes:*
add metrics related to AWS S3 operation
*Rollback procedure:*
roll back
<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>
Yes
*Test*
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10741939621
*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
