### PR TITLE
Fix Python Canary workflow wrong outputs

### DIFF
--- a/.github/workflows/python-lambda-test.yml
+++ b/.github/workflows/python-lambda-test.yml
@@ -34,9 +34,9 @@ on:
         default: 'github'
     outputs:
       job-started:
-        value: ${{ jobs.python-ec2-default.outputs.job-started }}
+        value: ${{ jobs.python-lambda-default.outputs.job-started }}
       validation-result:
-        value: ${{ jobs.python-ec2-default.outputs.validation-result }}
+        value: ${{ jobs.python-lambda-default.outputs.validation-result }}
 
 permissions:
   id-token: write


### PR DESCRIPTION
*Description of changes:*
Correct Python Lambda Canary workflow typos on Outputs. So it will not run twice and also publish the correct test results.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
