### PR TITLE
Add Python Version Input Option for K8s

### DIFF
--- a/.github/workflows/python-k8s-canary.yml
+++ b/.github/workflows/python-k8s-canary.yml
@@ -22,3 +22,4 @@ jobs:
       # To run in more regions, a cluster must be provisioned manually on EC2 instances in that region
       aws-region: 'us-east-1'
       caller-workflow-name: 'appsignals-e2e-python-k8s-canary-test'
+      python-version: '3.10'

--- a/.github/workflows/python-k8s-retry.yml
+++ b/.github/workflows/python-k8s-retry.yml
@@ -14,6 +14,9 @@ on:
       caller-workflow-name:
         required: true
         type: string
+      python-version:
+        required: true
+        type: string
 
 concurrency:
   group: 'python-k8s-${{ inputs.aws-region }}-${{ github.ref_name }}'
@@ -30,6 +33,7 @@ jobs:
     with:
       aws-region: ${{ inputs.aws-region }}
       caller-workflow-name: ${{ inputs.caller-workflow-name }}
+      python-version: ${{ inputs.python-version }}
 
   python-k8s-attempt-2:
     needs: [ python-k8s-attempt-1 ]
@@ -39,6 +43,7 @@ jobs:
     with:
       aws-region: ${{ inputs.aws-region }}
       caller-workflow-name: ${{ inputs.caller-workflow-name }}
+      python-version: ${{ inputs.python-version }}
 
   publish-metric-attempt-1:
     needs: [ python-k8s-attempt-1, python-k8s-attempt-2 ]

--- a/.github/workflows/python-k8s-test.yml
+++ b/.github/workflows/python-k8s-test.yml
@@ -17,6 +17,11 @@ on:
       caller-repository:
         required: false
         type: string
+      python-version:
+        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12"
+        required: false
+        type: string
+        default: '3.10'
       adot-image-name:
         required: false
         type: string
@@ -37,6 +42,7 @@ env:
   E2E_TEST_AWS_REGION: ${{ inputs.aws-region }}
   CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
   CALLER_REPOSITORY: ${{ inputs.caller-repository }}
+  PYTHON_VERSION: ${{ inputs.python-version }}
   ADOT_IMAGE_NAME: ${{ inputs.adot-image-name }}
   CW_AGENT_OPERATOR_TAG: ${{ inputs.cw-agent-operator-tag }}
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
@@ -114,9 +120,9 @@ jobs:
         working-directory: terraform/python/k8s/deploy/resources
         run: |
           sed -i 's#\${TESTING_ID}#${{ env.TESTING_ID }}#' python-frontend-service-depl.yaml
-          sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.PYTHON_MAIN_SAMPLE_APP_IMAGE }}#' python-frontend-service-depl.yaml
+          sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.PYTHON_MAIN_SAMPLE_APP_IMAGE }}:v${{ env.PYTHON_VERSION }}#' python-frontend-service-depl.yaml
           sed -i 's#\${TESTING_ID}#${{ env.TESTING_ID }}#' python-remote-service-depl.yaml
-          sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.PYTHON_REMOTE_SAMPLE_APP_IMAGE }}#' python-remote-service-depl.yaml
+          sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.PYTHON_REMOTE_SAMPLE_APP_IMAGE }}:v${{ env.PYTHON_VERSION }}#' python-remote-service-depl.yaml
           aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key python-frontend-service-depl-${{ env.TESTING_ID }}.yaml --body python-frontend-service-depl.yaml
           aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key python-remote-service-depl-${{ env.TESTING_ID }}.yaml --body python-remote-service-depl.yaml
 


### PR DESCRIPTION
*Issue description:*
Same change as this [PR](https://github.com/aws-observability/aws-application-signals-test-framework/pull/266) but for K8s

*Description of changes:*

*Rollback procedure:*
Revert

Test Run: https://github.com/harrryr/aws-application-signals-test-framework/actions/runs/11129636602/job/30927186734

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
