### PR TITLE
Fix ADOT Python image for ECS E2E test.

### DIFF
--- a/.github/workflows/python-ecs-test.yml
+++ b/.github/workflows/python-ecs-test.yml
@@ -114,7 +114,7 @@ jobs:
         run: |
           if [ "${{ github.event.repository.name }}" = "aws-otel-python-instrumentation" ]; then
             # Use the staging image build by the ADOT Python repo
-            echo ADOT_INSTRUMENTATION_IMAGE_URI=="${{ env.ADOT_IMAGE_NAME }}" >> $GITHUB_ENV
+            echo ADOT_INSTRUMENTATION_IMAGE_URI="${{ env.ADOT_IMAGE_NAME }}" >> $GITHUB_ENV
           else
             ADOT_INSTRUMENTATION_IMAGE_TAG=$(curl -s -I -L 'https://github.com/aws-observability/aws-otel-python-instrumentation/releases/latest' | grep -i Location | awk -F'/tag/' '{print $2}' | tr -d '\r')
             echo ADOT_INSTRUMENTATION_IMAGE_URI="public.ecr.aws/aws-observability/adot-autoinstrumentation-python:$ADOT_INSTRUMENTATION_IMAGE_TAG" >> $GITHUB_ENV


### PR DESCRIPTION
*Issue description:*
Fix a typo in python-ecs-test.yml.

*Rollback procedure:*
revert this commit

*Ensure you've run the following tests on your changes and include the link below:*
An example of test running in ADOT python repo:
https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/10926973971/job/30332087514

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
