### PR TITLE
Add Language Version Option for Java E2E ECS

### DIFF
--- a/.github/workflows/java-ecs-canary.yml
+++ b/.github/workflows/java-ecs-canary.yml
@@ -25,3 +25,4 @@ jobs:
     with:
       aws-region: ${{ matrix.aws-region }}
       caller-workflow-name: 'appsignals-e2e-java-ecs-canary-test'
+      java-version: '11'

--- a/.github/workflows/java-ecs-retry.yml
+++ b/.github/workflows/java-ecs-retry.yml
@@ -14,6 +14,9 @@ on:
       caller-workflow-name:
         required: true
         type: string
+      java-version:
+        required: true
+        type: string
 
 permissions:
   id-token: write
@@ -26,6 +29,7 @@ jobs:
     with:
       aws-region: ${{ inputs.aws-region }}
       caller-workflow-name: ${{ inputs.caller-workflow-name }}
+      java-version: '11'
 
   java-ecs-attempt-2:
     needs: [ java-ecs-attempt-1 ]
@@ -35,6 +39,7 @@ jobs:
     with:
       aws-region: ${{ inputs.aws-region }}
       caller-workflow-name: ${{ inputs.caller-workflow-name }}
+      java-version: '11'
 
   publish-metric-attempt-1:
     needs: [ java-ecs-attempt-1, java-ecs-attempt-2 ]

--- a/.github/workflows/java-ecs-retry.yml
+++ b/.github/workflows/java-ecs-retry.yml
@@ -29,7 +29,7 @@ jobs:
     with:
       aws-region: ${{ inputs.aws-region }}
       caller-workflow-name: ${{ inputs.caller-workflow-name }}
-      java-version: '11'
+      java-version: ${{ inputs.java-version }}
 
   java-ecs-attempt-2:
     needs: [ java-ecs-attempt-1 ]
@@ -39,7 +39,7 @@ jobs:
     with:
       aws-region: ${{ inputs.aws-region }}
       caller-workflow-name: ${{ inputs.caller-workflow-name }}
-      java-version: '11'
+      java-version: ${{ inputs.java-version }}
 
   publish-metric-attempt-1:
     needs: [ java-ecs-attempt-1, java-ecs-attempt-2 ]

--- a/.github/workflows/java-ecs-test.yml
+++ b/.github/workflows/java-ecs-test.yml
@@ -14,6 +14,11 @@ on:
       caller-workflow-name:
         required: true
         type: string
+      java-version:
+        description: "Currently support version 8, 11, 17, 21, 22"
+        required: false
+        type: string
+        default: '11'
       adot-image-name:
         required: false
         type: string
@@ -33,6 +38,7 @@ permissions:
 env:
   E2E_TEST_AWS_REGION: ${{ inputs.aws-region }}
   CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
+  JAVA_VERSION: ${{ inputs.java-version }}
   ADOT_IMAGE_NAME: ${{ inputs.adot-image-name }}
   CLUSTER_NAME: e2e-test-java
   SAMPLE_APP_NAME: main-service-java
@@ -107,8 +113,8 @@ jobs:
 
       - name: Set Sample App Image
         run: |
-          echo MAIN_SAMPLE_APP_IMAGE_URI="${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.JAVA_MAIN_SAMPLE_APP_IMAGE }}" >> $GITHUB_ENV
-          echo REMOTE_SAMPLE_APP_IMAGE_URI="${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.JAVA_REMOTE_SAMPLE_APP_IMAGE }}" >> $GITHUB_ENV
+          echo MAIN_SAMPLE_APP_IMAGE_URI="${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.JAVA_MAIN_SAMPLE_APP_IMAGE }}:v${{ env.JAVA_VERSION }}" >> $GITHUB_ENV
+          echo REMOTE_SAMPLE_APP_IMAGE_URI="${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.JAVA_REMOTE_SAMPLE_APP_IMAGE }}:v${{ env.JAVA_VERSION }}" >> $GITHUB_ENV
 
       - name: Set ADOT Java image environment variable
         run: |


### PR DESCRIPTION
*Issue description:*
Same change as this [PR](https://github.com/aws-observability/aws-application-signals-test-framework/pull/252) but for ECS

*Test Run:*
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/11062420746

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
