### PR TITLE
[Dotnet] Allow Extra Run Time for Dotnet Windows

### DIFF
--- a/.github/workflows/dotnet-ec2-windows-test.yml
+++ b/.github/workflows/dotnet-ec2-windows-test.yml
@@ -188,7 +188,7 @@ jobs:
 # 15 Min loose upper timeout bound is designed to allow for a rate situation: in a very small chance,
 # It's possible for SSM document to take up to 8min to run and still produce expect setup outcome
       - name: Monitor EC2 instances readiness and SSM execute status in Systems Manager
-        timeout-minutes: 15
+        timeout-minutes: 18
         run: |
           # Allow up to 5 min for EC2 instance connect to SSM
           max_attempts=30
@@ -234,7 +234,7 @@ jobs:
           
           watch_command() {
             local command_id=$1
-            local max_attempts=20  # 10 minutes timeout with 30 seconds interval
+            local max_attempts=30  # 15 minutes timeout with 30 seconds interval
             local attempt=0
             local interval=30
 


### PR DESCRIPTION
*Issue description:*
In specific case, the deploy script can take around 12 min to run, this allow that behaviour
*Description of changes:*

*Rollback procedure:*
Revert
<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
