### PR TITLE
[K8s/Patching] Add jitter to K8s-on-EC2 cluster creation

### DIFF
--- a/.github/workflows/k8s-patch-os-jobs.yml
+++ b/.github/workflows/k8s-patch-os-jobs.yml
@@ -5,6 +5,9 @@ name: K8s Patch OS Job
 on:
   workflow_call:
     inputs:
+      jitter_index:
+        required: true
+        type: number
       repo_name:
         required: true
         type: string
@@ -20,6 +23,7 @@ permissions:
   contents: read
 
 env:
+  JITTER_INDEX: ${{ inputs.jitter_index }}
   REPO: ${{ inputs.repo_name }}
   EC2_NAME: ${{ inputs.ec2_name }}
   LANGUAGE:  ${{ inputs.language }}
@@ -31,6 +35,10 @@ jobs:
   create-k8s-on-ec2:
     runs-on: ubuntu-latest
     steps:
+      # Sleep 20 seconds between each job's start
+      - name: Sleep to avoid throttling limits
+        run: sleep $((${{ env.JITTER_INDEX }} * 20))
+
       - name: Generate Testing ID
         run: |
           echo TESTING_ID="${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}" >> $GITHUB_ENV

--- a/.github/workflows/k8s-patch-os-matrix.yml
+++ b/.github/workflows/k8s-patch-os-matrix.yml
@@ -17,25 +17,26 @@ jobs:
       fail-fast: false
       matrix:
         instance: [
-          { repo_name: 'amazon-cloudwatch-agent-operator', ec2_name: 'cw-agent-operator-release', language: 'java' },
-          { repo_name: 'amazon-cloudwatch-agent-operator', ec2_name: 'cw-agent-operator-release', language: 'python' },
-          { repo_name: 'amazon-cloudwatch-agent-operator', ec2_name: 'cw-agent-operator-release', language: 'dotnet' },
-          { repo_name: 'amazon-cloudwatch-agent-operator', ec2_name: 'cw-agent-operator-release', language: 'node' },
-          { repo_name: 'amazon-cloudwatch-agent', ec2_name: 'cw-agent-release', language: 'java' },
-          { repo_name: 'amazon-cloudwatch-agent', ec2_name: 'cw-agent-release', language: 'python' },
-          { repo_name: 'amazon-cloudwatch-agent', ec2_name: 'cw-agent-release', language: 'dotnet' },
-          { repo_name: 'amazon-cloudwatch-agent', ec2_name: 'cw-agent-release', language: 'node' },
-          { repo_name: 'aws-otel-java-instrumentation', ec2_name: 'adot-java-release', language: 'java' },
-          { repo_name: 'aws-otel-python-instrumentation', ec2_name: 'adot-python-release', language: 'python' },
-          { repo_name: 'aws-otel-dotnet-instrumentation', ec2_name: 'adot-dotnet-release', language: 'dotnet' },
-          { repo_name: 'aws-otel-js-instrumentation', ec2_name: 'adot-node-release', language: 'node' },
-          { repo_name: 'aws-application-signals-test-framework', ec2_name: 'java-canary', language: 'java' },
-          { repo_name: 'aws-application-signals-test-framework', ec2_name: 'python-canary', language: 'python' },
-          { repo_name: 'aws-application-signals-test-framework', ec2_name: 'dotnet-canary', language: 'dotnet' },
-          { repo_name: 'aws-application-signals-test-framework', ec2_name: 'node-canary', language: 'node' } ]
+          { jitter_index: 0, repo_name: 'amazon-cloudwatch-agent-operator', ec2_name: 'cw-agent-operator-release', language: 'java' },
+          { jitter_index: 1, repo_name: 'amazon-cloudwatch-agent-operator', ec2_name: 'cw-agent-operator-release', language: 'python' },
+          { jitter_index: 2, repo_name: 'amazon-cloudwatch-agent-operator', ec2_name: 'cw-agent-operator-release', language: 'dotnet' },
+          { jitter_index: 3, repo_name: 'amazon-cloudwatch-agent-operator', ec2_name: 'cw-agent-operator-release', language: 'node' },
+          { jitter_index: 4, repo_name: 'amazon-cloudwatch-agent', ec2_name: 'cw-agent-release', language: 'java' },
+          { jitter_index: 5, repo_name: 'amazon-cloudwatch-agent', ec2_name: 'cw-agent-release', language: 'python' },
+          { jitter_index: 6, repo_name: 'amazon-cloudwatch-agent', ec2_name: 'cw-agent-release', language: 'dotnet' },
+          { jitter_index: 7, repo_name: 'amazon-cloudwatch-agent', ec2_name: 'cw-agent-release', language: 'node' },
+          { jitter_index: 8, repo_name: 'aws-otel-java-instrumentation', ec2_name: 'adot-java-release', language: 'java' },
+          { jitter_index: 9, repo_name: 'aws-otel-python-instrumentation', ec2_name: 'adot-python-release', language: 'python' },
+          { jitter_index: 10, repo_name: 'aws-otel-dotnet-instrumentation', ec2_name: 'adot-dotnet-release', language: 'dotnet' },
+          { jitter_index: 11, repo_name: 'aws-otel-js-instrumentation', ec2_name: 'adot-node-release', language: 'node' },
+          { jitter_index: 12, repo_name: 'aws-application-signals-test-framework', ec2_name: 'java-canary', language: 'java' },
+          { jitter_index: 13, repo_name: 'aws-application-signals-test-framework', ec2_name: 'python-canary', language: 'python' },
+          { jitter_index: 14, repo_name: 'aws-application-signals-test-framework', ec2_name: 'dotnet-canary', language: 'dotnet' },
+          { jitter_index: 15, repo_name: 'aws-application-signals-test-framework', ec2_name: 'node-canary', language: 'node' } ]
     uses: ./.github/workflows/k8s-patch-os-jobs.yml
     secrets: inherit
     with:
+      jitter_index: ${{ matrix.instance.jitter_index }}
       repo_name: ${{ matrix.instance.repo_name }}
       ec2_name: ${{ matrix.instance.ec2_name }}
       language: ${{ matrix.instance.language }}


### PR DESCRIPTION
### Issue
K8s OS patching workflow does not succeed some jobs because of throttling when trying to create EC2 instances

### Description of changes
- Added jitter_index to input
- Added sleep based on jitter index
- Each job will now sleep 20 seconds for each job before it in the list, ensuring they run somewhat sequentially and not all at the same time

Note: The github scheduler/worker assignment may still lead to some of the jobs doing things at the same time, but the risk of this causing throttling should be low

### Testing
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/11172296461

### Rollback procedure
Revert PR and rerun the workflow