### PR TITLE
Create a Dummy Test to make sure K8s Infra Create Success

### DIFF
--- a/.github/workflows/dummy-k8s-test.yml
+++ b/.github/workflows/dummy-k8s-test.yml
@@ -1,0 +1,28 @@
+## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+
+# This is a DUMMY reusable workflow for running K8s Infra Creation in New Language
+# It is meant to be called from another workflow.
+# Read more about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview
+name: Dummy K8s on EC2 Use Case
+on:
+  workflow_call:
+    inputs:
+      aws-region:
+        required: true
+        type: string
+      caller-workflow-name:
+        required: true
+        type: string
+      caller-repository:
+        required: false
+        type: string
+
+jobs:
+  dummy-k8s:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: I am a Dummy Test, Replace me after done implementation
+        id: job-started
+        run: echo "I am a Dummy Test"

--- a/.github/workflows/k8s-patch-os-jobs.yml
+++ b/.github/workflows/k8s-patch-os-jobs.yml
@@ -112,31 +112,31 @@ jobs:
       caller-workflow-name: 'k8s-os-patching'
       caller-repository: ${{ inputs.repo_name }}
 
-  # TODO: Update to use dotnet-k8s-test once it's available
-  # run-dotnet-k8s-test:
-  #   if: ${{ inputs.LANGUAGE == 'dotnet' }}
-  #   needs: create-k8s-on-ec2
-  #   uses: ./.github/workflows/dotnet-k8s-test.yml
-  #   secrets: inherit
-  #   with:
-  #     aws-region: 'us-east-1'
-  #     caller-workflow-name: 'k8s-os-patching'
-  #     caller-repository: ${{ inputs.repo_name }}
+  run-dotnet-k8s-test:
+    if: ${{ inputs.LANGUAGE == 'dotnet' }}
+    needs: create-k8s-on-ec2
+    # TODO: Point to REAL K8s implementation after K8s Infra created.
+    uses: ./.github/workflows/dummy-k8s-test.yml
+    secrets: inherit
+    with:
+      aws-region: 'us-east-1'
+      caller-workflow-name: 'k8s-os-patching'
+      caller-repository: ${{ inputs.repo_name }}
 
-  # TODO: Update to use node-k8s-test once it's available
-  # run-node-k8s-test:
-  #   if: ${{ inputs.LANGUAGE == 'node' }}
-  #   needs: create-k8s-on-ec2
-  #   uses: ./.github/workflows/node-k8s-test.yml
-  #   secrets: inherit
-  #   with:
-  #     aws-region: 'us-east-1'
-  #     caller-workflow-name: 'k8s-os-patching'
-  #     caller-repository: ${{ inputs.repo_name }}
+  run-node-k8s-test:
+    if: ${{ inputs.LANGUAGE == 'node' }}
+    needs: create-k8s-on-ec2
+    # TODO: Point to REAL K8s implementation after K8s Infra created.
+    uses: ./.github/workflows/dummy-k8s-test.yml
+    secrets: inherit
+    with:
+      aws-region: 'us-east-1'
+      caller-workflow-name: 'k8s-os-patching'
+      caller-repository: ${{ inputs.repo_name }}
 
   update-secrets:
-    needs: [ run-java-k8s-test, run-python-k8s-test ]
-    if: ${{ always() && (needs.run-java-k8s-test.result == 'success' || needs.run-python-k8s-test.result == 'success') }}
+    needs: [ run-java-k8s-test, run-python-k8s-test, run-dotnet-k8s-test, run-node-k8s-test ]
+    if: ${{ always() && (needs.run-java-k8s-test.result == 'success' || needs.run-python-k8s-test.result == 'success'  || needs.run-dotnet-k8s-test.result == 'success'  || needs.run-node-k8s-test.result == 'success') }}
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
@@ -192,8 +192,8 @@ jobs:
       validation-result: ${{ needs.update-secrets.result }}
 
   cleanup-if-failed:
-    needs: [ run-java-k8s-test, run-python-k8s-test ]
-    if: ${{ always() && (needs.run-java-k8s-test.result != 'success' && needs.run-python-k8s-test.result != 'success') }}
+    needs: [ run-java-k8s-test, run-python-k8s-test, run-dotnet-k8s-test, run-node-k8s-test ]
+    if: ${{ always() && (needs.run-java-k8s-test.result != 'success' && needs.run-python-k8s-test.result != 'success' && needs.run-dotnet-k8s-test.result != 'success' && needs.run-node-k8s-test.result != 'success') }}
     runs-on: ubuntu-latest
     steps:
       - name: Delete Key Pair and EC2 Instance


### PR DESCRIPTION
*Issue description:*
K8s Infra script will looking for a success run for E2E test creation, this is annoy when creating infra for new language
*Description of changes:*
Create a Dummy Test to make sure K8s Infra Create Success
*Rollback procedure:*
Revert
<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>
Yes
*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
