### PR TITLE
[Node] Small RDS fix

### DIFF
--- a/.github/workflows/node-eks-test.yml
+++ b/.github/workflows/node-eks-test.yml
@@ -180,8 +180,8 @@ jobs:
             RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroraenablementscriptpythone2eclusterformysql"
           elif [ "${{ env.CLUSTER_NAME }}" = "e2e-cw-agent-test" ]; then
             RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroracwagente2eclusterformysql"
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-adot-test" ]; then
-            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroraadote2eclusterformysql"
+          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-node-adot-test" ]; then
+            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroraadotnodee2eclusterformysql"
           elif [ "${{ env.CLUSTER_NAME }}" = "e2e-cw-agent-operator-test" ]; then
             RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroracwagentoperatore2eclusterformysql"
           elif [ "${{ env.CLUSTER_NAME }}" = "e2e-node-canary-test" ]; then


### PR DESCRIPTION
Small fix to make sure release testing does not break due to missing RDS credentials, even though we don't use them yet.

Revert procedure: Rollback

Testing: https://github.com/aws-observability/aws-otel-js-instrumentation/actions/runs/11074788929