### PR TITLE
[Node/EC2] Run canary in all regions

### DIFF
--- a/.github/workflows/node-ec2-canary.yml
+++ b/.github/workflows/node-ec2-canary.yml
@@ -20,11 +20,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        aws-region: [ 'us-east-1' ]
-        # aws-region: ['af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
-        #              'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-        #              'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
-        #              'us-east-1','us-east-2', 'us-west-1', 'us-west-2']
+        aws-region: ['af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
+                     'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
+                     'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+                     'us-east-1','us-east-2', 'us-west-1', 'us-west-2']
     uses: ./.github/workflows/node-ec2-default-retry.yml
     secrets: inherit
     with:

--- a/.github/workflows/node-ec2-default-test.yml
+++ b/.github/workflows/node-ec2-default-test.yml
@@ -16,7 +16,7 @@ on:
         type: string
       staging-instrumentation-name:
         required: false
-        default: 'aws-aws-distro-opentelemetry-node-autoinstrumentation-0.0.1.tgz'
+        default: '@aws/aws-distro-opentelemetry-node-autoinstrumentation'
         type: string
     outputs:
       job-started:
@@ -92,20 +92,13 @@ jobs:
           role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
           aws-region: ${{ env.E2E_TEST_AWS_REGION }}
 
-      # TODO: Remove the following step once release testing is ready
-      - name: TEMPORARY TEST CONFIGS
-        run: |
-          echo ADOT_INSTRUMENTATION_NAME="aws-aws-distro-opentelemetry-node-autoinstrumentation-0.0.1.tgz" >> $GITHUB_ENV
-
       - name: Set Get ADOT Instrumentation command environment variable
         run: |
-          echo GET_ADOT_INSTRUMENTATION_COMMAND="aws s3 cp s3://adot-autoinstrumentation-node-staging/${{ env.ADOT_INSTRUMENTATION_NAME }} ./${{ env.ADOT_INSTRUMENTATION_NAME }} && npm install ${{ env.ADOT_INSTRUMENTATION_NAME }}" >> $GITHUB_ENV
-        # TODO: Reintroduce release testing logic when artifacts are ready
-        # if [ "${{ github.event.repository.name }}" = "aws-otel-js-instrumentation" ]; then
-        #   echo GET_ADOT_INSTRUMENTATION_COMMAND="aws s3 cp s3://adot-autoinstrumentation-node-staging/${{ env.ADOT_INSTRUMENTATION_NAME }} ./${{ env.ADOT_INSTRUMENTATION_NAME }} && npm install ${{ env.ADOT_INSTRUMENTATION_NAME }}" >> $GITHUB_ENV
-        # else
-        #   echo GET_ADOT_INSTRUMENTATION_COMMAND="npm install ${{ env.ADOT_INSTRUMENTATION_NAME }}" >> $GITHUB_ENV
-        # fi
+          if [ "${{ github.event.repository.name }}" = "aws-otel-js-instrumentation" ]; then
+            echo GET_ADOT_INSTRUMENTATION_COMMAND="aws s3 cp s3://adot-autoinstrumentation-node-staging/${{ env.ADOT_INSTRUMENTATION_NAME }} ./${{ env.ADOT_INSTRUMENTATION_NAME }} && npm install ${{ env.ADOT_INSTRUMENTATION_NAME }}" >> $GITHUB_ENV
+          else
+            echo GET_ADOT_INSTRUMENTATION_COMMAND="npm install ${{ env.ADOT_INSTRUMENTATION_NAME }}" >> $GITHUB_ENV
+          fi
 
       - name: Set Get CW Agent command environment variable
         run: |
@@ -273,6 +266,5 @@ jobs:
         continue-on-error: true
         working-directory: terraform/node/ec2/default
         run: |
-          sleep 180 && \
           terraform destroy -auto-approve \
             -var="test_id=${{ env.TESTING_ID }}"


### PR DESCRIPTION
## Background
Quick update after release to allow canary to run in all regions

## Testing
After most updates:
Run: [link](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10857501977)

After removing sleep and updating syntax syntax:
Run 1: [link](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10857501977)
Run 2: [link](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10857568950)
Run 3: [link](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10857570012)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
