### PR TITLE
Increase EC2 volume

### DIFF
--- a/terraform/dotnet/ec2/asg/main.tf
+++ b/terraform/dotnet/ec2/asg/main.tf
@@ -91,6 +91,10 @@ resource "aws_launch_configuration" "launch_configuration" {
   associate_public_ip_address = true
   iam_instance_profile        = "APP_SIGNALS_EC2_TEST_ROLE"
   security_groups             = [aws_default_vpc.default.default_security_group_id]
+  
+  root_block_device {
+    volume_size = 5
+  }
 
   user_data = <<-EOF
     #!/bin/bash
@@ -185,8 +189,13 @@ resource "aws_instance" "remote_service_instance" {
   vpc_security_group_ids               = [aws_default_vpc.default.default_security_group_id]
   associate_public_ip_address          = true
   instance_initiated_shutdown_behavior = "terminate"
+
   metadata_options {
     http_tokens = "required"
+  }
+
+  root_block_device {
+    volume_size = 5
   }
 
   tags = {

--- a/terraform/dotnet/ec2/default/main.tf
+++ b/terraform/dotnet/ec2/default/main.tf
@@ -85,8 +85,13 @@ resource "aws_instance" "main_service_instance" {
   vpc_security_group_ids               = [aws_default_vpc.default.default_security_group_id]
   associate_public_ip_address          = true
   instance_initiated_shutdown_behavior = "terminate"
+
   metadata_options {
     http_tokens = "required"
+  }
+
+  root_block_device {
+    volume_size = 5
   }
 
   tags = {
@@ -188,8 +193,13 @@ resource "aws_instance" "remote_service_instance" {
   vpc_security_group_ids               = [aws_default_vpc.default.default_security_group_id]
   associate_public_ip_address          = true
   instance_initiated_shutdown_behavior = "terminate"
+
   metadata_options {
     http_tokens = "required"
+  }
+
+  root_block_device {
+    volume_size = 5
   }
 
   tags = {

--- a/terraform/dotnet/ec2/nuget/main.tf
+++ b/terraform/dotnet/ec2/nuget/main.tf
@@ -85,8 +85,13 @@ resource "aws_instance" "main_service_instance" {
   vpc_security_group_ids               = [aws_default_vpc.default.default_security_group_id]
   associate_public_ip_address          = true
   instance_initiated_shutdown_behavior = "terminate"
+
   metadata_options {
     http_tokens = "required"
+  }
+
+  root_block_device {
+    volume_size = 5
   }
 
   tags = {
@@ -174,8 +179,13 @@ resource "aws_instance" "remote_service_instance" {
   vpc_security_group_ids               = [aws_default_vpc.default.default_security_group_id]
   associate_public_ip_address          = true
   instance_initiated_shutdown_behavior = "terminate"
+
   metadata_options {
     http_tokens = "required"
+  }
+
+  root_block_device {
+    volume_size = 5
   }
 
   tags = {

--- a/terraform/dotnet/ec2/windows/main.tf
+++ b/terraform/dotnet/ec2/windows/main.tf
@@ -69,10 +69,15 @@ resource "aws_instance" "main_service_instance" {
   vpc_security_group_ids               = [aws_default_vpc.default.default_security_group_id]
   associate_public_ip_address          = true
   instance_initiated_shutdown_behavior = "terminate"
+  
   metadata_options {
     http_tokens = "required"
   }
   get_password_data = true
+
+  root_block_device {
+    volume_size = 5
+  }
 
   tags = {
     Name = "main-service-${var.test_id}"
@@ -111,10 +116,15 @@ resource "aws_instance" "remote_service_instance" {
   vpc_security_group_ids               = [aws_default_vpc.default.default_security_group_id]
   associate_public_ip_address          = true
   instance_initiated_shutdown_behavior = "terminate"
+
   metadata_options {
     http_tokens = "required"
   }
   get_password_data = true
+
+  root_block_device {
+    volume_size = 5
+  }
 
   tags = {
     Name = "remote-service-${var.test_id}"

--- a/terraform/java/ec2/asg/main.tf
+++ b/terraform/java/ec2/asg/main.tf
@@ -92,6 +92,10 @@ resource "aws_launch_configuration" "launch_configuration" {
   iam_instance_profile = "APP_SIGNALS_EC2_TEST_ROLE"
   security_groups = [aws_default_vpc.default.default_security_group_id]
 
+  root_block_device {
+    volume_size = 5
+  }
+
   user_data = <<-EOF
     #!/bin/bash
     # Make the Terraform fail if any step throws an error
@@ -171,8 +175,13 @@ resource "aws_instance" "remote_service_instance" {
   vpc_security_group_ids                = [aws_default_vpc.default.default_security_group_id]
   associate_public_ip_address           = true
   instance_initiated_shutdown_behavior  = "terminate"
+
   metadata_options {
     http_tokens = "required"
+  }
+
+  root_block_device {
+    volume_size = 5
   }
 
   tags = {

--- a/terraform/java/ec2/default/main.tf
+++ b/terraform/java/ec2/default/main.tf
@@ -85,8 +85,13 @@ resource "aws_instance" "main_service_instance" {
   vpc_security_group_ids                = [aws_default_vpc.default.default_security_group_id]
   associate_public_ip_address           = true
   instance_initiated_shutdown_behavior  = "terminate"
+
   metadata_options {
     http_tokens = "required"
+  }
+
+  root_block_device {
+    volume_size = 5
   }
 
   tags = {
@@ -176,8 +181,13 @@ resource "aws_instance" "remote_service_instance" {
   vpc_security_group_ids                = [aws_default_vpc.default.default_security_group_id]
   associate_public_ip_address           = true
   instance_initiated_shutdown_behavior  = "terminate"
+
   metadata_options {
     http_tokens = "required"
+  }
+
+  root_block_device {
+    volume_size = 5
   }
 
   tags = {

--- a/terraform/node/ec2/asg/main.tf
+++ b/terraform/node/ec2/asg/main.tf
@@ -92,6 +92,10 @@ resource "aws_launch_configuration" "launch_configuration" {
   iam_instance_profile = "APP_SIGNALS_EC2_TEST_ROLE"
   security_groups = [aws_default_vpc.default.default_security_group_id]
 
+  root_block_device {
+    volume_size = 5
+  }
+
   user_data = <<-EOF
     #!/bin/bash
 
@@ -193,8 +197,13 @@ resource "aws_instance" "remote_service_instance" {
   vpc_security_group_ids                = [aws_default_vpc.default.default_security_group_id]
   associate_public_ip_address           = true
   instance_initiated_shutdown_behavior  = "terminate"
+
   metadata_options {
     http_tokens = "required"
+  }
+
+  root_block_device {
+    volume_size = 5
   }
 
   tags = {

--- a/terraform/node/ec2/default/main.tf
+++ b/terraform/node/ec2/default/main.tf
@@ -85,8 +85,13 @@ resource "aws_instance" "main_service_instance" {
   vpc_security_group_ids                = [aws_default_vpc.default.default_security_group_id]
   associate_public_ip_address           = true
   instance_initiated_shutdown_behavior  = "terminate"
+
   metadata_options {
     http_tokens = "required"
+  }
+
+  root_block_device {
+    volume_size = 5
   }
 
   tags = {
@@ -197,8 +202,13 @@ resource "aws_instance" "remote_service_instance" {
   vpc_security_group_ids                = [aws_default_vpc.default.default_security_group_id]
   associate_public_ip_address           = true
   instance_initiated_shutdown_behavior  = "terminate"
+
   metadata_options {
     http_tokens = "required"
+  }
+
+  root_block_device {
+    volume_size = 5
   }
 
   tags = {

--- a/terraform/python/ec2/asg/main.tf
+++ b/terraform/python/ec2/asg/main.tf
@@ -92,6 +92,10 @@ resource "aws_launch_configuration" "launch_configuration" {
   iam_instance_profile = "APP_SIGNALS_EC2_TEST_ROLE"
   security_groups = [aws_default_vpc.default.default_security_group_id]
 
+  root_block_device {
+    volume_size = 5
+  }
+
   user_data = <<-EOF
     #!/bin/bash
 
@@ -206,8 +210,13 @@ resource "aws_instance" "remote_service_instance" {
   vpc_security_group_ids                = [aws_default_vpc.default.default_security_group_id]
   associate_public_ip_address           = true
   instance_initiated_shutdown_behavior  = "terminate"
+
   metadata_options {
     http_tokens = "required"
+  }
+
+  root_block_device {
+    volume_size = 5
   }
 
   tags = {

--- a/terraform/python/ec2/default/main.tf
+++ b/terraform/python/ec2/default/main.tf
@@ -85,8 +85,13 @@ resource "aws_instance" "main_service_instance" {
   vpc_security_group_ids                = [aws_default_vpc.default.default_security_group_id]
   associate_public_ip_address           = true
   instance_initiated_shutdown_behavior  = "terminate"
+
   metadata_options {
     http_tokens = "required"
+  }
+
+  root_block_device {
+    volume_size = 5
   }
 
   tags = {
@@ -208,8 +213,13 @@ resource "aws_instance" "remote_service_instance" {
   vpc_security_group_ids                = [aws_default_vpc.default.default_security_group_id]
   associate_public_ip_address           = true
   instance_initiated_shutdown_behavior  = "terminate"
+
   metadata_options {
     http_tokens = "required"
+  }
+
+  root_block_device {
+    volume_size = 5
   }
 
   tags = {


### PR DESCRIPTION
*Issue description:*
Fix disk shortage in EC2 canaries.

*Description of changes:*

*Rollback procedure:*

<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
