### PR TITLE
[Node] Finalize main-build/release testing

### DIFF
--- a/.github/workflows/actions/patch_image_and_check_diff/action.yml
+++ b/.github/workflows/actions/patch_image_and_check_diff/action.yml
@@ -122,6 +122,20 @@ runs:
         sleep 10
         kubectl wait --for=condition=Ready pod --all -n ${{ inputs.sample-app-namespace }}
 
+    - name: Patch the Node ADOT image and restart CloudWatch pods
+      if: ${{ inputs.repository == 'aws-otel-js-instrumentation' }}
+      shell: bash
+      run: |
+        kubectl patch deploy -namazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' \
+        -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/5", "value": "--auto-instrumentation-nodejs-image=${{ inputs.patch-image-arn }}"}]'
+        kubectl delete pods --all -n amazon-cloudwatch
+        sleep 10
+        kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
+
+        kubectl delete pods --all -n ${{ inputs.sample-app-namespace }}
+        sleep 10
+        kubectl wait --for=condition=Ready pod --all -n ${{ inputs.sample-app-namespace }}
+
     - name: Patch the CloudWatch Agent image and restart CloudWatch pods
       if: ${{ inputs.repository == 'amazon-cloudwatch-agent' }}
       shell: bash
@@ -153,7 +167,7 @@ runs:
         kubectl get pods -n amazon-cloudwatch -l app.kubernetes.io/name=amazon-cloudwatch-observability -o json | \
         jq '.items[0].spec.containers[0].args'
     
-    - name: Log pod Adot image ID and save image to the environment
+    - name: Log pod ADOT image ID and save image to the environment
       id: latest-adot-image
       shell: bash
       run: |
@@ -193,30 +207,39 @@ runs:
         echo "FLUENT_BIT_IMAGE"=$(kubectl get pods -n amazon-cloudwatch -l k8s-app=fluent-bit -o json | \
         jq '.items[0].status.containerStatuses[0].imageID') >> $GITHUB_OUTPUT
 
-    - name: Check if Python Adot image has changed
+    - name: Check if Python ADOT image has changed
       if: ${{ inputs.repository == 'aws-otel-python-instrumentation' }}
       shell: bash
       run: |
         if [ ${{ steps.default-adot-image.outputs.DEFAULT_ADOT_IMAGE }} = ${{ steps.latest-adot-image.outputs.LATEST_ADOT_IMAGE }} ]; then
-          echo "Adot image did not change"
+          echo "ADOT image did not change"
           exit 1
         fi
 
-    - name: Check if Java Adot image has changed
+    - name: Check if Java ADOT image has changed
       if: ${{ inputs.repository == 'aws-otel-java-instrumentation' }}
       shell: bash
       run: |
         if [ ${{ steps.default-adot-image.outputs.DEFAULT_ADOT_IMAGE }} = ${{ steps.latest-adot-image.outputs.LATEST_ADOT_IMAGE }} ]; then
-          echo "Adot image did not change"
+          echo "ADOT image did not change"
           exit 1
         fi
 
-    - name: Check if DotNet Adot image has changed
+    - name: Check if DotNet ADOT image has changed
       if: ${{ inputs.repository == 'aws-otel-dotnet-instrumentation' }}
       shell: bash
       run: |
         if [ ${{ steps.default-adot-image.outputs.DEFAULT_ADOT_IMAGE }} = ${{ steps.latest-adot-image.outputs.LATEST_ADOT_IMAGE }} ]; then
-          echo "Adot image did not change"
+          echo "ADOT image did not change"
+          exit 1
+        fi
+
+    - name: Check if Node ADOT image has changed
+      if: ${{ inputs.repository == 'aws-otel-js-instrumentation' }}
+      shell: bash
+      run: |
+        if [ ${{ steps.default-adot-image.outputs.DEFAULT_ADOT_IMAGE }} = ${{ steps.latest-adot-image.outputs.LATEST_ADOT_IMAGE }} ]; then
+          echo "ADOT image did not change"
           exit 1
         fi
 

--- a/.github/workflows/node-ec2-asg-test.yml
+++ b/.github/workflows/node-ec2-asg-test.yml
@@ -16,7 +16,7 @@ on:
         type: string
       staging-instrumentation-name:
         required: false
-        default: 'aws-opentelemetry-distro'
+        default: '@aws/aws-distro-opentelemetry-node-autoinstrumentation'
         type: string
     outputs:
       job-started:
@@ -92,20 +92,13 @@ jobs:
           role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
           aws-region: ${{ env.E2E_TEST_AWS_REGION }}
 
-      # TODO: Remove the following step once release testing is ready
-      - name: TEMPORARY TEST CONFIGS
-        run: |
-          echo ADOT_INSTRUMENTATION_NAME="aws-aws-distro-opentelemetry-node-autoinstrumentation-0.0.1.tgz" >> $GITHUB_ENV
-
       - name: Set Get ADOT Instrumentation command environment variable
         run: |
-          echo GET_ADOT_INSTRUMENTATION_COMMAND="aws s3 cp s3://adot-autoinstrumentation-node-staging/${{ env.ADOT_INSTRUMENTATION_NAME }} ./${{ env.ADOT_INSTRUMENTATION_NAME }} && npm install ${{ env.ADOT_INSTRUMENTATION_NAME }}" >> $GITHUB_ENV
-        # TODO: Reintroduce release testing logic when artifacts are ready
-        # if [ "${{ github.event.repository.name }}" = "aws-otel-js-instrumentation" ]; then
-        #   echo GET_ADOT_INSTRUMENTATION_COMMAND="aws s3 cp s3://adot-autoinstrumentation-node-staging/${{ env.ADOT_INSTRUMENTATION_NAME }} ./${{ env.ADOT_INSTRUMENTATION_NAME }} && npm install ${{ env.ADOT_INSTRUMENTATION_NAME }}" >> $GITHUB_ENV
-        # else
-        #   echo GET_ADOT_INSTRUMENTATION_COMMAND="npm install ${{ env.ADOT_INSTRUMENTATION_NAME }}" >> $GITHUB_ENV
-        # fi
+          if [ "${{ github.event.repository.name }}" = "aws-otel-js-instrumentation" ]; then
+            echo GET_ADOT_INSTRUMENTATION_COMMAND="aws s3 cp s3://adot-autoinstrumentation-node-staging/${{ env.ADOT_INSTRUMENTATION_NAME }} ./${{ env.ADOT_INSTRUMENTATION_NAME }} && npm install ${{ env.ADOT_INSTRUMENTATION_NAME }}" >> $GITHUB_ENV
+          else
+            echo GET_ADOT_INSTRUMENTATION_COMMAND="npm install ${{ env.ADOT_INSTRUMENTATION_NAME }}" >> $GITHUB_ENV
+          fi
 
       - name: Set Get CW Agent command environment variable
         run: |


### PR DESCRIPTION
### Description of changes:
- Adding patching logic for release/main-build testing in aws-otel-js-instrumentation repo
- Fix capitalization of `Adot` to `ADOT` in a bunch of places (echos, step names, nothing in the logic)
- Change default value for npm installation of ADOT JS instrumentation. This isn't used but might as well put it to something that should work
- Copy new logic for pulling latest helm chart from Java K8s test
- Update image patch index from 3 to 5 based on testing
- Update ASG test to remove temporary test configs from before public preview release

### Rollback procedure
Revert, no other actions needed

### Testing
Tested JS K8s here: https://github.com/aws-observability/aws-otel-js-instrumentation/actions/runs/11061371844/job/30733884840
No other test should be impacted by this change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
