### PR TITLE
Fix the wrong sample app S3 bucket name in Lambda canary

### DIFF
--- a/.github/workflows/node-lambda-test.yml
+++ b/.github/workflows/node-lambda-test.yml
@@ -106,7 +106,7 @@ jobs:
         if: ${{ env.CALLER_WORKFLOW_NAME == 'appsignals-node-e2e-lambda-canary-test' }}
         run: | 
           echo IS_CANARY=true >> $GITHUB_ENV |
-          aws s3 cp {{ env.SAMPLE_APP_ZIP }} ${{ env.ARTIFACTS_DIR }}/jsfunction.zip
+          aws s3 cp ${{ env.SAMPLE_APP_ZIP }} ${{ env.ARTIFACTS_DIR }}/jsfunction.zip
 
       - name: Set up terraform
         uses: ./.github/workflows/actions/execute_and_retry

--- a/.github/workflows/python-lambda-test.yml
+++ b/.github/workflows/python-lambda-test.yml
@@ -121,7 +121,7 @@ jobs:
         if: ${{ env.CALLER_WORKFLOW_NAME == 'appsignals-python-e2e-lambda-canary-test' }}
         run: |
           echo IS_CANARY=true >> $GITHUB_ENV |
-          aws s3 cp {{ env.SAMPLE_APP_ZIP }} ${{ env.ARTIFACTS_DIR }}/pyfunction.zip
+          aws s3 cp ${{ env.SAMPLE_APP_ZIP }} ${{ env.ARTIFACTS_DIR }}/pyfunction.zip
 
       - name: Set up terraform
         uses: ./.github/workflows/actions/execute_and_retry


### PR DESCRIPTION

*Description of changes:*
Fix the wrong sample app S3 bucket name in Lambda canary

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
