### PR TITLE
Revert "Enhance Logs E2E test and bump up MySQL library to 8.4 (#221)"

### DIFF
--- a/sample-apps/springboot/build.gradle.kts
+++ b/sample-apps/springboot/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
   implementation("io.opentelemetry:opentelemetry-api:1.34.1")
   implementation("software.amazon.awssdk:s3")
   implementation("software.amazon.awssdk:sts")
-  implementation("com.mysql:mysql-connector-j:8.4.0")
+  implementation("com.mysql:mysql-connector-j:8.0.33")
 }
 
 jib {

--- a/validator/src/main/java/com/amazon/aoc/validators/CWLogValidator.java
+++ b/validator/src/main/java/com/amazon/aoc/validators/CWLogValidator.java
@@ -66,11 +66,9 @@ public class CWLogValidator implements IValidator {
           String operation = (String) expectedAttributes.get("Operation");
           String remoteService = (String) expectedAttributes.get("RemoteService");
           String remoteOperation = (String) expectedAttributes.get("RemoteOperation");
-          String remoteResourceType = (String) expectedAttributes.get("RemoteResourceType");
-          String remoteResourceIdentifier = (String) expectedAttributes.get("RemoteResourceIdentifier");
 
           Map<String, Object> actualLog =
-                  this.getActualLog(operation, remoteService, remoteOperation, remoteResourceType, remoteResourceIdentifier);
+                  this.getActualLog(operation, remoteService, remoteOperation);
           log.info("Value of an actual log: {}", actualLog);
 
           if (actualLog == null) throw new BaseException(ExceptionCode.EXPECTED_LOG_NOT_FOUND);
@@ -128,7 +126,7 @@ public class CWLogValidator implements IValidator {
   }
 
   private Map<String, Object> getActualLog(
-    String operation, String remoteService, String remoteOperation, String remoteResourceType, String remoteResourceIdentifier) throws Exception {
+      String operation, String remoteService, String remoteOperation) throws Exception {
     String dependencyFilter = null;
 
     // Dependency calls will have the remoteService and remoteOperation attribute, but service calls
@@ -139,10 +137,6 @@ public class CWLogValidator implements IValidator {
       dependencyFilter = "&& ($.RemoteService NOT EXISTS) && ($.RemoteOperation NOT EXISTS)";
     } else {
       dependencyFilter = String.format("&& ($.RemoteService = \"%s\") && ($.RemoteOperation = \"%s\")", remoteService, remoteOperation);
-    }
-
-    if (remoteResourceType != null && remoteResourceIdentifier != null) {
-      dependencyFilter += String.format(" && ($.RemoteResourceType = %%%s%%) && ($.RemoteResourceIdentifier = %%%s%%)", remoteResourceType, remoteResourceIdentifier);
     }
 
     String filterPattern = String.format("{ ($.Service = %s) && ($.Operation = \"%s\") %s }", context.getServiceName(), operation, dependencyFilter);

--- a/validator/src/main/resources/expected-data-template/java/eks/rds-mysql-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks/rds-mysql-trace.mustache
@@ -26,8 +26,8 @@
             "default": {
                 "EC2.AutoScalingGroup": "^eks-.+",
                 "EKS.Cluster": "^{{platformInfo}}$",
-                "K8s.Namespace": "^{{appNamespace}}$",
-                "otel.resource.K8s.Workload": "^sample-app-deployment-{{testingId}}$",
+                "K8s.Namespace": "^{{appNamespace}}",
+                "otel.resource.K8s.Workload": "^sample-app-deployment-{{testingId}}",
                 "otel.resource.K8s.Node": "^i-[A-Za-z0-9]{17}$",
                 "otel.resource.K8s.Pod": "^sample-app-deployment-{{testingId}}(-[A-Za-z0-9]*)*$",
                 "otel.resource.host.name": "^ip(-[0-9]{1,3}){4}.*$",
@@ -53,12 +53,6 @@
                     {
                         "name": "^mysql$",
                         "sql": {
-                            "url": "^Create connection$"
-                        }
-                    },
-                    {
-                        "name": "^mysql$",
-                        "sql": {
                             "url": "^SELECT information_schema.tables$",
                             "sanitized_query": "SELECT \\* FROM tables LIMIT \\?;",
                             "database_type": "^mysql$"
@@ -67,7 +61,7 @@
                             "aws.remote.operation": "^SELECT$",
                             "aws.local.operation": "^GET /mysql$",
                             "aws.remote.resource.type": "^DB::Connection$",
-                            "aws.remote.resource.identifier": "^{{remoteResourceIdentifier}}$",
+                            "aws.remote.resource.identifier": "{{remoteResourceIdentifier}}",
                             "aws.remote.service": "^mysql$",
                             "aws.local.service": "^{{serviceName}}$",
                             "aws.local.environment": "^eks:{{platformInfo}}/{{appNamespace}}$"


### PR DESCRIPTION
This reverts commit 3502e733750aa4105c6ebc5167f8aeb410a3cafd.

*Issue description:*

Need to investigate the flaky test: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10822227767/job/30025736602

*Description of changes:*

*Rollback procedure:*

<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
