### PR TITLE
Set EKS addon to v2.2.1-eksbuild.1 for dotnet E2E test

### DIFF
--- a/.github/workflows/dotnet-eks-test.yml
+++ b/.github/workflows/dotnet-eks-test.yml
@@ -76,7 +76,7 @@ jobs:
         uses: ./.github/workflows/actions/execute_and_retry
         with:
           pre-command: "mkdir enablement-script && cd enablement-script"
-          command: "wget https://raw.githubusercontent.com/aws-observability/application-signals-demo/main/scripts/eks/appsignals/enable-app-signals.sh 
+          command: "wget https://raw.githubusercontent.com/aws-observability/application-signals-demo/dotnet-sdk-1_3_2/scripts/eks/appsignals/enable-app-signals.sh
           && wget https://raw.githubusercontent.com/aws-observability/application-signals-demo/main/scripts/eks/appsignals/clean-app-signals.sh"
           cleanup: "rm -f enable-app-signals.sh && rm -f clean-app-signals.sh"
           post-command: "chmod +x enable-app-signals.sh && chmod +x clean-app-signals.sh"


### PR DESCRIPTION
*Description of changes:*
Set current .NET SDK release for .NET E2E tests instead of the latest version because the new ADOT .NET SDK release will introduce breaking changes. It will prevent E2E EKS test failures when new EKS addon (which will use the new ADOT .NET SDK) is released. It is related to https://github.com/aws-observability/aws-application-signals-test-framework/pull/310 and https://github.com/aws-observability/aws-application-signals-test-framework/pull/309.

The EKS addon installation script is updated in `dotnet-sdk-1_3_2` branch as https://github.com/aws-observability/application-signals-demo/compare/main...dotnet-sdk-1_3_2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
