### PR TITLE
Revert Temporarily Measurement to Disable Canary Result Publish

### DIFF
--- a/.github/workflows/enablement-test-publish-result.yml
+++ b/.github/workflows/enablement-test-publish-result.yml
@@ -66,6 +66,6 @@ jobs:
             aws cloudwatch put-metric-data --namespace 'ADOT/GitHubActions' \
             --metric-name Failure \
             --dimensions repository=${{ github.repository }},branch=${{ github.ref_name }},workflow=${{ env.CALLER_WORKFLOW_NAME }} \
-            --value 0.0 \
+            --value 1.0 \
             --region ${{ env.E2E_TEST_AWS_REGION }}
           fi


### PR DESCRIPTION
This reverts commit 1c529a890fce8709740f8b5599b8ec0d43ab1f0d.

*Issue description:*
Upstream fix the issue on hashicorp terrafrom aws, no need to block metric publish now

*Description of changes:*

*Rollback procedure:*

<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
