### PR TITLE
Changed volume size from 5 to 35GB for Windows EC2 tests

### DIFF
--- a/terraform/dotnet/ec2/windows/main.tf
+++ b/terraform/dotnet/ec2/windows/main.tf
@@ -76,7 +76,7 @@ resource "aws_instance" "main_service_instance" {
   get_password_data = true
 
   root_block_device {
-    volume_size = 5
+    volume_size = 35
   }
 
   tags = {

--- a/terraform/dotnet/ec2/windows/main.tf
+++ b/terraform/dotnet/ec2/windows/main.tf
@@ -123,7 +123,7 @@ resource "aws_instance" "remote_service_instance" {
   get_password_data = true
 
   root_block_device {
-    volume_size = 5
+    volume_size = 35
   }
 
   tags = {


### PR DESCRIPTION
*Description of changes:*
Windows EC2 tests were failing due to capacity issues. Updated the terraform script to increase the capacity and did a test run and it's now passing:
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/12243621218/job/34153583025

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
