### PR TITLE
Updated E2E DotNet Operation after route template fix

### DIFF
--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/aws-sdk-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/aws-sdk-call-log.mustache
@@ -11,7 +11,7 @@
   "EC2.InstanceId": "^{{instanceId}}$",
   "Environment": "^ec2:{{platformInfo}}$",
   "PlatformType": "^AWS::EC2$",
-  "Operation": "GET /aws-sdk-call",
+  "Operation": "GET aws-sdk-call",
   "Version": "^1$",
   "RemoteService": "AWS::S3",
   "RemoteOperation": "GetBucketLocation",

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/aws-sdk-call-metric.mustache
@@ -29,7 +29,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -80,7 +80,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -154,7 +154,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -205,7 +205,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -279,7 +279,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -330,7 +330,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/aws-sdk-call-trace.mustache
@@ -35,7 +35,7 @@
       },
       "annotations": {
         "aws.local.service": "^{{serviceName}}$",
-        "aws.local.operation": "^GET /aws-sdk-call$",
+        "aws.local.operation": "^GET aws-sdk-call$",
         "aws.remote.service": "^AWS::S3$",
         "aws.remote.operation": "^GetBucketLocation$",
         "aws.local.environment": "^ec2:{{platformInfo}}$",

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/outgoing-http-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/outgoing-http-call-log.mustache
@@ -11,7 +11,7 @@
   "EC2.InstanceId": "^{{instanceId}}$",
   "Environment": "^ec2:{{platformInfo}}$",
   "PlatformType": "^AWS::EC2$",
-  "Operation": "GET /outgoing-http-call",
+  "Operation": "GET outgoing-http-call",
   "Version": "^1$",
   "RemoteService": "aws.amazon.com:443",
   "RemoteOperation": "GET /",

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/outgoing-http-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/outgoing-http-call-metric.mustache
@@ -29,7 +29,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -105,7 +105,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -181,7 +181,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/outgoing-http-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/outgoing-http-call-trace.mustache
@@ -38,7 +38,7 @@
       },
       "annotations": {
         "aws.local.service": "^{{serviceName}}$",
-        "aws.local.operation": "^GET /outgoing-http-call$",
+        "aws.local.operation": "^GET outgoing-http-call$",
         "aws.remote.service": "^aws.amazon.com:443$",
         "aws.remote.operation": "^GET /$",
         "aws.local.environment": "^ec2:{{platformInfo}}$"

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/remote-service-log.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/remote-service-log.mustache
@@ -11,7 +11,7 @@
   "EC2.InstanceId": "^{{instanceId}}$",
   "Environment": "^ec2:{{platformInfo}}$",
   "PlatformType": "^AWS::EC2$",
-  "Operation": "GET /remote-service",
+  "Operation": "GET remote-service",
   "Version": "^1$",
   "RemoteService": "{{remoteServiceDeploymentName}}",
   "RemoteOperation": "GET /healthcheck",

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/remote-service-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/remote-service-metric.mustache
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -127,7 +127,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -236,7 +236,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/remote-service-trace.mustache
@@ -38,7 +38,7 @@
       },
       "annotations": {
         "aws.local.service": "^{{serviceName}}$",
-        "aws.local.operation": "^GET /remote-service$",
+        "aws.local.operation": "^GET remote-service$",
         "aws.remote.service": "^{{remoteServiceDeploymentName}}$",
         "aws.remote.operation": "^GET /healthcheck$",
         "aws.local.environment": "^ec2:{{platformInfo}}$"

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-log.mustache
@@ -2,7 +2,7 @@
   "EC2.InstanceId": "^{{instanceId}}$",
   "Environment": "^ec2:default$",
   "PlatformType": "^AWS::EC2$",
-  "Operation": "GET /aws-sdk-call",
+  "Operation": "GET aws-sdk-call",
   "Version": "^1$",
   "Telemetry.Source": "^LocalRootSpan$",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"
@@ -11,7 +11,7 @@
   "EC2.InstanceId": "^{{instanceId}}$",
   "Environment": "^ec2:default$",
   "PlatformType": "^AWS::EC2$",
-  "Operation": "GET /aws-sdk-call",
+  "Operation": "GET aws-sdk-call",
   "Version": "^1$",
   "RemoteService": "AWS::S3",
   "RemoteOperation": "GetBucketLocation",

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-metric.mustache
@@ -15,7 +15,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -29,7 +29,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -80,7 +80,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -140,7 +140,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -154,7 +154,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -205,7 +205,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -265,7 +265,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -279,7 +279,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -331,7 +331,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-trace.mustache
@@ -11,7 +11,7 @@
   },
   "annotations": {
     "aws.local.service": "^{{serviceName}}$",
-    "aws.local.operation": "^GET /aws-sdk-call$",
+    "aws.local.operation": "^GET aws-sdk-call$",
     "aws.local.environment": "^ec2:default$"
   },
   "metadata": {
@@ -31,7 +31,7 @@
       },
       "annotations": {
         "aws.local.service": "^{{serviceName}}$",
-        "aws.local.operation": "^GET /aws-sdk-call$",
+        "aws.local.operation": "^GET aws-sdk-call$",
         "aws.remote.service": "^AWS::S3$",
         "aws.remote.operation": "^GetBucketLocation$",
         "aws.local.environment": "^ec2:default$",

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/outgoing-http-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/outgoing-http-call-log.mustache
@@ -2,7 +2,7 @@
   "EC2.InstanceId": "^{{instanceId}}$",
   "Environment": "^ec2:default$",
   "PlatformType": "^AWS::EC2$",
-  "Operation": "GET /outgoing-http-call",
+  "Operation": "GET outgoing-http-call",
   "Version": "^1$",
   "Telemetry.Source": "^LocalRootSpan$",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"
@@ -11,7 +11,7 @@
   "EC2.InstanceId": "^{{instanceId}}$",
   "Environment": "^ec2:default$",
   "PlatformType": "^AWS::EC2$",
-  "Operation": "GET /outgoing-http-call",
+  "Operation": "GET outgoing-http-call",
   "Version": "^1$",
   "RemoteService": "aws.amazon.com:443",
   "RemoteOperation": "GET /",

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/outgoing-http-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/outgoing-http-call-metric.mustache
@@ -15,7 +15,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -29,7 +29,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -91,7 +91,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -105,7 +105,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -167,7 +167,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -181,7 +181,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/outgoing-http-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/outgoing-http-call-trace.mustache
@@ -11,7 +11,7 @@
   },
   "annotations": {
     "aws.local.service": "^{{serviceName}}$",
-    "aws.local.operation": "^GET /outgoing-http-call$",
+    "aws.local.operation": "^GET outgoing-http-call$",
     "aws.local.environment": "^ec2:default$"
   },
   "metadata": {
@@ -34,7 +34,7 @@
       },
       "annotations": {
         "aws.local.service": "^{{serviceName}}$",
-        "aws.local.operation": "^GET /outgoing-http-call$",
+        "aws.local.operation": "^GET outgoing-http-call$",
         "aws.remote.service": "^aws.amazon.com:443$",
         "aws.remote.operation": "^GET /$",
         "aws.local.environment": "^ec2:default$"

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/remote-service-log.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/remote-service-log.mustache
@@ -2,7 +2,7 @@
   "EC2.InstanceId": "^{{instanceId}}$",
   "Environment": "^ec2:default$",
   "PlatformType": "^AWS::EC2$",
-  "Operation": "GET /remote-service",
+  "Operation": "GET remote-service",
   "Version": "^1$",
   "Telemetry.Source": "^LocalRootSpan$",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"
@@ -11,7 +11,7 @@
   "EC2.InstanceId": "^{{instanceId}}$",
   "Environment": "^ec2:default$",
   "PlatformType": "^AWS::EC2$",
-  "Operation": "GET /remote-service",
+  "Operation": "GET remote-service",
   "Version": "^1$",
   "RemoteService": "{{remoteServiceDeploymentName}}",
   "RemoteOperation": "GET /healthcheck",

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/remote-service-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/remote-service-metric.mustache
@@ -4,7 +4,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -113,7 +113,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -127,7 +127,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -222,7 +222,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -236,7 +236,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/remote-service-trace.mustache
@@ -11,7 +11,7 @@
   },
   "annotations": {
     "aws.local.service": "^{{serviceName}}$",
-    "aws.local.operation": "^GET /remote-service$",
+    "aws.local.operation": "^GET remote-service$",
     "aws.local.environment": "^ec2:default$"
   },
   "metadata": {
@@ -34,7 +34,7 @@
       },
       "annotations": {
         "aws.local.service": "^{{serviceName}}$",
-        "aws.local.operation": "^GET /remote-service$",
+        "aws.local.operation": "^GET remote-service$",
         "aws.remote.service": "^{{remoteServiceDeploymentName}}$",
         "aws.remote.operation": "^GET /healthcheck$",
         "aws.local.environment": "^ec2:default$"

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/aws-sdk-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/aws-sdk-call-log.mustache
@@ -2,7 +2,7 @@
   "EC2.InstanceId": "^{{instanceId}}$",
   "Environment": "^ec2:default$",
   "PlatformType": "^AWS::EC2$",
-  "Operation": "GET /aws-sdk-call",
+  "Operation": "GET aws-sdk-call",
   "Version": "^1$",
   "Telemetry.Source": "^LocalRootSpan$",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"
@@ -11,7 +11,7 @@
   "EC2.InstanceId": "^{{instanceId}}$",
   "Environment": "^ec2:default$",
   "PlatformType": "^AWS::EC2$",
-  "Operation": "GET /aws-sdk-call",
+  "Operation": "GET aws-sdk-call",
   "Version": "^1$",
   "RemoteService": "AWS::S3",
   "RemoteOperation": "GetBucketLocation",

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/aws-sdk-call-metric.mustache
@@ -15,7 +15,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -29,7 +29,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -80,7 +80,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -140,7 +140,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -154,7 +154,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -205,7 +205,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -265,7 +265,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -279,7 +279,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -330,7 +330,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/aws-sdk-call-trace.mustache
@@ -11,7 +11,7 @@
   },
   "annotations": {
     "aws.local.service": "^{{serviceName}}$",
-    "aws.local.operation": "^GET /aws-sdk-call$",
+    "aws.local.operation": "^GET aws-sdk-call$",
     "aws.local.environment": "^ec2:default$"
   },
   "metadata": {
@@ -31,7 +31,7 @@
       },
       "annotations": {
         "aws.local.service": "^{{serviceName}}$",
-        "aws.local.operation": "^GET /aws-sdk-call$",
+        "aws.local.operation": "^GET aws-sdk-call$",
         "aws.remote.service": "^AWS::S3$",
         "aws.remote.operation": "^GetBucketLocation$",
         "aws.local.environment": "^ec2:default$",

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/outgoing-http-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/outgoing-http-call-log.mustache
@@ -2,7 +2,7 @@
   "EC2.InstanceId": "^{{instanceId}}$",
   "Environment": "^ec2:default$",
   "PlatformType": "^AWS::EC2$",
-  "Operation": "GET /outgoing-http-call",
+  "Operation": "GET outgoing-http-call",
   "Version": "^1$",
   "Telemetry.Source": "^LocalRootSpan$",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"
@@ -11,7 +11,7 @@
   "EC2.InstanceId": "^{{instanceId}}$",
   "Environment": "^ec2:default$",
   "PlatformType": "^AWS::EC2$",
-  "Operation": "GET /outgoing-http-call",
+  "Operation": "GET outgoing-http-call",
   "Version": "^1$",
   "RemoteService": "aws.amazon.com:443",
   "RemoteOperation": "GET /",

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/outgoing-http-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/outgoing-http-call-metric.mustache
@@ -15,7 +15,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -29,7 +29,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -91,7 +91,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -105,7 +105,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -167,7 +167,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -181,7 +181,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/outgoing-http-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/outgoing-http-call-trace.mustache
@@ -11,7 +11,7 @@
   },
   "annotations": {
     "aws.local.service": "^{{serviceName}}$",
-    "aws.local.operation": "^GET /outgoing-http-call$",
+    "aws.local.operation": "^GET outgoing-http-call$",
     "aws.local.environment": "^ec2:default$"
   },
   "metadata": {
@@ -34,7 +34,7 @@
       },
       "annotations": {
         "aws.local.service": "^{{serviceName}}$",
-        "aws.local.operation": "^GET /outgoing-http-call$",
+        "aws.local.operation": "^GET outgoing-http-call$",
         "aws.remote.service": "^aws.amazon.com:443$",
         "aws.remote.operation": "^GET /$",
         "aws.local.environment": "^ec2:default$"

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/remote-service-log.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/remote-service-log.mustache
@@ -2,7 +2,7 @@
   "EC2.InstanceId": "^{{instanceId}}$",
   "Environment": "^ec2:default$",
   "PlatformType": "^AWS::EC2$",
-  "Operation": "GET /remote-service",
+  "Operation": "GET remote-service",
   "Version": "^1$",
   "Telemetry.Source": "^LocalRootSpan$",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"
@@ -11,7 +11,7 @@
   "EC2.InstanceId": "^{{instanceId}}$",
   "Environment": "^ec2:default$",
   "PlatformType": "^AWS::EC2$",
-  "Operation": "GET /remote-service",
+  "Operation": "GET remote-service",
   "Version": "^1$",
   "RemoteService": "{{remoteServiceDeploymentName}}",
   "RemoteOperation": "GET /healthcheck",

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/remote-service-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/remote-service-metric.mustache
@@ -4,7 +4,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -99,7 +99,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -113,7 +113,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -208,7 +208,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -222,7 +222,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/remote-service-trace.mustache
@@ -11,7 +11,7 @@
   },
   "annotations": {
     "aws.local.service": "^{{serviceName}}$",
-    "aws.local.operation": "^GET /remote-service$",
+    "aws.local.operation": "^GET remote-service$",
     "aws.local.environment": "^ec2:default$"
   },
   "metadata": {
@@ -34,7 +34,7 @@
       },
       "annotations": {
         "aws.local.service": "^{{serviceName}}$",
-        "aws.local.operation": "^GET /remote-service$",
+        "aws.local.operation": "^GET remote-service$",
         "aws.remote.service": "^{{remoteServiceDeploymentName}}$",
         "aws.remote.operation": "^GET /healthcheck$",
         "aws.local.environment": "^ec2:default$"

--- a/validator/src/main/resources/expected-data-template/dotnet/eks/linux/aws-sdk-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/eks/linux/aws-sdk-call-log.mustache
@@ -9,7 +9,7 @@
   "K8s.Workload": "^dotnet-app-deployment-{{testingId}}$",
   "PlatformType": "^AWS::EKS$",
   "Service": "^{{serviceName}}$",
-  "Operation": "GET /aws-sdk-call",
+  "Operation": "GET aws-sdk-call",
   "Version": "^1$",
   "Telemetry.Source": "^LocalRootSpan$",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"
@@ -25,7 +25,7 @@
   "K8s.Workload": "^dotnet-app-deployment-{{testingId}}$",
   "PlatformType": "^AWS::EKS$",
   "Service": "^{{serviceName}}$",
-  "Operation": "GET /aws-sdk-call",
+  "Operation": "GET aws-sdk-call",
   "Version": "^1$",
   "RemoteService": "AWS::S3",
   "RemoteOperation": "GetBucketLocation",

--- a/validator/src/main/resources/expected-data-template/dotnet/eks/linux/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/eks/linux/aws-sdk-call-metric.mustache
@@ -4,7 +4,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -80,7 +80,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -129,7 +129,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -143,7 +143,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -205,7 +205,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -255,7 +255,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -269,7 +269,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -331,7 +331,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/dotnet/eks/linux/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/eks/linux/aws-sdk-call-trace.mustache
@@ -11,7 +11,7 @@
   },
   "annotations": {
     "aws.local.service": "^{{serviceName}}$",
-    "aws.local.operation": "^GET /aws-sdk-call$",
+    "aws.local.operation": "^GET aws-sdk-call$",
     "aws.local.environment": "^eks:{{platformInfo}}/{{appNamespace}}$"
   },
   "metadata": {
@@ -36,7 +36,7 @@
       },
       "annotations": {
         "aws.local.service": "^{{serviceName}}$",
-        "aws.local.operation": "^GET /aws-sdk-call$",
+        "aws.local.operation": "^GET aws-sdk-call$",
         "aws.remote.service": "^AWS::S3$",
         "aws.remote.operation": "^GetBucketLocation$",
         "aws.local.environment": "^eks:{{platformInfo}}/{{appNamespace}}$",

--- a/validator/src/main/resources/expected-data-template/dotnet/eks/linux/outgoing-http-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/eks/linux/outgoing-http-call-log.mustache
@@ -9,7 +9,7 @@
   "K8s.Workload": "^dotnet-app-deployment-{{testingId}}$",
   "PlatformType": "^AWS::EKS$",
   "Service": "^{{serviceName}}$",
-  "Operation": "GET /outgoing-http-call",
+  "Operation": "GET outgoing-http-call",
   "Version": "^1$",
   "Telemetry.Source": "^LocalRootSpan$",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"
@@ -25,7 +25,7 @@
   "K8s.Workload": "^dotnet-app-deployment-{{testingId}}$",
   "PlatformType": "^AWS::EKS$",
   "Service": "^{{serviceName}}$",
-  "Operation": "GET /outgoing-http-call",
+  "Operation": "GET outgoing-http-call",
   "Version": "^1$",
   "RemoteService": "aws.amazon.com:443",
   "RemoteOperation": "GET /",

--- a/validator/src/main/resources/expected-data-template/dotnet/eks/linux/outgoing-http-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/eks/linux/outgoing-http-call-metric.mustache
@@ -4,7 +4,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -80,7 +80,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -94,7 +94,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -156,7 +156,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -170,7 +170,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/dotnet/eks/linux/outgoing-http-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/eks/linux/outgoing-http-call-trace.mustache
@@ -11,7 +11,7 @@
   },
   "annotations": {
     "aws.local.service": "^{{serviceName}}$",
-    "aws.local.operation": "^GET /outgoing-http-call$",
+    "aws.local.operation": "^GET outgoing-http-call$",
     "aws.local.environment": "^eks:{{platformInfo}}/{{appNamespace}}$"
   },
   "metadata": {
@@ -38,7 +38,7 @@
       },
       "annotations": {
         "aws.local.service": "^{{serviceName}}$",
-        "aws.local.operation": "^GET /outgoing-http-call$",
+        "aws.local.operation": "^GET outgoing-http-call$",
         "aws.remote.service": "^aws.amazon.com:443$",
         "aws.remote.operation": "^GET /$",
         "aws.local.environment": "^eks:{{platformInfo}}/{{appNamespace}}$"

--- a/validator/src/main/resources/expected-data-template/dotnet/eks/linux/remote-service-log.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/eks/linux/remote-service-log.mustache
@@ -9,7 +9,7 @@
   "K8s.Workload": "^dotnet-app-deployment-{{testingId}}$",
   "PlatformType": "^AWS::EKS$",
   "Service": "^{{serviceName}}$",
-  "Operation": "GET /remote-service",
+  "Operation": "GET remote-service",
   "Version": "^1$",
   "Telemetry.Source": "^LocalRootSpan$",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"
@@ -26,7 +26,7 @@
   "K8s.Workload": "^dotnet-app-deployment-{{testingId}}$",
   "PlatformType": "^AWS::EKS$",
   "Service": "^{{serviceName}}$",
-  "Operation": "GET /remote-service",
+  "Operation": "GET remote-service",
   "Version": "^1$",
   "RemoteService": "{{remoteServiceDeploymentName}}",
   "RemoteOperation": "GET /healthcheck",

--- a/validator/src/main/resources/expected-data-template/dotnet/eks/linux/remote-service-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/eks/linux/remote-service-metric.mustache
@@ -4,7 +4,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -126,175 +126,6 @@
 
 -
   metricName: Latency
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Environment
-      value: eks:{{platformInfo}}/{{appNamespace}}
-    -
-      name: RemoteEnvironment
-      value: eks:{{platformInfo}}/{{appNamespace}}
-    -
-      name: RemoteOperation
-      value: GET /healthcheck
-    -
-      name: RemoteService
-      value: {{remoteServiceDeploymentName}}
-    -
-      name: Service
-      value: {{serviceName}}
-
--
-  metricName: Latency
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Environment
-      value: eks:{{platformInfo}}/{{appNamespace}}
-    -
-      name: RemoteEnvironment
-      value: eks:{{platformInfo}}/{{appNamespace}}
-    -
-      name: Operation
-      value: GET /remote-service
-    -
-      name: RemoteOperation
-      value: GET /healthcheck
-    -
-      name: RemoteService
-      value: {{remoteServiceDeploymentName}}
-    -
-      name: Service
-      value: {{serviceName}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Operation
-      value: GET /remote-service
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: Environment
-      value: eks:{{platformInfo}}/{{appNamespace}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Operation
-      value: GET /remote-service
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: Environment
-      value: eks:{{platformInfo}}/{{appNamespace}}
-    -
-      name: RemoteOperation
-      value: GET /healthcheck
-    -
-      name: RemoteService
-      value: {{remoteServiceDeploymentName}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Environment
-      value: eks:{{platformInfo}}/{{appNamespace}}
-    -
-      name: Operation
-      value: GET /healthcheck
-    -
-      name: Service
-      value: {{remoteServiceDeploymentName}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: Environment
-      value: eks:{{platformInfo}}/{{appNamespace}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Service
-      value: {{remoteServiceDeploymentName}}
-    -
-      name: Environment
-      value: eks:{{platformInfo}}/{{appNamespace}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: Environment
-      value: eks:{{platformInfo}}/{{appNamespace}}
-    -
-      name: RemoteService
-      value: {{remoteServiceDeploymentName}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: Environment
-      value: eks:{{platformInfo}}/{{appNamespace}}
-    -
-      name: RemoteOperation
-      value: GET /healthcheck
-    -
-      name: RemoteService
-      value: {{remoteServiceDeploymentName}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: RemoteService
-      value: {{remoteServiceDeploymentName}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Environment
-      value: eks:{{platformInfo}}/{{appNamespace}}
-    -
-      name: RemoteEnvironment
-      value: eks:{{platformInfo}}/{{appNamespace}}
-    -
-      name: RemoteService
-      value: {{remoteServiceDeploymentName}}
-    -
-      name: Service
-      value: {{serviceName}}
-
--
-  metricName: Error
   namespace: {{metricNamespace}}
   dimensions:
     -
@@ -314,6 +145,175 @@
       value: {{serviceName}}
 
 -
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteEnvironment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: Operation
+      value: GET remote-service
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+    -
+      name: Service
+      value: {{serviceName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: Operation
+      value: GET /healthcheck
+    -
+      name: Service
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{remoteServiceDeploymentName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteEnvironment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+    -
+      name: Service
+      value: {{serviceName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Environment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteEnvironment
+      value: eks:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+    -
+      name: Service
+      value: {{serviceName}}
+
+-
   metricName: Error
   namespace: {{metricNamespace}}
   dimensions:
@@ -325,7 +325,7 @@
       value: eks:{{platformInfo}}/{{appNamespace}}
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: RemoteOperation
       value: GET /healthcheck
@@ -342,7 +342,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -356,7 +356,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -494,7 +494,7 @@
       value: eks:{{platformInfo}}/{{appNamespace}}
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: RemoteOperation
       value: GET /healthcheck

--- a/validator/src/main/resources/expected-data-template/dotnet/eks/linux/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/eks/linux/remote-service-trace.mustache
@@ -11,7 +11,7 @@
   },
   "annotations": {
     "aws.local.service": "^{{serviceName}}$",
-    "aws.local.operation": "^GET /remote-service$",
+    "aws.local.operation": "^GET remote-service$",
     "aws.local.environment": "^eks:{{platformInfo}}/{{appNamespace}}$"
   },
   "metadata": {
@@ -38,7 +38,7 @@
       },
       "annotations": {
         "aws.local.service": "^{{serviceName}}$",
-        "aws.local.operation": "^GET /remote-service$",
+        "aws.local.operation": "^GET remote-service$",
         "aws.remote.service": "^{{remoteServiceDeploymentName}}$",
         "aws.remote.operation": "^GET /healthcheck$",
         "aws.local.environment": "^eks:{{platformInfo}}/{{appNamespace}}$",

--- a/validator/src/main/resources/expected-data-template/dotnet/k8s/aws-sdk-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/k8s/aws-sdk-call-log.mustache
@@ -7,7 +7,7 @@
   "K8s.Workload": "^dotnet-sample-app-deployment-{{testingId}}$",
   "PlatformType": "^K8s$",
   "Service": "^{{serviceName}}$",
-  "Operation": "GET /aws-sdk-call",
+  "Operation": "GET aws-sdk-call",
   "Version": "^1$",
   "Telemetry.Source": "^LocalRootSpan$",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"
@@ -21,7 +21,7 @@
   "K8s.Workload": "^dotnet-sample-app-deployment-{{testingId}}$",
   "PlatformType": "^K8s$",
   "Service": "^{{serviceName}}$",
-  "Operation": "GET /aws-sdk-call",
+  "Operation": "GET aws-sdk-call",
   "Version": "^1$",
   "RemoteService": "AWS::S3",
   "RemoteOperation": "GetBucketLocation",

--- a/validator/src/main/resources/expected-data-template/dotnet/k8s/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/k8s/aws-sdk-call-metric.mustache
@@ -4,7 +4,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -80,7 +80,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -129,7 +129,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -143,7 +143,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -205,7 +205,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -255,7 +255,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -269,7 +269,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -331,7 +331,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/dotnet/k8s/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/k8s/aws-sdk-call-trace.mustache
@@ -11,7 +11,7 @@
   },
   "annotations": {
     "aws.local.service": "^{{serviceName}}$",
-    "aws.local.operation": "^GET /aws-sdk-call$",
+    "aws.local.operation": "^GET aws-sdk-call$",
     "aws.local.environment": "^k8s:{{platformInfo}}/{{appNamespace}}$"
   },
   "metadata": {
@@ -34,7 +34,7 @@
       },
       "annotations": {
         "aws.local.service": "^{{serviceName}}$",
-        "aws.local.operation": "^GET /aws-sdk-call$",
+        "aws.local.operation": "^GET aws-sdk-call$",
         "aws.remote.service": "^AWS::S3$",
         "aws.remote.operation": "^GetBucketLocation$",
         "aws.local.environment": "^k8s:{{platformInfo}}/{{appNamespace}}$",

--- a/validator/src/main/resources/expected-data-template/dotnet/k8s/outgoing-http-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/k8s/outgoing-http-call-log.mustache
@@ -7,7 +7,7 @@
   "K8s.Workload": "^dotnet-sample-app-deployment-{{testingId}}$",
   "PlatformType": "^K8s$",
   "Service": "^{{serviceName}}$",
-  "Operation": "GET /outgoing-http-call",
+  "Operation": "GET outgoing-http-call",
   "Version": "^1$",
   "Telemetry.Source": "^LocalRootSpan$",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"
@@ -21,7 +21,7 @@
   "K8s.Workload": "^dotnet-sample-app-deployment-{{testingId}}$",
   "PlatformType": "^K8s$",
   "Service": "^{{serviceName}}$",
-  "Operation": "GET /outgoing-http-call",
+  "Operation": "GET outgoing-http-call",
   "Version": "^1$",
   "RemoteService": "aws.amazon.com:443",
   "RemoteOperation": "GET /",

--- a/validator/src/main/resources/expected-data-template/dotnet/k8s/outgoing-http-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/k8s/outgoing-http-call-metric.mustache
@@ -4,7 +4,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -80,7 +80,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -94,7 +94,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -156,7 +156,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -170,7 +170,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/dotnet/k8s/outgoing-http-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/k8s/outgoing-http-call-trace.mustache
@@ -11,7 +11,7 @@
   },
   "annotations": {
     "aws.local.service": "^{{serviceName}}$",
-    "aws.local.operation": "^GET /outgoing-http-call$",
+    "aws.local.operation": "^GET outgoing-http-call$",
     "aws.local.environment": "^k8s:{{platformInfo}}/{{appNamespace}}$"
   },
   "metadata": {
@@ -36,7 +36,7 @@
       },
       "annotations": {
         "aws.local.service": "^{{serviceName}}$",
-        "aws.local.operation": "^GET /outgoing-http-call$",
+        "aws.local.operation": "^GET outgoing-http-call$",
         "aws.remote.service": "^aws.amazon.com:443$",
         "aws.remote.operation": "^GET /$",
         "aws.local.environment": "^k8s:{{platformInfo}}/{{appNamespace}}$"

--- a/validator/src/main/resources/expected-data-template/dotnet/k8s/remote-service-log.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/k8s/remote-service-log.mustache
@@ -7,7 +7,7 @@
   "K8s.Workload": "^dotnet-sample-app-deployment-{{testingId}}$",
   "PlatformType": "^K8s$",
   "Service": "^{{serviceName}}$",
-  "Operation": "GET /remote-service",
+  "Operation": "GET remote-service",
   "Version": "^1$",
   "Telemetry.Source": "^LocalRootSpan$",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"
@@ -22,7 +22,7 @@
   "K8s.Workload": "^dotnet-sample-app-deployment-{{testingId}}$",
   "PlatformType": "^K8s$",
   "Service": "^{{serviceName}}$",
-  "Operation": "GET /remote-service",
+  "Operation": "GET remote-service",
   "Version": "^1$",
   "RemoteService": "{{remoteServiceDeploymentName}}",
   "RemoteOperation": "GET /healthcheck",

--- a/validator/src/main/resources/expected-data-template/dotnet/k8s/remote-service-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/k8s/remote-service-metric.mustache
@@ -4,7 +4,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -126,175 +126,6 @@
 
 -
   metricName: Latency
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Environment
-      value: k8s:{{platformInfo}}/{{appNamespace}}
-    -
-      name: RemoteEnvironment
-      value: k8s:{{platformInfo}}/{{appNamespace}}
-    -
-      name: RemoteOperation
-      value: GET /healthcheck
-    -
-      name: RemoteService
-      value: {{remoteServiceDeploymentName}}
-    -
-      name: Service
-      value: {{serviceName}}
-
--
-  metricName: Latency
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Environment
-      value: k8s:{{platformInfo}}/{{appNamespace}}
-    -
-      name: RemoteEnvironment
-      value: k8s:{{platformInfo}}/{{appNamespace}}
-    -
-      name: Operation
-      value: GET /remote-service
-    -
-      name: RemoteOperation
-      value: GET /healthcheck
-    -
-      name: RemoteService
-      value: {{remoteServiceDeploymentName}}
-    -
-      name: Service
-      value: {{serviceName}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Operation
-      value: GET /remote-service
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: Environment
-      value: k8s:{{platformInfo}}/{{appNamespace}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Operation
-      value: GET /remote-service
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: Environment
-      value: k8s:{{platformInfo}}/{{appNamespace}}
-    -
-      name: RemoteOperation
-      value: GET /healthcheck
-    -
-      name: RemoteService
-      value: {{remoteServiceDeploymentName}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Environment
-      value: k8s:{{platformInfo}}/{{appNamespace}}
-    -
-      name: Operation
-      value: GET /healthcheck
-    -
-      name: Service
-      value: {{remoteServiceDeploymentName}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: Environment
-      value: k8s:{{platformInfo}}/{{appNamespace}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Service
-      value: {{remoteServiceDeploymentName}}
-    -
-      name: Environment
-      value: k8s:{{platformInfo}}/{{appNamespace}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: Environment
-      value: k8s:{{platformInfo}}/{{appNamespace}}
-    -
-      name: RemoteService
-      value: {{remoteServiceDeploymentName}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: Environment
-      value: k8s:{{platformInfo}}/{{appNamespace}}
-    -
-      name: RemoteOperation
-      value: GET /healthcheck
-    -
-      name: RemoteService
-      value: {{remoteServiceDeploymentName}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: RemoteService
-      value: {{remoteServiceDeploymentName}}
-
--
-  metricName: Error
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Environment
-      value: k8s:{{platformInfo}}/{{appNamespace}}
-    -
-      name: RemoteEnvironment
-      value: k8s:{{platformInfo}}/{{appNamespace}}
-    -
-      name: RemoteService
-      value: {{remoteServiceDeploymentName}}
-    -
-      name: Service
-      value: {{serviceName}}
-
--
-  metricName: Error
   namespace: {{metricNamespace}}
   dimensions:
     -
@@ -314,6 +145,175 @@
       value: {{serviceName}}
 
 -
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Environment
+      value: k8s:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteEnvironment
+      value: k8s:{{platformInfo}}/{{appNamespace}}
+    -
+      name: Operation
+      value: GET remote-service
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+    -
+      name: Service
+      value: {{serviceName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: k8s:{{platformInfo}}/{{appNamespace}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: k8s:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Environment
+      value: k8s:{{platformInfo}}/{{appNamespace}}
+    -
+      name: Operation
+      value: GET /healthcheck
+    -
+      name: Service
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: k8s:{{platformInfo}}/{{appNamespace}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{remoteServiceDeploymentName}}
+    -
+      name: Environment
+      value: k8s:{{platformInfo}}/{{appNamespace}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: k8s:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: k8s:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Environment
+      value: k8s:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteEnvironment
+      value: k8s:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+    -
+      name: Service
+      value: {{serviceName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Environment
+      value: k8s:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteEnvironment
+      value: k8s:{{platformInfo}}/{{appNamespace}}
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+    -
+      name: Service
+      value: {{serviceName}}
+
+-
   metricName: Error
   namespace: {{metricNamespace}}
   dimensions:
@@ -325,7 +325,7 @@
       value: k8s:{{platformInfo}}/{{appNamespace}}
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: RemoteOperation
       value: GET /healthcheck
@@ -342,7 +342,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -356,7 +356,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -494,7 +494,7 @@
       value: k8s:{{platformInfo}}/{{appNamespace}}
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: RemoteOperation
       value: GET /healthcheck

--- a/validator/src/main/resources/expected-data-template/dotnet/k8s/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/k8s/remote-service-trace.mustache
@@ -11,7 +11,7 @@
   },
   "annotations": {
     "aws.local.service": "^{{serviceName}}$",
-    "aws.local.operation": "^GET /remote-service$",
+    "aws.local.operation": "^GET remote-service$",
     "aws.local.environment": "^k8s:{{platformInfo}}/{{appNamespace}}$"
   },
   "metadata": {
@@ -36,7 +36,7 @@
       },
       "annotations": {
         "aws.local.service": "^{{serviceName}}$",
-        "aws.local.operation": "^GET /remote-service$",
+        "aws.local.operation": "^GET remote-service$",
         "aws.remote.service": "^{{remoteServiceDeploymentName}}$",
         "aws.remote.operation": "^GET /healthcheck$",
         "aws.local.environment": "^k8s:{{platformInfo}}/{{appNamespace}}$",


### PR DESCRIPTION
*Issue description:*

*Description of changes:*

*Rollback procedure:*

<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
