### PR TITLE
Enable runtime metrics in canaries

### DIFF
--- a/.github/workflows/java-ec2-default-test.yml
+++ b/.github/workflows/java-ec2-default-test.yml
@@ -112,8 +112,8 @@ jobs:
             # Reusing the adot-main-build-staging-jar bucket to store the python wheel file
             echo GET_ADOT_JAR_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/aws-opentelemetry-agent.jar ./adot.jar" >> $GITHUB_ENV
           elif [ "${{ env.OTEL_SOURCE }}" == "maven" ]; then
-            echo "Latest version for Maven is: 1.32.4"
-            echo GET_ADOT_JAR_COMMAND="wget -O adot.jar https://repo1.maven.org/maven2/software/amazon/opentelemetry/aws-opentelemetry-agent/1.32.4/aws-opentelemetry-agent-1.32.4.jar" >> $GITHUB_ENV
+            echo "Latest version for Maven is: 1.32.5"
+            echo GET_ADOT_JAR_COMMAND="wget -O adot.jar https://repo1.maven.org/maven2/software/amazon/opentelemetry/aws-opentelemetry-agent/1.32.5/aws-opentelemetry-agent-1.32.5.jar" >> $GITHUB_ENV
           else
             echo GET_ADOT_JAR_COMMAND="wget -O adot.jar https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar" >> $GITHUB_ENV
           fi

--- a/sample-apps/java/springboot-main-service/build.gradle.kts
+++ b/sample-apps/java/springboot-main-service/build.gradle.kts
@@ -61,6 +61,7 @@ jib {
   }
   container {
     mainClass = "com.amazon.sampleapp.FrontendService"
+    jvmFlags = listOf("-XX:+UseG1GC")
     ports = listOf("8080")
   }
 }

--- a/sample-apps/java/springboot-remote-service/build.gradle.kts
+++ b/sample-apps/java/springboot-remote-service/build.gradle.kts
@@ -56,6 +56,7 @@ jib {
   }
   container {
     mainClass = "com.amazon.sampleapp.RemoteService"
+    jvmFlags = listOf("-XX:+UseG1GC")
     ports = listOf("8080")
   }
 }

--- a/terraform/java/ec2/default/main.tf
+++ b/terraform/java/ec2/default/main.tf
@@ -141,12 +141,11 @@ resource "null_resource" "main_service_setup" {
       OTEL_METRICS_EXPORTER=none \
       OTEL_LOGS_EXPORT=none \
       OTEL_AWS_APPLICATION_SIGNALS_ENABLED=true \
-      OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED=false \
       OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics \
       OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
       OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4316/v1/traces \
       OTEL_RESOURCE_ATTRIBUTES=service.name=sample-application-${var.test_id} \
-      nohup java -jar main-service.jar &> nohup.out &
+      nohup java -XX:+UseG1GC -jar main-service.jar &> nohup.out &
 
       # The application needs time to come up and reach a steady state, this should not take longer than 30 seconds
       sleep 30
@@ -217,6 +216,9 @@ resource "null_resource" "remote_service_setup" {
         sudo yum install java-${var.language_version}-amazon-corretto -y
       fi
 
+      # enable ec2 instance connect for debug
+      sudo yum install ec2-instance-connect -y
+
       # Copy in CW Agent configuration
       agent_config='${replace(replace(file("./amazon-cloudwatch-agent.json"), "/\\s+/", ""), "$REGION", var.aws_region)}'
       echo $agent_config > amazon-cloudwatch-agent.json
@@ -236,12 +238,11 @@ resource "null_resource" "remote_service_setup" {
       OTEL_METRICS_EXPORTER=none \
       OTEL_LOGS_EXPORT=none \
       OTEL_AWS_APPLICATION_SIGNALS_ENABLED=true \
-      OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED=false \
       OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics \
       OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
       OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4316/v1/traces \
       OTEL_RESOURCE_ATTRIBUTES=service.name=sample-remote-application-${var.test_id} \
-      nohup java -jar remote-service.jar &> nohup.out &
+      nohup java -XX:+UseG1GC -jar remote-service.jar &> nohup.out &
 
       # The application needs time to come up and reach a steady state, this should not take longer than 30 seconds
       sleep 30

--- a/terraform/java/ecs/resources/main-service.json.tpl
+++ b/terraform/java/ecs/resources/main-service.json.tpl
@@ -23,10 +23,6 @@
         "value": "true"
       },
       {
-        "name": "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED",
-        "value": "false"
-      },
-      {
         "name": "OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT",
         "value": "http://localhost:4316/v1/metrics"
       },

--- a/terraform/java/eks/main.tf
+++ b/terraform/java/eks/main.tf
@@ -123,10 +123,6 @@ resource "kubernetes_deployment" "sample_app_deployment" {
             name = "RDS_MYSQL_CLUSTER_PASSWORD"
             value = var.rds_mysql_cluster_password
           }
-          env {
-            name = "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED"
-            value = "false"
-          }
           port {
             container_port = 8080
           }
@@ -194,10 +190,6 @@ resource "kubernetes_deployment" "sample_remote_app_deployment" {
           image_pull_policy = "Always"
           port {
             container_port = 8080
-          }
-          env {
-            name = "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED"
-            value = "false"
           }
         }
       }

--- a/terraform/java/k8s/deploy/resources/frontend-service-depl.yaml
+++ b/terraform/java/k8s/deploy/resources/frontend-service-depl.yaml
@@ -19,12 +19,11 @@ spec:
       containers:
         - name: frontend
           image: ${IMAGE}
+          imagePullPolicy: Always
           ports:
             - containerPort: 8080
           env:
             - name: "OTEL_SERVICE_NAME"
               value: "sample-application-${TESTING_ID}"
-            - name: "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED"
-              value: "false"
       imagePullSecrets:
         - name: ecr-secret

--- a/terraform/java/k8s/deploy/resources/remote-service-depl.yaml
+++ b/terraform/java/k8s/deploy/resources/remote-service-depl.yaml
@@ -19,10 +19,8 @@ spec:
       containers:
         - name: remote
           image: ${IMAGE}
+          imagePullPolicy: Always
           ports:
             - containerPort: 8081
-          env:
-            - name: OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED
-              value: "false"
       imagePullSecrets:
         - name: ecr-secret

--- a/terraform/python/ec2/asg/main.tf
+++ b/terraform/python/ec2/asg/main.tf
@@ -160,7 +160,6 @@ resource "aws_launch_configuration" "launch_configuration" {
     export OTEL_METRICS_EXPORTER=none
     export OTEL_TRACES_EXPORTER=otlp
     export OTEL_AWS_APPLICATION_SIGNALS_ENABLED=true
-    export OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED=false
     export OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT=http://localhost:4315
     export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4315
     export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc
@@ -295,7 +294,6 @@ resource "null_resource" "remote_service_setup" {
       export OTEL_METRICS_EXPORTER=none
       export OTEL_TRACES_EXPORTER=otlp
       export OTEL_AWS_APPLICATION_SIGNALS_ENABLED=true
-      export OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED=false
       export OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT=http://localhost:4315
       export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4315
       export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc

--- a/terraform/python/ec2/default/main.tf
+++ b/terraform/python/ec2/default/main.tf
@@ -141,6 +141,9 @@ resource "null_resource" "main_service_setup" {
         sudo dnf install -y python${var.language_version}-pip
       fi
 
+      # enable ec2 instance connect for debug
+      sudo yum install ec2-instance-connect -y
+
       # Copy in CW Agent configuration
       agent_config='${replace(replace(file("./amazon-cloudwatch-agent.json"), "/\\s+/", ""), "$REGION", var.aws_region)}'
       echo $agent_config > amazon-cloudwatch-agent.json
@@ -170,7 +173,6 @@ resource "null_resource" "main_service_setup" {
       export OTEL_METRICS_EXPORTER=none
       export OTEL_TRACES_EXPORTER=otlp
       export OTEL_AWS_APPLICATION_SIGNALS_ENABLED=true
-      export OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED=false
       export OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT=http://localhost:4315
       export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4315
       export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc
@@ -269,6 +271,9 @@ resource "null_resource" "remote_service_setup" {
         sudo dnf install -y python${var.language_version}-pip
       fi
 
+      # enable ec2 instance connect for debug
+      sudo yum install ec2-instance-connect -y
+
       # Copy in CW Agent configuration
       agent_config='${replace(replace(file("./amazon-cloudwatch-agent.json"), "/\\s+/", ""), "$REGION", var.aws_region)}'
       echo $agent_config > amazon-cloudwatch-agent.json
@@ -298,7 +303,6 @@ resource "null_resource" "remote_service_setup" {
       export OTEL_METRICS_EXPORTER=none
       export OTEL_TRACES_EXPORTER=otlp
       export OTEL_AWS_APPLICATION_SIGNALS_ENABLED=true
-      export OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED=false
       export OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT=http://localhost:4315
       export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4315
       export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc

--- a/terraform/python/ecs/resources/main-service.json.tpl
+++ b/terraform/python/ecs/resources/main-service.json.tpl
@@ -60,10 +60,6 @@
         "value": "true"
       },
       {
-        "name": "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED",
-        "value": "false"
-      },
-      {
         "name": "OTEL_RESOURCE_ATTRIBUTES",
         "value": "service.name=${app_service_name}"
       },

--- a/terraform/python/eks/main.tf
+++ b/terraform/python/eks/main.tf
@@ -135,10 +135,6 @@ resource "kubernetes_deployment" "python_app_deployment" {
             name = "RDS_MYSQL_CLUSTER_PASSWORD"
             value = var.rds_mysql_cluster_password
           }
-          env {
-            name = "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED"
-            value = "false"
-          }
           port {
             container_port = 8000
           }
@@ -208,10 +204,6 @@ resource "kubernetes_deployment" "python_r_app_deployment" {
           env {
               name = "DJANGO_SETTINGS_MODULE"
               value = "django_remote_service.settings"
-          }
-          env {
-            name = "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED"
-            value = "false"
           }
           port {
             container_port = 8001

--- a/terraform/python/k8s/deploy/resources/python-frontend-service-depl.yaml
+++ b/terraform/python/k8s/deploy/resources/python-frontend-service-depl.yaml
@@ -19,6 +19,7 @@ spec:
       containers:
         - name: python-frontend
           image: ${IMAGE}
+          imagePullPolicy: Always
           args:
             - "sh"
             - "-c"
@@ -32,7 +33,5 @@ spec:
               value: "/django_frontend_app"
             - name: "DJANGO_SETTINGS_MODULE"
               value: "django_frontend_service.settings"
-            - name: "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED"
-              value: "false"
       imagePullSecrets:
         - name: ecr-secret

--- a/terraform/python/k8s/deploy/resources/python-remote-service-depl.yaml
+++ b/terraform/python/k8s/deploy/resources/python-remote-service-depl.yaml
@@ -19,6 +19,7 @@ spec:
       containers:
         - name: python-remote
           image: ${IMAGE}
+          imagePullPolicy: Always
           args:
             - "sh"
             - "-c"
@@ -28,8 +29,6 @@ spec:
               value: "/django_remote_app"
             - name: "DJANGO_SETTINGS_MODULE"
               value: "django_remote_service.settings"
-            - name: "OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED"
-              value: "false"
           ports:
             - containerPort: 8001
       imagePullSecrets:

--- a/validator/src/main/resources/validations/java/ec2/asg/log-validation.yml
+++ b/validator/src/main/resources/validations/java/ec2/asg/log-validation.yml
@@ -22,4 +22,7 @@
   httpMethod: "get"
   callingType: "http"
   expectedLogStructureTemplate: "JAVA_EC2_ASG_CLIENT_CALL_LOG"
-
+-
+  validationType: "cw-log"
+  callingType: "none"
+  expectedLogStructureTemplate: "JAVA_RUNTIME_METRIC_LOG"

--- a/validator/src/main/resources/validations/java/ec2/asg/metric-validation.yml
+++ b/validator/src/main/resources/validations/java/ec2/asg/metric-validation.yml
@@ -22,4 +22,7 @@
   httpMethod: "get"
   callingType: "http"
   expectedMetricTemplate: "JAVA_EC2_ASG_CLIENT_CALL_METRIC"
-
+-
+  validationType: "cw-metric"
+  callingType: "none"
+  expectedMetricTemplate: "JAVA_RUNTIME_METRIC"

--- a/validator/src/main/resources/validations/java/ec2/default/log-validation.yml
+++ b/validator/src/main/resources/validations/java/ec2/default/log-validation.yml
@@ -22,4 +22,7 @@
   httpMethod: "get"
   callingType: "http"
   expectedLogStructureTemplate: "JAVA_EC2_DEFAULT_CLIENT_CALL_LOG"
-
+-
+  validationType: "cw-log"
+  callingType: "none"
+  expectedLogStructureTemplate: "JAVA_RUNTIME_METRIC_LOG"

--- a/validator/src/main/resources/validations/java/ec2/default/metric-validation.yml
+++ b/validator/src/main/resources/validations/java/ec2/default/metric-validation.yml
@@ -22,4 +22,7 @@
   httpMethod: "get"
   callingType: "http"
   expectedMetricTemplate: "JAVA_EC2_DEFAULT_CLIENT_CALL_METRIC"
-
+-
+  validationType: "cw-metric"
+  callingType: "none"
+  expectedMetricTemplate: "JAVA_RUNTIME_METRIC"

--- a/validator/src/main/resources/validations/java/ecs/log-validation.yml
+++ b/validator/src/main/resources/validations/java/ecs/log-validation.yml
@@ -2,3 +2,7 @@
   validationType: "cw-log"
   callingType: "none"
   expectedLogStructureTemplate: "JAVA_ECS_HC_CALL_LOG"
+-
+  validationType: "cw-log"
+  callingType: "none"
+  expectedLogStructureTemplate: "JAVA_RUNTIME_METRIC_LOG"

--- a/validator/src/main/resources/validations/java/ecs/metric-validation.yml
+++ b/validator/src/main/resources/validations/java/ecs/metric-validation.yml
@@ -2,3 +2,7 @@
   validationType: "cw-metric"
   callingType: "none"
   expectedMetricTemplate: "JAVA_ECS_HC_CALL_METRIC"
+-
+  validationType: "cw-metric"
+  callingType: "none"
+  expectedMetricTemplate: "JAVA_RUNTIME_METRIC"

--- a/validator/src/main/resources/validations/java/eks/log-validation.yml
+++ b/validator/src/main/resources/validations/java/eks/log-validation.yml
@@ -28,3 +28,7 @@
   httpMethod: "get"
   callingType: "http"
   expectedLogStructureTemplate: "JAVA_EKS_RDS_MYSQL_LOG"
+-
+  validationType: "cw-log"
+  callingType: "none"
+  expectedLogStructureTemplate: "JAVA_RUNTIME_METRIC_LOG"

--- a/validator/src/main/resources/validations/java/eks/metric-validation.yml
+++ b/validator/src/main/resources/validations/java/eks/metric-validation.yml
@@ -28,3 +28,7 @@
   httpMethod: "get"
   callingType: "http"
   expectedMetricTemplate: "JAVA_EKS_RDS_MYSQL_METRIC"
+-
+  validationType: "cw-metric"
+  callingType: "none"
+  expectedMetricTemplate: "JAVA_RUNTIME_METRIC"

--- a/validator/src/main/resources/validations/java/k8s/log-validation.yml
+++ b/validator/src/main/resources/validations/java/k8s/log-validation.yml
@@ -22,3 +22,7 @@
   httpMethod: "get"
   callingType: "http"
   expectedLogStructureTemplate: "JAVA_K8S_CLIENT_CALL_LOG"
+-
+  validationType: "cw-log"
+  callingType: "none"
+  expectedLogStructureTemplate: "JAVA_RUNTIME_METRIC_LOG"

--- a/validator/src/main/resources/validations/java/k8s/metric-validation.yml
+++ b/validator/src/main/resources/validations/java/k8s/metric-validation.yml
@@ -22,3 +22,7 @@
   httpMethod: "get"
   callingType: "http"
   expectedMetricTemplate: "JAVA_K8S_CLIENT_CALL_METRIC"
+-
+  validationType: "cw-metric"
+  callingType: "none"
+  expectedMetricTemplate: "JAVA_RUNTIME_METRIC"

--- a/validator/src/main/resources/validations/python/ec2/asg/log-validation.yml
+++ b/validator/src/main/resources/validations/python/ec2/asg/log-validation.yml
@@ -22,4 +22,7 @@
   httpMethod: "get"
   callingType: "http"
   expectedLogStructureTemplate: "PYTHON_EC2_ASG_CLIENT_CALL_LOG"
-
+-
+  validationType: "cw-log"
+  callingType: "none"
+  expectedLogStructureTemplate: "PYTHON_RUNTIME_METRIC_LOG"

--- a/validator/src/main/resources/validations/python/ec2/asg/metric-validation.yml
+++ b/validator/src/main/resources/validations/python/ec2/asg/metric-validation.yml
@@ -22,4 +22,7 @@
   httpMethod: "get"
   callingType: "http"
   expectedMetricTemplate: "PYTHON_EC2_ASG_CLIENT_CALL_METRIC"
-
+-
+  validationType: "cw-metric"
+  callingType: "none"
+  expectedMetricTemplate: "PYTHON_RUNTIME_METRIC"

--- a/validator/src/main/resources/validations/python/ec2/default/log-validation.yml
+++ b/validator/src/main/resources/validations/python/ec2/default/log-validation.yml
@@ -22,4 +22,7 @@
   httpMethod: "get"
   callingType: "http"
   expectedLogStructureTemplate: "PYTHON_EC2_DEFAULT_CLIENT_CALL_LOG"
-
+-
+  validationType: "cw-log"
+  callingType: "none"
+  expectedLogStructureTemplate: "PYTHON_RUNTIME_METRIC_LOG"

--- a/validator/src/main/resources/validations/python/ec2/default/metric-validation.yml
+++ b/validator/src/main/resources/validations/python/ec2/default/metric-validation.yml
@@ -22,4 +22,7 @@
   httpMethod: "get"
   callingType: "http"
   expectedMetricTemplate: "PYTHON_EC2_DEFAULT_CLIENT_CALL_METRIC"
-
+-
+  validationType: "cw-metric"
+  callingType: "none"
+  expectedMetricTemplate: "PYTHON_RUNTIME_METRIC"

--- a/validator/src/main/resources/validations/python/ecs/log-validation.yml
+++ b/validator/src/main/resources/validations/python/ecs/log-validation.yml
@@ -2,3 +2,7 @@
   validationType: "cw-log"
   callingType: "none"
   expectedLogStructureTemplate: "PYTHON_ECS_HC_CALL_LOG"
+-
+  validationType: "cw-log"
+  callingType: "none"
+  expectedLogStructureTemplate: "PYTHON_RUNTIME_METRIC_LOG"

--- a/validator/src/main/resources/validations/python/ecs/metric-validation.yml
+++ b/validator/src/main/resources/validations/python/ecs/metric-validation.yml
@@ -2,3 +2,7 @@
   validationType: "cw-metric"
   callingType: "none"
   expectedMetricTemplate: "PYTHON_ECS_HC_CALL_METRIC"
+-
+  validationType: "cw-metric"
+  callingType: "none"
+  expectedMetricTemplate: "PYTHON_RUNTIME_METRIC"

--- a/validator/src/main/resources/validations/python/eks/log-validation.yml
+++ b/validator/src/main/resources/validations/python/eks/log-validation.yml
@@ -28,3 +28,7 @@
   httpMethod: "get"
   callingType: "http"
   expectedLogStructureTemplate: "PYTHON_EKS_RDS_MYSQL_LOG"
+-
+  validationType: "cw-log"
+  callingType: "none"
+  expectedLogStructureTemplate: "PYTHON_RUNTIME_METRIC_LOG"

--- a/validator/src/main/resources/validations/python/eks/metric-validation.yml
+++ b/validator/src/main/resources/validations/python/eks/metric-validation.yml
@@ -28,3 +28,7 @@
   httpMethod: "get"
   callingType: "http"
   expectedMetricTemplate: "PYTHON_EKS_RDS_MYSQL_METRIC"
+-
+  validationType: "cw-metric"
+  callingType: "none"
+  expectedMetricTemplate: "PYTHON_RUNTIME_METRIC"

--- a/validator/src/main/resources/validations/python/k8s/log-validation.yml
+++ b/validator/src/main/resources/validations/python/k8s/log-validation.yml
@@ -22,3 +22,7 @@
   httpMethod: "get"
   callingType: "http"
   expectedLogStructureTemplate: "PYTHON_K8S_CLIENT_CALL_LOG"
+-
+  validationType: "cw-log"
+  callingType: "none"
+  expectedLogStructureTemplate: "PYTHON_RUNTIME_METRIC_LOG"

--- a/validator/src/main/resources/validations/python/k8s/metric-validation.yml
+++ b/validator/src/main/resources/validations/python/k8s/metric-validation.yml
@@ -22,3 +22,7 @@
   httpMethod: "get"
   callingType: "http"
   expectedMetricTemplate: "PYTHON_K8S_CLIENT_CALL_METRIC"
+-
+  validationType: "cw-metric"
+  callingType: "none"
+  expectedMetricTemplate: "PYTHON_RUNTIME_METRIC"


### PR DESCRIPTION
*Description of changes:*
1. Enable runtime metrics in existing Python and Java canaries.
2. Upgrade ECR image to use G1GC as default GC.
3. Use `Always` ImagePullPolicy for k8s workloads.

*Rollback procedure:*

<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

*Ensure you've run the following tests on your changes and include the link below:*

ECR
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/11967144237

Python eks
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/11963840109

Python ec2
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/11963729958

Python ecs
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/11963731839

Python k8s
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/11963859634


Java eks
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/11977537794

Java ec2
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/11964002141

Java ecs
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/11967188838

Java k8s
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/11967448835


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
