### PR TITLE
Set dotnet E2E test target for dotnet sdk v1.3.2 and cloudwatch helm charts v2.2.0

### DIFF
--- a/.github/workflows/dotnet-ec2-default-test.yml
+++ b/.github/workflows/dotnet-ec2-default-test.yml
@@ -94,7 +94,7 @@ jobs:
             echo GET_ADOT_DISTRO_COMMAND="aws s3 cp s3://adot-autoinstrumentation-dotnet-staging/${{ env.ADOT_DISTRO_NAME }} ./${{ env.ADOT_DISTRO_NAME }} && unzip -d dotnet-distro ${{ env.ADOT_DISTRO_NAME }}" >> $GITHUB_ENV
           else
             # After Release will switch to latest tag instead of hard code version for canary purpose
-            echo GET_ADOT_DISTRO_COMMAND="wget -O aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/latest/download/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip && unzip -d dotnet-distro aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip" >> $GITHUB_ENV
+            echo GET_ADOT_DISTRO_COMMAND="wget -O aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/download/v1.3.2/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip && unzip -d dotnet-distro aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip" >> $GITHUB_ENV
           fi
 
       - name: Set Get CW Agent command environment variable

--- a/terraform/dotnet/k8s/deploy/main.tf
+++ b/terraform/dotnet/k8s/deploy/main.tf
@@ -37,7 +37,7 @@ resource "null_resource" "deploy" {
       [ ! -e dotnet-remote-service-depl.yaml ] || rm dotnet-remote-service-depl.yaml
 
       echo "LOG: Getting latest helm chart release URL"
-      latest_version_url=$(curl -s https://api.github.com/repos/aws-observability/helm-charts/releases/latest | grep "tarball_url" | cut -d '"' -f 4)
+      latest_version_url=$(curl -s https://api.github.com/repos/aws-observability/helm-charts/releases/182005608 | grep "tarball_url" | cut -d '"' -f 4)
       echo "LOG: The latest helm chart version url is $latest_version_url"
       echo "LOG: Downloading and unpacking the helm chart repo"
       curl -L $latest_version_url -o aws-observability-helm-charts-latest.tar.gz


### PR DESCRIPTION
*Description of changes:*
Set current .NET SDK release for .NET E2E tests instead of the latest version because the new ADOT .NET SDK release will introduce breaking changes. It will prevent E2E test failures during release process.
- EC2 test target : [ADOT .NET SDK v1.3.2](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/releases/tag/v1.3.2)
- K8s test target: [Amazon CloudWatch Observability Helm Chart v2.2.0](https://github.com/aws-observability/helm-charts/releases/tag/amazon-cloudwatch-observability-2.2.0)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
