### PR TITLE
[Dotnet] Update to Match Latest Release Artifacts for EC2

### DIFF
--- a/.github/workflows/dotnet-ec2-canary.yml
+++ b/.github/workflows/dotnet-ec2-canary.yml
@@ -10,9 +10,6 @@ on:
   workflow_dispatch: # be able to run the workflow on demand
   schedule:
     - cron: '*/15 * * * *' # run the workflow every 15 minutes
-  push:
-    branches:
-      - "e2e-linux-dotnet-expect"
 
 permissions:
   id-token: write

--- a/.github/workflows/dotnet-ec2-canary.yml
+++ b/.github/workflows/dotnet-ec2-canary.yml
@@ -10,6 +10,9 @@ on:
   workflow_dispatch: # be able to run the workflow on demand
   schedule:
     - cron: '*/15 * * * *' # run the workflow every 15 minutes
+  push:
+    branches:
+      - "e2e-linux-dotnet-expect"
 
 permissions:
   id-token: write

--- a/.github/workflows/dotnet-ec2-default-test.yml
+++ b/.github/workflows/dotnet-ec2-default-test.yml
@@ -94,7 +94,7 @@ jobs:
             echo GET_ADOT_DISTRO_COMMAND="aws s3 cp s3://adot-autoinstrumentation-dotnet-staging/${{ env.ADOT_DISTRO_NAME }} ./${{ env.ADOT_DISTRO_NAME }} && unzip -d dotnet-distro ${{ env.ADOT_DISTRO_NAME }}" >> $GITHUB_ENV
           else
             # After Release will switch to latest tag instead of hard code version for canary purpose
-            echo GET_ADOT_DISTRO_COMMAND="wget -O aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/download/v1.2.0/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip && unzip -d dotnet-distro aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip" >> $GITHUB_ENV
+            echo GET_ADOT_DISTRO_COMMAND="wget -O aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/latest/download/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip && unzip -d dotnet-distro aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip" >> $GITHUB_ENV
           fi
 
       - name: Set Get CW Agent command environment variable

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-log.mustache
@@ -2,7 +2,7 @@
   "EC2.InstanceId": "^{{instanceId}}$",
   "Environment": "^ec2:default$",
   "PlatformType": "^AWS::EC2$",
-  "Operation": "GET aws-sdk-call",
+  "Operation": "GET /aws-sdk-call",
   "Version": "^1$",
   "Telemetry.Source": "^LocalRootSpan$",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-metric.mustache
@@ -15,7 +15,7 @@
   dimensions:
     -
       name: Operation
-      value: GET aws-sdk-call
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -140,7 +140,7 @@
   dimensions:
     -
       name: Operation
-      value: GET aws-sdk-call
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -265,7 +265,7 @@
   dimensions:
     -
       name: Operation
-      value: GET aws-sdk-call
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-trace.mustache
@@ -11,7 +11,7 @@
   },
   "annotations": {
     "aws.local.service": "^{{serviceName}}$",
-    "aws.local.operation": "^GET aws-sdk-call$",
+    "aws.local.operation": "^GET /aws-sdk-call$",
     "aws.local.environment": "^ec2:default$"
   },
   "metadata": {

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/outgoing-http-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/outgoing-http-call-log.mustache
@@ -2,7 +2,7 @@
   "EC2.InstanceId": "^{{instanceId}}$",
   "Environment": "^ec2:default$",
   "PlatformType": "^AWS::EC2$",
-  "Operation": "GET outgoing-http-call",
+  "Operation": "GET /outgoing-http-call",
   "Version": "^1$",
   "Telemetry.Source": "^LocalRootSpan$",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/outgoing-http-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/outgoing-http-call-metric.mustache
@@ -15,7 +15,7 @@
   dimensions:
     -
       name: Operation
-      value: GET outgoing-http-call
+      value: GET /outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -91,7 +91,7 @@
   dimensions:
     -
       name: Operation
-      value: GET outgoing-http-call
+      value: GET /outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -167,7 +167,7 @@
   dimensions:
     -
       name: Operation
-      value: GET outgoing-http-call
+      value: GET /outgoing-http-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/outgoing-http-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/outgoing-http-call-trace.mustache
@@ -11,7 +11,7 @@
   },
   "annotations": {
     "aws.local.service": "^{{serviceName}}$",
-    "aws.local.operation": "^GET outgoing-http-call$",
+    "aws.local.operation": "^GET /outgoing-http-call$",
     "aws.local.environment": "^ec2:default$"
   },
   "metadata": {

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/remote-service-log.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/remote-service-log.mustache
@@ -2,7 +2,7 @@
   "EC2.InstanceId": "^{{instanceId}}$",
   "Environment": "^ec2:default$",
   "PlatformType": "^AWS::EC2$",
-  "Operation": "GET remote-service",
+  "Operation": "GET /remote-service",
   "Version": "^1$",
   "Telemetry.Source": "^LocalRootSpan$",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/remote-service-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/remote-service-metric.mustache
@@ -4,7 +4,7 @@
   dimensions:
     -
       name: Operation
-      value: GET remote-service
+      value: GET /remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -41,7 +41,7 @@
       value: ec2:default
     -
       name: Operation
-      value: GET healthcheck
+      value: GET /healthcheck
     -
       name: Service
       value: {{remoteServiceName}}
@@ -113,7 +113,7 @@
   dimensions:
     -
       name: Operation
-      value: GET remote-service
+      value: GET /remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -150,7 +150,7 @@
       value: ec2:default
     -
       name: Operation
-      value: GET healthcheck
+      value: GET /healthcheck
     -
       name: Service
       value: {{remoteServiceName}}
@@ -222,7 +222,7 @@
   dimensions:
     -
       name: Operation
-      value: GET remote-service
+      value: GET /remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -259,7 +259,7 @@
       value: ec2:default
     -
       name: Operation
-      value: GET healthcheck
+      value: GET /healthcheck
     -
       name: Service
       value: {{remoteServiceName}}

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/remote-service-trace.mustache
@@ -11,7 +11,7 @@
   },
   "annotations": {
     "aws.local.service": "^{{serviceName}}$",
-    "aws.local.operation": "^GET remote-service$",
+    "aws.local.operation": "^GET /remote-service$",
     "aws.local.environment": "^ec2:default$"
   },
   "metadata": {
@@ -60,7 +60,7 @@
   },
   "annotations": {
     "aws.local.service": "^{{remoteServiceName}}$",
-    "aws.local.operation": "^GET healthcheck$",
+    "aws.local.operation": "^GET /healthcheck$",
     "aws.local.environment": "^ec2:default$"
   },
   "metadata": {


### PR DESCRIPTION
*Issue description:*
Dotnet Instrumentation get updated, need to update expect result as well
*Description of changes:*
Update Dotnet to be point to latest release version and update expect reulst
*Rollback procedure:*
Revert
<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>
Yes
*Ensure you've run the following tests on your changes and include the link below:*
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10802362410
To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
