### PR TITLE
Update validation result success condition for OTLP/OCB

### DIFF
--- a/.github/workflows/java-eks-otlp-ocb-test.yml
+++ b/.github/workflows/java-eks-otlp-ocb-test.yml
@@ -336,7 +336,7 @@ jobs:
         if: always()
         id: validation-result
         run: |
-          if [ "${{ steps.trace-validation.outcome }}" = "success" ]; then
+          if [ "${{ steps.log-validation.outcome }}" = "success" ] && [ "${{ steps.metric-validation.outcome }}" = "success" ] && [ "${{ steps.trace-validation.outcome }}" = "success" ]; then
             echo "validation-result=success" >> $GITHUB_OUTPUT
           else
             echo "validation-result=failure" >> $GITHUB_OUTPUT


### PR DESCRIPTION
*Issue description:*

*Description of changes:*
- In `"Save test results"` of OCB+OTLP EKS workflow, update logic for setting `"validation-result=success"` to be more similar to other workflows.
  - [Current OTLP Java EKS test
](https://github.com/aws-observability/aws-application-signals-test-framework/blob/3a14868c977cdad993100ed03a5f365ff0751bbb/.github/workflows/java-eks-otlp-ocb-test.yml#L339)
  - [Compared to regular Java EKS](https://github.com/aws-observability/aws-application-signals-test-framework/blob/3a14868c977cdad993100ed03a5f365ff0751bbb/.github/workflows/java-eks-test.yml#L455)

*Rollback procedure:*

N/A

*Ensure you've run the following tests on your changes and include the link below:*

https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/12188286530/job/34000954449#step:31:1


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
