### PR TITLE
Add Python Version Input Option for EKS

### DIFF
--- a/.github/workflows/python-eks-canary.yml
+++ b/.github/workflows/python-eks-canary.yml
@@ -31,3 +31,4 @@ jobs:
       aws-region: ${{ matrix.aws-region }}
       test-cluster-name: 'e2e-python-canary-test'
       caller-workflow-name: 'appsignals-python-e2e-eks-canary-test'
+      python-version: '3.10'

--- a/.github/workflows/python-eks-retry.yml
+++ b/.github/workflows/python-eks-retry.yml
@@ -17,6 +17,9 @@ on:
       caller-workflow-name:
         required: true
         type: string
+      python-version:
+        required: true
+        type: string
 
 concurrency:
   group: 'python-eks-${{ inputs.aws-region }}-${{ github.ref_name }}'
@@ -34,6 +37,7 @@ jobs:
       aws-region: ${{ inputs.aws-region }}
       test-cluster-name: ${{ inputs.test-cluster-name }}
       caller-workflow-name: ${{ inputs.caller-workflow-name }}
+      python-version: ${{ inputs.python-version }}
 
   python-eks-attempt-2:
     needs: [ python-eks-attempt-1 ]
@@ -44,6 +48,7 @@ jobs:
       aws-region: ${{ inputs.aws-region }}
       test-cluster-name: ${{ inputs.test-cluster-name }}
       caller-workflow-name: ${{ inputs.caller-workflow-name }}
+      python-version: ${{ inputs.python-version }}
 
   publish-metric-attempt-1:
     needs: [ python-eks-attempt-1, python-eks-attempt-2 ]

--- a/.github/workflows/python-eks-test.yml
+++ b/.github/workflows/python-eks-test.yml
@@ -17,6 +17,11 @@ on:
       caller-workflow-name:
         required: true
         type: string
+      python-version:
+        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12"
+        required: false
+        type: string
+        default: '3.10'
       adot-image-name:
         required: false
         type: string
@@ -37,6 +42,7 @@ env:
   E2E_TEST_AWS_REGION: ${{ inputs.aws-region }}
   CLUSTER_NAME: ${{ inputs.test-cluster-name }}
   CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
+  PYTHON_VERSION: ${{ inputs.python-version }}
   ADOT_IMAGE_NAME: ${{ inputs.adot-image-name }}
   CW_AGENT_OPERATOR_TAG: ${{ inputs.cw-agent-operator-tag }}
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
@@ -223,8 +229,8 @@ jobs:
 
       - name: Set Sample App Image
         run: |
-            echo MAIN_SAMPLE_APP_IMAGE_ARN="${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.PYTHON_MAIN_SAMPLE_APP_IMAGE }}" >> $GITHUB_ENV
-            echo REMOTE_SAMPLE_APP_IMAGE_ARN="${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.PYTHON_REMOTE_SAMPLE_APP_IMAGE }}" >> $GITHUB_ENV
+            echo MAIN_SAMPLE_APP_IMAGE_ARN="${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.PYTHON_MAIN_SAMPLE_APP_IMAGE }}:v${{ env.PYTHON_VERSION }}" >> $GITHUB_ENV
+            echo REMOTE_SAMPLE_APP_IMAGE_ARN="${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.PYTHON_REMOTE_SAMPLE_APP_IMAGE }}:v${{ env.PYTHON_VERSION }}" >> $GITHUB_ENV
 
       - name: Deploy sample app via terraform and wait for the endpoint to come online
         id: deploy-python-app


### PR DESCRIPTION
*Issue description:*
Follow up on [PR](https://github.com/aws-observability/aws-application-signals-test-framework/pull/265). Updating Python EKS to have input option for language version

*Rollback procedure:*
Revert

Test Run: https://github.com/harrryr/aws-application-signals-test-framework/actions/runs/11156946447

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
