### PR TITLE
[Dotnet] Update Dotnet K8s Expect Result Follow Breaking Change

### DIFF
--- a/.github/workflows/dotnet-k8s-canary.yml
+++ b/.github/workflows/dotnet-k8s-canary.yml
@@ -11,6 +11,9 @@ on:
   schedule:
     - cron: '*/15 * * * *' # run the workflow every 15 minutes
   workflow_dispatch: # be able to run the workflow on demand
+  push:
+    branches:
+      - "dotnet-k8s-fix-expect"
 
 permissions:
   id-token: write

--- a/.github/workflows/dotnet-k8s-canary.yml
+++ b/.github/workflows/dotnet-k8s-canary.yml
@@ -11,9 +11,6 @@ on:
   schedule:
     - cron: '*/15 * * * *' # run the workflow every 15 minutes
   workflow_dispatch: # be able to run the workflow on demand
-  push:
-    branches:
-      - "dotnet-k8s-fix-expect"
 
 permissions:
   id-token: write

--- a/validator/src/main/resources/expected-data-template/dotnet/k8s/aws-sdk-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/k8s/aws-sdk-call-log.mustache
@@ -7,7 +7,7 @@
   "K8s.Workload": "^dotnet-sample-app-deployment-{{testingId}}$",
   "PlatformType": "^K8s$",
   "Service": "^{{serviceName}}$",
-  "Operation": "GET aws-sdk-call",
+  "Operation": "GET /aws-sdk-call",
   "Version": "^1$",
   "Telemetry.Source": "^LocalRootSpan$",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"

--- a/validator/src/main/resources/expected-data-template/dotnet/k8s/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/k8s/aws-sdk-call-metric.mustache
@@ -4,7 +4,7 @@
   dimensions:
     -
       name: Operation
-      value: GET aws-sdk-call
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -129,7 +129,7 @@
   dimensions:
     -
       name: Operation
-      value: GET aws-sdk-call
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -255,7 +255,7 @@
   dimensions:
     -
       name: Operation
-      value: GET aws-sdk-call
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/dotnet/k8s/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/k8s/aws-sdk-call-trace.mustache
@@ -11,7 +11,7 @@
   },
   "annotations": {
     "aws.local.service": "^{{serviceName}}$",
-    "aws.local.operation": "^GET aws-sdk-call$",
+    "aws.local.operation": "^GET /aws-sdk-call$",
     "aws.local.environment": "^k8s:{{platformInfo}}/{{appNamespace}}$"
   },
   "metadata": {

--- a/validator/src/main/resources/expected-data-template/dotnet/k8s/client-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/k8s/client-call-metric.mustache
@@ -7,7 +7,7 @@
       value: {{serviceName}}
     -
       name: Operation
-      value: GET client-call
+      value: GET /client-call
     -
       name: Environment
       value: k8s:{{platformInfo}}/{{appNamespace}}
@@ -97,7 +97,7 @@
       value: {{serviceName}}
     -
       name: Operation
-      value: GET client-call
+      value: GET /client-call
     -
       name: Environment
       value: k8s:{{platformInfo}}/{{appNamespace}}
@@ -187,7 +187,7 @@
       value: {{serviceName}}
     -
       name: Operation
-      value: GET client-call
+      value: GET /client-call
     -
       name: Environment
       value: k8s:{{platformInfo}}/{{appNamespace}}

--- a/validator/src/main/resources/expected-data-template/dotnet/k8s/outgoing-http-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/k8s/outgoing-http-call-log.mustache
@@ -7,7 +7,7 @@
   "K8s.Workload": "^dotnet-sample-app-deployment-{{testingId}}$",
   "PlatformType": "^K8s$",
   "Service": "^{{serviceName}}$",
-  "Operation": "GET outgoing-http-call",
+  "Operation": "GET /outgoing-http-call",
   "Version": "^1$",
   "Telemetry.Source": "^LocalRootSpan$",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"

--- a/validator/src/main/resources/expected-data-template/dotnet/k8s/outgoing-http-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/k8s/outgoing-http-call-metric.mustache
@@ -4,7 +4,7 @@
   dimensions:
     -
       name: Operation
-      value: GET outgoing-http-call
+      value: GET /outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -80,7 +80,7 @@
   dimensions:
     -
       name: Operation
-      value: GET outgoing-http-call
+      value: GET /outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -156,7 +156,7 @@
   dimensions:
     -
       name: Operation
-      value: GET outgoing-http-call
+      value: GET /outgoing-http-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/dotnet/k8s/outgoing-http-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/k8s/outgoing-http-call-trace.mustache
@@ -11,7 +11,7 @@
   },
   "annotations": {
     "aws.local.service": "^{{serviceName}}$",
-    "aws.local.operation": "^GET outgoing-http-call$",
+    "aws.local.operation": "^GET /outgoing-http-call$",
     "aws.local.environment": "^k8s:{{platformInfo}}/{{appNamespace}}$"
   },
   "metadata": {

--- a/validator/src/main/resources/expected-data-template/dotnet/k8s/remote-service-log.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/k8s/remote-service-log.mustache
@@ -7,7 +7,7 @@
   "K8s.Workload": "^dotnet-sample-app-deployment-{{testingId}}$",
   "PlatformType": "^K8s$",
   "Service": "^{{serviceName}}$",
-  "Operation": "GET remote-service",
+  "Operation": "GET /remote-service",
   "Version": "^1$",
   "Telemetry.Source": "^LocalRootSpan$",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"

--- a/validator/src/main/resources/expected-data-template/dotnet/k8s/remote-service-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/k8s/remote-service-metric.mustache
@@ -4,7 +4,7 @@
   dimensions:
     -
       name: Operation
-      value: GET remote-service
+      value: GET /remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -41,7 +41,7 @@
       value: k8s:{{platformInfo}}/{{appNamespace}}
     -
       name: Operation
-      value: GET healthcheck
+      value: GET /healthcheck
     -
       name: Service
       value: {{remoteServiceDeploymentName}}
@@ -173,7 +173,7 @@
   dimensions:
     -
       name: Operation
-      value: GET remote-service
+      value: GET /remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -210,7 +210,7 @@
       value: k8s:{{platformInfo}}/{{appNamespace}}
     -
       name: Operation
-      value: GET healthcheck
+      value: GET /healthcheck
     -
       name: Service
       value: {{remoteServiceDeploymentName}}
@@ -342,7 +342,7 @@
   dimensions:
     -
       name: Operation
-      value: GET remote-service
+      value: GET /remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -379,7 +379,7 @@
       value: k8s:{{platformInfo}}/{{appNamespace}}
     -
       name: Operation
-      value: GET healthcheck
+      value: GET /healthcheck
     -
       name: Service
       value: {{remoteServiceDeploymentName}}

--- a/validator/src/main/resources/expected-data-template/dotnet/k8s/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/k8s/remote-service-trace.mustache
@@ -11,7 +11,7 @@
   },
   "annotations": {
     "aws.local.service": "^{{serviceName}}$",
-    "aws.local.operation": "^GET remote-service$",
+    "aws.local.operation": "^GET /remote-service$",
     "aws.local.environment": "^k8s:{{platformInfo}}/{{appNamespace}}$"
   },
   "metadata": {
@@ -63,7 +63,7 @@
   },
   "annotations": {
     "aws.local.service": "^{{remoteServiceDeploymentName}}$",
-    "aws.local.operation": "^GET healthcheck$",
+    "aws.local.operation": "^GET /healthcheck$",
     "aws.local.environment": "^k8s:{{platformInfo}}/{{appNamespace}}$"
   },
   "metadata": {

--- a/validator/src/main/resources/validations/dotnet/k8s/log-validation.yml
+++ b/validator/src/main/resources/validations/dotnet/k8s/log-validation.yml
@@ -1,24 +1,24 @@
 -
   validationType: "cw-log"
-  httpPath: "outgoing-http-call"
+  httpPath: "/outgoing-http-call"
   httpMethod: "get"
   callingType: "http"
   expectedLogStructureTemplate: "DOTNET_K8S_OUTGOING_HTTP_CALL_LOG"
 -
   validationType: "cw-log"
-  httpPath: "aws-sdk-call"
+  httpPath: "/aws-sdk-call"
   httpMethod: "get"
   callingType: "http-with-query"
   expectedLogStructureTemplate: "DOTNET_K8S_AWS_SDK_CALL_LOG"
 -
   validationType: "cw-log"
-  httpPath: "remote-service"
+  httpPath: "/remote-service"
   httpMethod: "get"
   callingType: "http-with-query"
   expectedLogStructureTemplate: "DOTNET_K8S_REMOTE_SERVICE_LOG"
 -
   validationType: "cw-log"
-  httpPath: "client-call"
+  httpPath: "/client-call"
   httpMethod: "get"
   callingType: "http"
   expectedLogStructureTemplate: "DOTNET_K8S_CLIENT_CALL_LOG"

--- a/validator/src/main/resources/validations/dotnet/k8s/metric-validation.yml
+++ b/validator/src/main/resources/validations/dotnet/k8s/metric-validation.yml
@@ -1,24 +1,24 @@
 -
   validationType: "cw-metric"
-  httpPath: "outgoing-http-call"
+  httpPath: "/outgoing-http-call"
   httpMethod: "get"
   callingType: "http"
   expectedMetricTemplate: "DOTNET_K8S_OUTGOING_HTTP_CALL_METRIC"
 -
   validationType: "cw-metric"
-  httpPath: "aws-sdk-call"
+  httpPath: "/aws-sdk-call"
   httpMethod: "get"
   callingType: "http-with-query"
   expectedMetricTemplate: "DOTNET_K8S_AWS_SDK_CALL_METRIC"
 -
   validationType: "cw-metric"
-  httpPath: "remote-service"
+  httpPath: "/remote-service"
   httpMethod: "get"
   callingType: "http-with-query"
   expectedMetricTemplate: "DOTNET_K8S_REMOTE_SERVICE_METRIC"
 -
   validationType: "cw-metric"
-  httpPath: "client-call"
+  httpPath: "/client-call"
   httpMethod: "get"
   callingType: "http"
   expectedMetricTemplate: "DOTNET_K8S_CLIENT_CALL_METRIC"

--- a/validator/src/main/resources/validations/dotnet/k8s/trace-validation.yml
+++ b/validator/src/main/resources/validations/dotnet/k8s/trace-validation.yml
@@ -1,24 +1,24 @@
 -
   validationType: "trace"
-  httpPath: "outgoing-http-call"
+  httpPath: "/outgoing-http-call"
   httpMethod: "get"
   callingType: "http"
   expectedTraceTemplate: "DOTNET_K8S_OUTGOING_HTTP_CALL_TRACE"
 -
   validationType: "trace"
-  httpPath: "aws-sdk-call"
+  httpPath: "/aws-sdk-call"
   httpMethod: "get"
   callingType: "http-with-query"
   expectedTraceTemplate: "DOTNET_K8S_AWS_SDK_CALL_TRACE"
 -
   validationType: "trace"
-  httpPath: "remote-service"
+  httpPath: "/remote-service"
   httpMethod: "get"
   callingType: "http-with-query"
   expectedTraceTemplate: "DOTNET_K8S_REMOTE_SERVICE_TRACE"
 -
   validationType: "trace"
-  httpPath: "client-call"
+  httpPath: "/client-call"
   httpMethod: "get"
   callingType: "http"
   expectedTraceTemplate: "DOTNET_K8S_CLIENT_CALL_TRACE"


### PR DESCRIPTION
*Description of changes:*
Update Dotnet K8s Expect Result Follow Breaking Change
*Rollback procedure:*
N/A
<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>
N/A
*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
