### PR TITLE
Encode RDS credential to base64 and decode in SampleApp

### DIFF
--- a/.github/workflows/java-eks-test.yml
+++ b/.github/workflows/java-eks-test.yml
@@ -207,6 +207,11 @@ jobs:
             RDS_MYSQL_CLUSTER_SECRETS, ${{env.RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME}}
           parse-json-secrets: true
 
+      - name: Convert RDS database credentials to base64
+        continue-on-error: true
+        run: |
+          echo "RDS_MYSQL_CLUSTER_SECRETS_PASSWORD_BASE64=$(echo -n '${{env.RDS_MYSQL_CLUSTER_SECRETS_PASSWORD}}' | base64)" >> $GITHUB_ENV
+
       - name: Initiate Terraform
         uses: ./.github/workflows/actions/execute_and_retry
         with:
@@ -245,7 +250,7 @@ jobs:
               -var="sample_remote_app_image=${{ env.REMOTE_SAMPLE_APP_IMAGE_ARN }}" \
               -var="rds_mysql_cluster_endpoint=${{env.RDS_MYSQL_CLUSTER_ENDPOINT}}" \
               -var="rds_mysql_cluster_username=${{env.RDS_MYSQL_CLUSTER_SECRETS_USERNAME}}" \
-              -var='rds_mysql_cluster_password=${{env.RDS_MYSQL_CLUSTER_SECRETS_PASSWORD}}' \
+              -var='rds_mysql_cluster_password=${{env.RDS_MYSQL_CLUSTER_SECRETS_PASSWORD_BASE64}}' \
               -var='account_id=${{ env.ACCOUNT_ID }}' \
             || deployment_failed=$?          
 

--- a/sample-apps/springboot/src/main/java/com/amazon/sampleapp/FrontendServiceController.java
+++ b/sample-apps/springboot/src/main/java/com/amazon/sampleapp/FrontendServiceController.java
@@ -29,6 +29,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.tomcat.util.codec.binary.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -170,11 +172,13 @@ public class FrontendServiceController {
   @ResponseBody
   public String mysql() {
     logger.info("mysql received");
+    final String rdsMySQLClusterPassword = new String(new Base64().decode(System.getenv("RDS_MYSQL_CLUSTER_PASSWORD").getBytes()));
+
     try {
       Connection connection = DriverManager.getConnection(
               System.getenv().get("RDS_MYSQL_CLUSTER_CONNECTION_URL"),
               System.getenv().get("RDS_MYSQL_CLUSTER_USERNAME"),
-              System.getenv().get("RDS_MYSQL_CLUSTER_PASSWORD"));
+              rdsMySQLClusterPassword);
       Statement statement = connection.createStatement();
       statement.executeQuery("SELECT * FROM tables LIMIT 1;");
     } catch (SQLException e) {


### PR DESCRIPTION
*Issue description:*

In the Java EKS E2E test, we pass RDS managed credential as an environment variable to SampleApp via Terraform. However, the credentials might contains `$$` which will be converted to PID in bash causing String interpolation.

*Description of changes:*

This change encode the credential to base64 and decode it from the SampleApp to avoid String interpolation.

*Rollback procedure:*

<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

We can safely revert this commit, remember to re-run Sample App Deployment - Java ECR workflow.

*Ensure you've run the following tests on your changes and include the link below:*

Run example: https://github.com/jerry-shao/aws-application-signals-test-framework/actions/runs/10962896688/job/30443193194

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
