### PR TITLE
Revert #316 "Stick to old AMI to workaround npm install"

### DIFF
--- a/terraform/node/ec2/asg/main.tf
+++ b/terraform/node/ec2/asg/main.tf
@@ -53,7 +53,7 @@ data "aws_ami" "ami" {
   most_recent      = true
   filter {
     name   = "name"
-    values = ["al20*-ami-minimal-2023.6.20241031.0-*-x86_64"]
+    values = ["al20*-ami-minimal-*-x86_64"]
   }
   filter {
     name   = "state"

--- a/terraform/node/ec2/default/main.tf
+++ b/terraform/node/ec2/default/main.tf
@@ -46,7 +46,7 @@ data "aws_ami" "ami" {
   most_recent      = true
   filter {
     name = "name"
-    values = ["al20*-ami-minimal-2023.6.20241031.0-*-${var.cpu_architecture}"]
+    values = ["al20*-ami-minimal-*-${var.cpu_architecture}"]
   }
   filter {
     name   = "state"


### PR DESCRIPTION
This reverts https://github.com/aws-observability/aws-application-signals-test-framework/pull/316.

*Issue description:*
The new AMI fixed npm issue: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/12589668222

*Description of changes:*

*Rollback procedure:*

<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
