### PR TITLE
[K8s] Remove testing for new language clusters

### DIFF
--- a/.github/workflows/k8s-patch-os-jobs.yml
+++ b/.github/workflows/k8s-patch-os-jobs.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - name: Generate Testing ID
         run: |
-          echo TESTING_ID="${{ github.run_id }}-${{ github.run_number }}" >> $GITHUB_ENV
+          echo TESTING_ID="${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}" >> $GITHUB_ENV
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -113,30 +113,30 @@ jobs:
       caller-repository: ${{ inputs.repo_name }}
 
   # TODO: Update to use dotnet-k8s-test once it's available
-  run-dotnet-k8s-test:
-    if: ${{ inputs.LANGUAGE == 'dotnet' }}
-    needs: create-k8s-on-ec2
-    uses: ./.github/workflows/java-k8s-test.yml
-    secrets: inherit
-    with:
-      aws-region: 'us-east-1'
-      caller-workflow-name: 'k8s-os-patching'
-      caller-repository: ${{ inputs.repo_name }}
+  # run-dotnet-k8s-test:
+  #   if: ${{ inputs.LANGUAGE == 'dotnet' }}
+  #   needs: create-k8s-on-ec2
+  #   uses: ./.github/workflows/dotnet-k8s-test.yml
+  #   secrets: inherit
+  #   with:
+  #     aws-region: 'us-east-1'
+  #     caller-workflow-name: 'k8s-os-patching'
+  #     caller-repository: ${{ inputs.repo_name }}
 
   # TODO: Update to use node-k8s-test once it's available
-  run-node-k8s-test:
-    if: ${{ inputs.LANGUAGE == 'node' }}
-    needs: create-k8s-on-ec2
-    uses: ./.github/workflows/java-k8s-test.yml
-    secrets: inherit
-    with:
-      aws-region: 'us-east-1'
-      caller-workflow-name: 'k8s-os-patching'
-      caller-repository: ${{ inputs.repo_name }}
+  # run-node-k8s-test:
+  #   if: ${{ inputs.LANGUAGE == 'node' }}
+  #   needs: create-k8s-on-ec2
+  #   uses: ./.github/workflows/node-k8s-test.yml
+  #   secrets: inherit
+  #   with:
+  #     aws-region: 'us-east-1'
+  #     caller-workflow-name: 'k8s-os-patching'
+  #     caller-repository: ${{ inputs.repo_name }}
 
   update-secrets:
-    needs: [ run-java-k8s-test, run-python-k8s-test, run-dotnet-k8s-test, run-node-k8s-test ]
-    if: ${{ always() && (needs.run-java-k8s-test.result == 'success' || needs.run-python-k8s-test.result == 'success' || needs.run-dotnet-k8s-test.result == 'success'  || needs.run-node-k8s-test.result == 'success') }}
+    needs: [ run-java-k8s-test, run-python-k8s-test ]
+    if: ${{ always() && (needs.run-java-k8s-test.result == 'success' || needs.run-python-k8s-test.result == 'success') }}
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
@@ -192,8 +192,8 @@ jobs:
       validation-result: ${{ needs.update-secrets.result }}
 
   cleanup-if-failed:
-    needs: [ run-java-k8s-test, run-python-k8s-test, run-dotnet-k8s-test, run-node-k8s-test ]
-    if: ${{ always() && (needs.run-java-k8s-test.result != 'success' && needs.run-python-k8s-test.result != 'success' && needs.run-dotnet-k8s-test.result != 'success' && needs.run-node-k8s-test.result != 'success') }}
+    needs: [ run-java-k8s-test, run-python-k8s-test ]
+    if: ${{ always() && (needs.run-java-k8s-test.result != 'success' && needs.run-python-k8s-test.result != 'success') }}
     runs-on: ubuntu-latest
     steps:
       - name: Delete Key Pair and EC2 Instance


### PR DESCRIPTION
## Issue/Description of changes
New clusters were using the java test, but the java test is hardcoded to use the temporary java clusters and does not automatically detect that it needs to use the clusters meant for other languages (which makes sense). As such:
- Removed the testing for now since the tests can be run after the fact anyways
- Also added run attempt to the testing ID so that the jobs in a workflow can be run again without overlapping resource names

## Rollback procedure
Revert and rerun k8s os patching
