### PR TITLE
Fix cleanup script

### DIFF
--- a/.github/workflows/resource-cleanup.yml
+++ b/.github/workflows/resource-cleanup.yml
@@ -89,4 +89,4 @@ jobs:
     with:
       aws-region: 'us-east-1'
       caller-workflow-name: 'enablement-test-resource-cleanup'
-      validation-result: ${{ (needs.cleanup-ec2-instances.result == 'success' && needs.cleanup-k8s-on-ec2.result == 'success') && 'success' || 'failure' }}
+      validation-result: ${{ (needs.cleanup-ec2-instances.result == 'success' && needs.cleanup-k8s-cluster.result == 'success') && 'success' || 'failure' }}


### PR DESCRIPTION
*Issue description:*
The variable name is wrong in the cleanup script, causing the metric to emit failure

*Description of changes:*
Update metric to correct name

Test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10743017221

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
