### PR TITLE
Update Helm Chart Installation to download from latest release

### DIFF
--- a/terraform/java/k8s/deploy/main.tf
+++ b/terraform/java/k8s/deploy/main.tf
@@ -37,10 +37,12 @@ resource "null_resource" "deploy" {
 
       # Clone and install operator onto cluster
       echo "LOG: Cloning helm-charts repo"
-      git clone https://github.com/aws-observability/helm-charts -q
-
-      cd helm-charts/charts/amazon-cloudwatch-observability/
-      git reset --hard e0e99c77f69ef388b0ffce769371f7c735a776e4
+      latest_version_url=$(curl -s https://api.github.com/repos/aws-observability/helm-charts/releases/latest | grep "tarball_url" | cut -d '"' -f 4)
+      echo "LOG: The latest helm chart version url is $latest_version_url"
+      curl -L $latest_version_url -o aws-observability-helm-charts-latest.tar.gz
+      mkdir helm-charts
+      tar -xvzf aws-observability-helm-charts-latest.tar.gz -C helm-charts
+      cd helm-charts/aws-observability-helm-charts*/charts/amazon-cloudwatch-observability
 
       echo "LOG: Installing CloudWatch Agent Operator using Helm"
       helm upgrade --install --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator ./ --create-namespace --set region=${var.aws_region} --set clusterName=k8s-cluster-${var.test_id}

--- a/terraform/java/k8s/deploy/main.tf
+++ b/terraform/java/k8s/deploy/main.tf
@@ -36,9 +36,11 @@ resource "null_resource" "deploy" {
       [ ! -e remote-service-depl.yaml ] || rm remote-service-depl.yaml
 
       # Clone and install operator onto cluster
-      echo "LOG: Cloning helm-charts repo"
+      echo "LOG: Getting latest helm chart release URL"
       latest_version_url=$(curl -s https://api.github.com/repos/aws-observability/helm-charts/releases/latest | grep "tarball_url" | cut -d '"' -f 4)
       echo "LOG: The latest helm chart version url is $latest_version_url"
+
+      echo "LOG: Downloading and unpacking the helm chart repo"
       curl -L $latest_version_url -o aws-observability-helm-charts-latest.tar.gz
       mkdir helm-charts
       tar -xvzf aws-observability-helm-charts-latest.tar.gz -C helm-charts

--- a/terraform/python/k8s/deploy/main.tf
+++ b/terraform/python/k8s/deploy/main.tf
@@ -37,9 +37,11 @@ resource "null_resource" "deploy" {
       [ ! -e python-remote-service-depl.yaml ] || rm python-remote-service-depl.yaml
 
       # Clone and install operator onto cluster
-      echo "LOG: Cloning helm-charts repo"
+      echo "LOG: Getting latest helm chart release URL"
       latest_version_url=$(curl -s https://api.github.com/repos/aws-observability/helm-charts/releases/latest | grep "tarball_url" | cut -d '"' -f 4)
       echo "LOG: The latest helm chart version url is $latest_version_url"
+
+      echo "LOG: Downloading and unpacking the helm chart repo"
       curl -L $latest_version_url -o aws-observability-helm-charts-latest.tar.gz
       mkdir helm-charts
       tar -xvzf aws-observability-helm-charts-latest.tar.gz -C helm-charts

--- a/terraform/python/k8s/deploy/main.tf
+++ b/terraform/python/k8s/deploy/main.tf
@@ -37,10 +37,13 @@ resource "null_resource" "deploy" {
       [ ! -e python-remote-service-depl.yaml ] || rm python-remote-service-depl.yaml
 
       # Clone and install operator onto cluster
-      echo "LOG: Cloning helm charts repo"
-      git clone https://github.com/aws-observability/helm-charts.git -q
-      cd helm-charts/charts/amazon-cloudwatch-observability
-      git reset --hard e0e99c77f69ef388b0ffce769371f7c735a776e4
+      echo "LOG: Cloning helm-charts repo"
+      latest_version_url=$(curl -s https://api.github.com/repos/aws-observability/helm-charts/releases/latest | grep "tarball_url" | cut -d '"' -f 4)
+      echo "LOG: The latest helm chart version url is $latest_version_url"
+      curl -L $latest_version_url -o aws-observability-helm-charts-latest.tar.gz
+      mkdir helm-charts
+      tar -xvzf aws-observability-helm-charts-latest.tar.gz -C helm-charts
+      cd helm-charts/aws-observability-helm-charts*/charts/amazon-cloudwatch-observability
 
       echo "LOG: Installing CloudWatch Agent Operator using Helm"
       helm upgrade --install --debug --namespace amazon-cloudwatch amazon-cloudwatch-operator ./ --create-namespace --set region=${var.aws_region} --set clusterName=k8s-cluster-${var.test_id}


### PR DESCRIPTION
*Issue description:*
We need to download Helm Charts from the latest release instead of using the main branch

*Description of changes:*
Update code to query for the latest release in `https://api.github.com/repos/aws-observability/helm-charts/releases/latest`

Unauthenticated Github API request limit are 60/hour. Personal API request limit is 5000/hour. Not sure which one we are using but both options should be safe

*Rollback procedure:*
Revert Code

*Test Run*
https://github.com/harrryr/aws-application-signals-test-framework/actions/runs/10785901713
https://github.com/harrryr/aws-application-signals-test-framework/actions/runs/10785837052

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
