### PR TITLE
Add Java Version Option for K8s

### DIFF
--- a/.github/workflows/java-k8s-canary.yml
+++ b/.github/workflows/java-k8s-canary.yml
@@ -24,3 +24,4 @@ jobs:
       # To run in more regions, a cluster must be provisioned manually on EC2 instances in that region
       aws-region: 'us-east-1'
       caller-workflow-name: 'appsignals-e2e-k8s-canary-test'
+      java-version: '11'

--- a/.github/workflows/java-k8s-retry.yml
+++ b/.github/workflows/java-k8s-retry.yml
@@ -33,7 +33,7 @@ jobs:
     with:
       aws-region: ${{ inputs.aws-region }}
       caller-workflow-name: ${{ inputs.caller-workflow-name }}
-      java-version: '11'
+      java-version: ${{ inputs.java-version }}
 
   java-k8s-attempt-2:
     needs: [ java-k8s-attempt-1 ]
@@ -43,7 +43,7 @@ jobs:
     with:
       aws-region: ${{ inputs.aws-region }}
       caller-workflow-name: ${{ inputs.caller-workflow-name }}
-      java-version: '11'
+      java-version: ${{ inputs.java-version }}
 
   publish-metric-attempt-1:
     needs: [ java-k8s-attempt-1, java-k8s-attempt-2 ]

--- a/.github/workflows/java-k8s-retry.yml
+++ b/.github/workflows/java-k8s-retry.yml
@@ -14,6 +14,9 @@ on:
       caller-workflow-name:
         required: true
         type: string
+      java-version:
+        required: true
+        type: string
 
 concurrency:
   group: 'java-k8s-${{ inputs.aws-region }}-${{ github.ref_name }}'
@@ -30,6 +33,7 @@ jobs:
     with:
       aws-region: ${{ inputs.aws-region }}
       caller-workflow-name: ${{ inputs.caller-workflow-name }}
+      java-version: '11'
 
   java-k8s-attempt-2:
     needs: [ java-k8s-attempt-1 ]
@@ -39,6 +43,7 @@ jobs:
     with:
       aws-region: ${{ inputs.aws-region }}
       caller-workflow-name: ${{ inputs.caller-workflow-name }}
+      java-version: '11'
 
   publish-metric-attempt-1:
     needs: [ java-k8s-attempt-1, java-k8s-attempt-2 ]

--- a/.github/workflows/java-k8s-test.yml
+++ b/.github/workflows/java-k8s-test.yml
@@ -17,6 +17,11 @@ on:
       caller-repository:
         required: false
         type: string
+      java-version:
+        description: "Currently support version 8, 11, 17, 21, 22"
+        required: false
+        type: string
+        default: '11'
       adot-image-name:
         required: false
         type: string
@@ -37,6 +42,7 @@ env:
   E2E_TEST_AWS_REGION: ${{ inputs.aws-region }}
   CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
   CALLER_REPOSITORY: ${{ inputs.caller-repository }}
+  JAVA_VERSION: ${{ inputs.java-version }}
   ADOT_IMAGE_NAME: ${{ inputs.adot-image-name }}
   CW_AGENT_OPERATOR_TAG: ${{ inputs.cw-agent-operator-tag }}
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
@@ -114,9 +120,9 @@ jobs:
         working-directory: terraform/java/k8s/deploy/resources
         run: |
           sed -i 's#\${TESTING_ID}#${{ env.TESTING_ID }}#' frontend-service-depl.yaml
-          sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.JAVA_MAIN_SAMPLE_APP_IMAGE }}#' frontend-service-depl.yaml
+          sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.JAVA_MAIN_SAMPLE_APP_IMAGE }}:v${{ env.JAVA_VERSION }}#' frontend-service-depl.yaml
           sed -i 's#\${TESTING_ID}#${{ env.TESTING_ID }}#' remote-service-depl.yaml
-          sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.JAVA_REMOTE_SAMPLE_APP_IMAGE }}#' remote-service-depl.yaml
+          sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.JAVA_REMOTE_SAMPLE_APP_IMAGE }}:v${{ env.JAVA_VERSION }}#' remote-service-depl.yaml
           aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key frontend-service-depl-${{ env.TESTING_ID }}.yaml --body frontend-service-depl.yaml
           aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key remote-service-depl-${{ env.TESTING_ID }}.yaml --body remote-service-depl.yaml
 


### PR DESCRIPTION
*Issue description:*
Same change as this [PR](https://github.com/aws-observability/aws-application-signals-test-framework/pull/252) but for K8s

*Test Run:*
https://github.com/harrryr/aws-application-signals-test-framework/actions/runs/11062165087

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
