### PR TITLE
extend and print trace search time range

### DIFF
--- a/validator/src/main/java/com/amazon/aoc/enums/GenericConstants.java
+++ b/validator/src/main/java/com/amazon/aoc/enums/GenericConstants.java
@@ -20,7 +20,7 @@ import lombok.Getter;
 @Getter
 public enum GenericConstants {
   // retry
-  SLEEP_IN_MILLISECONDS("10000"), // ms
+  SLEEP_IN_MILLISECONDS("30000"), // ms
   SLEEP_IN_SECONDS("30"),
   MAX_RETRIES("10"),
 

--- a/validator/src/main/java/com/amazon/aoc/services/XRayService.java
+++ b/validator/src/main/java/com/amazon/aoc/services/XRayService.java
@@ -25,11 +25,13 @@ import com.amazonaws.services.xray.model.Trace;
 import com.amazonaws.services.xray.model.TraceSummary;
 import java.util.Date;
 import java.util.List;
+import lombok.extern.log4j.Log4j2;
 import org.joda.time.DateTime;
 
+@Log4j2
 public class XRayService {
   private AWSXRay awsxRay;
-  private final int SEARCH_PERIOD = 600;
+  private final int SEARCH_PERIOD = 600 * 3;
   public static String DEFAULT_TRACE_ID = "1-00000000-000000000000000000000000";
 
   public XRayService(String region) {
@@ -53,6 +55,7 @@ public class XRayService {
   public List<TraceSummary> searchTraces(String traceFilter) {
     Date currentDate = new Date();
     Date pastDate = new DateTime(currentDate).minusSeconds(SEARCH_PERIOD).toDate();
+    log.info("--start-time: " + pastDate + ", --end-time: " + currentDate + ", traceFilter: " + traceFilter);
     GetTraceSummariesResult traceSummaryResult =
             awsxRay.getTraceSummaries(
                     new GetTraceSummariesRequest()


### PR DESCRIPTION
*Issue description:*

Lambda canary randomly fails, try to test if it is caused by xray service misses annotation SLA
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/12561234254/job/35019797312#step:21:335

*Description of changes:*

*Rollback procedure:*

<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
