### PR TITLE
Update node express version - dependabot security

### DIFF
--- a/sample-apps/node/frontend-service/package-lock.json
+++ b/sample-apps/node/frontend-service/package-lock.json
@@ -1798,9 +1798,10 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -1821,7 +1822,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -1836,6 +1837,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -2185,9 +2190,10 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",

--- a/sample-apps/node/frontend-service/package.json
+++ b/sample-apps/node/frontend-service/package.json
@@ -13,7 +13,7 @@
     "@aws-sdk/client-s3": "^3.621.0",
     "@types/express": "^4.17.21",
     "@types/node": "^20.14.6",
-    "express": "^4.21.1",
+    "express": "^4.21.2",
     "mysql2": "^3.11.0"
   }
 }


### PR DESCRIPTION
*Issue description:*
Dependabot security telling us to upgrade express version for node, but it is unable to generate the PR. 
https://github.com/aws-observability/aws-application-signals-test-framework/security/dependabot/17

*Description of changes:*
Updated express to 4.21.2, matching PR as this one: https://github.com/aws-observability/aws-application-signals-test-framework/pull/330/files

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
