### PR TITLE
[EKS] Fix: Ensure concurrency tag includes cluster name

### DIFF
--- a/.github/workflows/dotnet-eks-retry.yml
+++ b/.github/workflows/dotnet-eks-retry.yml
@@ -19,7 +19,7 @@ on:
         type: string
 
 concurrency:
-  group: 'dotnet-eks-${{ inputs.aws-region }}-${{ github.ref_name }}'
+  group: 'dotnet-eks-${{ inputs.aws-region }}-${{ inputs.test-cluster-name }}'
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/java-eks-otlp-ocb-retry.yml
+++ b/.github/workflows/java-eks-otlp-ocb-retry.yml
@@ -22,7 +22,7 @@ on:
         type: string
 
 concurrency:
-  group: 'java-eks-otlp-ocb-${{ inputs.aws-region }}-${{ github.ref_name }}'
+  group: 'java-eks-otlp-ocb-${{ inputs.aws-region }}-${{ inputs.test-cluster-name }}'
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/java-eks-retry.yml
+++ b/.github/workflows/java-eks-retry.yml
@@ -22,7 +22,7 @@ on:
         type: string
 
 concurrency:
-  group: 'java-eks-${{ inputs.aws-region }}-${{ github.ref_name }}'
+  group: 'java-eks-${{ inputs.aws-region }}-${{ inputs.test-cluster-name }}'
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/node-eks-retry.yml
+++ b/.github/workflows/node-eks-retry.yml
@@ -19,7 +19,7 @@ on:
         type: string
 
 concurrency:
-  group: 'node-eks-${{ inputs.aws-region }}-${{ github.ref_name }}'
+  group: 'node-eks-${{ inputs.aws-region }}-${{ inputs.test-cluster-name }}'
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/python-eks-retry.yml
+++ b/.github/workflows/python-eks-retry.yml
@@ -22,7 +22,7 @@ on:
         type: string
 
 concurrency:
-  group: 'python-eks-${{ inputs.aws-region }}-${{ github.ref_name }}'
+  group: 'python-eks-${{ inputs.aws-region }}-${{ inputs.test-cluster-name }}'
   cancel-in-progress: false
 
 permissions:


### PR DESCRIPTION
## Notes
Ensure concurrency tag includes cluster name so that if the cluster is used in another branch the tests still don't run at the same time.

## Rollback procedure
Revert PR

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
