### PR TITLE
[Node/K8s] Rename canary test metric to match other platforms

### DIFF
--- a/.github/workflows/node-k8s-canary.yml
+++ b/.github/workflows/node-k8s-canary.yml
@@ -23,4 +23,4 @@ jobs:
     with:
       # To run in more regions, a cluster must be provisioned manually on EC2 instances in that region
       aws-region: 'us-east-1'
-      caller-workflow-name: 'appsignals-e2e-node-k8s-canary-test'
+      caller-workflow-name: 'appsignals-node-e2e-k8s-canary-test'


### PR DESCRIPTION
Small PR to match naming of outgoing metrics for other platforms:
EKS: `appsignals-node-e2e-eks-canary-test`
EC2: `appsignals-node-e2e-ec2-canary-test`