### PR TITLE
Temporary Hard Code Java Maven Canary Test Version to Avoid Issue

### DIFF
--- a/.github/workflows/java-ec2-canary.yml
+++ b/.github/workflows/java-ec2-canary.yml
@@ -10,25 +10,28 @@ on:
   schedule:
     - cron: '*/15 * * * *' # run the workflow every 15 minutes
   workflow_dispatch: # be able to run the workflow on demand
+  push:
+    branches:
+      - "java-maven-mitigation"
 
 permissions:
   id-token: write
   contents: read
 
 jobs:
-  github:
-    strategy:
-      fail-fast: false
-      matrix:
-        aws-region: ['af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
-                     'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-                     'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
-                     'us-east-1','us-east-2', 'us-west-1', 'us-west-2']
-    uses: ./.github/workflows/java-ec2-default-retry.yml
-    secrets: inherit
-    with:
-      aws-region: ${{ matrix.aws-region }}
-      caller-workflow-name: 'appsignals-e2e-ec2-canary-test'
+#  github:
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        aws-region: ['af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
+#                     'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
+#                     'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+#                     'us-east-1','us-east-2', 'us-west-1', 'us-west-2']
+#    uses: ./.github/workflows/java-ec2-default-retry.yml
+#    secrets: inherit
+#    with:
+#      aws-region: ${{ matrix.aws-region }}
+#      caller-workflow-name: 'appsignals-e2e-ec2-canary-test'
 
   maven:
     uses: ./.github/workflows/java-ec2-default-retry.yml

--- a/.github/workflows/java-ec2-default-test.yml
+++ b/.github/workflows/java-ec2-default-test.yml
@@ -99,9 +99,8 @@ jobs:
             # Reusing the adot-main-build-staging-jar bucket to store the python wheel file
             echo GET_ADOT_JAR_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/aws-opentelemetry-agent.jar ./adot.jar" >> $GITHUB_ENV
           elif [ "${{ env.OTEL_SOURCE }}" == "maven" ]; then
-            latest_version=$(curl -s "https://search.maven.org/solrsearch/select?q=g:software.amazon.opentelemetry+a:aws-opentelemetry-agent&core=gav&rows=1&wt=json" | jq -r '.response.docs[0].v')
-            echo "Latest version for Maven is: $latest_version"
-            echo GET_ADOT_JAR_COMMAND="wget -O adot.jar https://repo1.maven.org/maven2/software/amazon/opentelemetry/aws-opentelemetry-agent/$latest_version/aws-opentelemetry-agent-$latest_version.jar" >> $GITHUB_ENV
+            echo "Latest version for Maven is: 1.32.3"
+            echo GET_ADOT_JAR_COMMAND="wget -O adot.jar https://repo1.maven.org/maven2/software/amazon/opentelemetry/aws-opentelemetry-agent/1.32.3/aws-opentelemetry-agent-1.32.3.jar" >> $GITHUB_ENV
           else
             echo GET_ADOT_JAR_COMMAND="wget -O adot.jar https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar" >> $GITHUB_ENV
           fi


### PR DESCRIPTION
*Issue description:*
Seems Maven search endpoint was not able to return latest version value today due to maven failure
*Description of changes:*
Temporarily hard code Java Maven artifacts version
*Rollback procedure:*
Revert
<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>
Yes
*Ensure you've run the following tests on your changes and include the link below:*
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/10917006967

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
