### PR TITLE
Set dotnet E2E nuget test target for dotnet sdk v1.3.2

### DIFF
--- a/terraform/dotnet/ec2/nuget/main.tf
+++ b/terraform/dotnet/ec2/nuget/main.tf
@@ -137,7 +137,7 @@ resource "null_resource" "main_service_setup" {
       export OTEL_RESOURCE_ATTRIBUTES=service.name=dotnet-sample-application-${var.test_id}
 
       cd ./asp_frontend_service
-      dotnet add package AWS.Distro.OpenTelemetry.AutoInstrumentation --prerelease
+      dotnet add package AWS.Distro.OpenTelemetry.AutoInstrumentation --version 1.3.2
       dotnet build --runtime linux-x64
       dos2unix bin/Debug/netcoreapp8.0/linux-x64/adot-launch.sh
       nohup sh bin/Debug/netcoreapp8.0/linux-x64/adot-launch.sh dotnet bin/Debug/netcoreapp8.0/linux-x64/asp_frontend_service.dll &
@@ -226,7 +226,7 @@ resource "null_resource" "remote_service_setup" {
       export OTEL_RESOURCE_ATTRIBUTES=service.name=dotnet-sample-remote-application-${var.test_id}
       export ASPNETCORE_URLS=http://0.0.0.0:8081
 
-      dotnet add package AWS.Distro.OpenTelemetry.AutoInstrumentation --prerelease
+      dotnet add package AWS.Distro.OpenTelemetry.AutoInstrumentation --version 1.3.2
       dotnet build --runtime linux-x64
       dos2unix bin/Debug/netcoreapp8.0/linux-x64/adot-launch.sh
       nohup sh bin/Debug/netcoreapp8.0/linux-x64/adot-launch.sh dotnet bin/Debug/netcoreapp8.0/linux-x64/asp_remote_service.dll &


### PR DESCRIPTION
*Description of changes:*
Set current .NET SDK release for .NET E2E Nuget instead of the latest version because the new ADOT .NET SDK release will introduce breaking changes. This will fix the current Nuget E2E failure. 