### PR TITLE
Revert 224 revert 201 add ec2 pypl test

### DIFF
--- a/.github/workflows/python-ec2-canary.yml
+++ b/.github/workflows/python-ec2-canary.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 jobs:
-  default:
+  github:
     strategy:
       fail-fast: false
       matrix:
@@ -29,3 +29,12 @@ jobs:
     with:
       aws-region: ${{ matrix.aws-region }}
       caller-workflow-name: 'appsignals-python-e2e-ec2-canary-test'
+      staging-wheel-name: 'aws_opentelemetry_distro-0.3.0-py3-none-any.whl'
+
+  pypi:
+    uses: ./.github/workflows/python-ec2-default-retry.yml
+    secrets: inherit
+    with:
+      aws-region: 'us-east-1'
+      caller-workflow-name: 'appsignals-python-e2e-ec2-pypi-canary-test'
+      otel-source: 'pypi'

--- a/.github/workflows/python-ec2-canary.yml
+++ b/.github/workflows/python-ec2-canary.yml
@@ -29,7 +29,6 @@ jobs:
     with:
       aws-region: ${{ matrix.aws-region }}
       caller-workflow-name: 'appsignals-python-e2e-ec2-canary-test'
-      staging-wheel-name: 'aws_opentelemetry_distro-0.3.0-py3-none-any.whl'
 
   pypi:
     uses: ./.github/workflows/python-ec2-default-retry.yml

--- a/.github/workflows/python-ec2-default-retry.yml
+++ b/.github/workflows/python-ec2-default-retry.yml
@@ -14,6 +14,14 @@ on:
       caller-workflow-name:
         required: true
         type: string
+      staging-wheel-name:
+        required: false
+        default: 'aws-opentelemetry-distro'
+        type: string
+      otel-source:
+        required: false
+        type: string
+        default: 'github'
 
 permissions:
   id-token: write
@@ -26,6 +34,8 @@ jobs:
     with:
       aws-region: ${{ inputs.aws-region }}
       caller-workflow-name: ${{ inputs.caller-workflow-name }}
+      staging-wheel-name: ${{ inputs.staging-wheel-name }}
+      otel-source: ${{ inputs.otel-source }}
 
   python-ec2-default-attempt-2:
     needs: [ python-ec2-default-attempt-1 ]
@@ -35,6 +45,8 @@ jobs:
     with:
       aws-region: ${{ inputs.aws-region }}
       caller-workflow-name: ${{ inputs.caller-workflow-name }}
+      staging-wheel-name: ${{ inputs.staging-wheel-name }}
+      otel-source: ${{ inputs.otel-source }}
 
   publish-metric-attempt-1:
     needs: [ python-ec2-default-attempt-1, python-ec2-default-attempt-2 ]

--- a/.github/workflows/python-ec2-default-test.yml
+++ b/.github/workflows/python-ec2-default-test.yml
@@ -104,13 +104,8 @@ jobs:
           elif [ "${{ env.OTEL_SOURCE }}" == "pypi" ]; then
             echo GET_ADOT_WHEEL_COMMAND="python3.9 -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
           else
-            latest_release_version=$(curl -sL https://github.com/aws-observability/aws-otel-python-instrumentation/releases/latest \
-            | grep 'releases/tag/' \
-            | sed 's|.*releases/tag/\(.*\)\".*|\1|' \
-            | grep '^v' \
-            | head -n 1 \
-            | sed 's/^v//')
-
+            latest_release_version=$(curl -sL https://github.com/aws-observability/aws-otel-python-instrumentation/releases/latest | grep -oP '/releases/tag/v\K[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
+            echo "The latest version is $latest_release_version"
             echo GET_ADOT_WHEEL_COMMAND="wget -O ${{ env.ADOT_WHEEL_NAME }} https://github.com/aws-observability/aws-otel-python-instrumentation/releases/latest/download/aws_opentelemetry_distro-$latest_release_version-py3-none-any.whl \
             && python3.9 -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
           fi

--- a/.github/workflows/python-ec2-default-test.yml
+++ b/.github/workflows/python-ec2-default-test.yml
@@ -18,6 +18,10 @@ on:
         required: false
         default: 'aws-opentelemetry-distro'
         type: string
+      otel-source:
+        required: false
+        type: string
+        default: 'github'
     outputs:
       job-started:
         value: ${{ jobs.python-ec2-default.outputs.job-started }}
@@ -32,6 +36,7 @@ env:
   E2E_TEST_AWS_REGION: ${{ inputs.aws-region }}
   CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
   ADOT_WHEEL_NAME: ${{ inputs.staging-wheel-name }}
+  OTEL_SOURCE: ${{ inputs.otel-source }}
   SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/python-sample-app.zip
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
@@ -70,7 +75,7 @@ jobs:
           sleep_time: 60
 
       - name: Generate testing id
-        run: echo TESTING_ID="${{ github.job }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}" >> $GITHUB_ENV
+        run: echo TESTING_ID="${{ github.run_id }}-${{ github.run_number }}-${RANDOM}" >> $GITHUB_ENV
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -96,8 +101,10 @@ jobs:
           if [ "${{ github.event.repository.name }}" = "aws-otel-python-instrumentation" ]; then
             # Reusing the adot-main-build-staging-jar bucket to store the python wheel file
             echo GET_ADOT_WHEEL_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && python3.9 -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
-          else
+          elif [ "${{ env.OTEL_SOURCE }}" == "pypi" ]; then
             echo GET_ADOT_WHEEL_COMMAND="python3.9 -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
+          else
+            echo GET_ADOT_WHEEL_COMMAND="wget -O ${{ env.ADOT_WHEEL_NAME }} https://github.com/aws-observability/aws-otel-python-instrumentation/releases/latest/download/${{ env.ADOT_WHEEL_NAME }} && python3.9 -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
           fi
 
       - name: Set Get CW Agent command environment variable

--- a/.github/workflows/python-ec2-default-test.yml
+++ b/.github/workflows/python-ec2-default-test.yml
@@ -104,7 +104,15 @@ jobs:
           elif [ "${{ env.OTEL_SOURCE }}" == "pypi" ]; then
             echo GET_ADOT_WHEEL_COMMAND="python3.9 -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
           else
-            echo GET_ADOT_WHEEL_COMMAND="wget -O ${{ env.ADOT_WHEEL_NAME }} https://github.com/aws-observability/aws-otel-python-instrumentation/releases/latest/download/${{ env.ADOT_WHEEL_NAME }} && python3.9 -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
+            latest_release_version=$(curl -sL https://github.com/aws-observability/aws-otel-python-instrumentation/releases/latest \
+            | grep 'releases/tag/' \
+            | sed 's|.*releases/tag/\(.*\)\".*|\1|' \
+            | grep '^v' \
+            | head -n 1 \
+            | sed 's/^v//')
+
+            echo GET_ADOT_WHEEL_COMMAND="wget -O ${{ env.ADOT_WHEEL_NAME }} https://github.com/aws-observability/aws-otel-python-instrumentation/releases/latest/download/aws_opentelemetry_distro-$latest_release_version-py3-none-any.whl \
+            && python3.9 -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
           fi
 
       - name: Set Get CW Agent command environment variable


### PR DESCRIPTION
*Issue description:*
Follow up on https://github.com/aws-observability/aws-application-signals-test-framework/pull/201.

This PR failed because we released a new python version 0.4.0, but the PR was hardcoded to use verison 0.3.0

*Description of changes:*
Query for the latest release version for python otel github

Test Run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10797652571/job/29949368547

*Rollback procedure:*
Revert PR

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
