### PR TITLE
AutoBuild Windows Dotnet ECR Sample App Image

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,1 +1,3 @@
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+MEOW

--- a/NOTICE
+++ b/NOTICE
@@ -1,3 +1,1 @@
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
-MEOW

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -4,6 +4,8 @@ phases:
   pre_build:
     commands:
       - echo "Pre-build phase -- Logging into Amazon ECR..."
+      - Write-Host "$env:AWS_DEFAULT_REGION"
+      - Write-Host "$env:ACCOUNT_ID"
 #      - (Get-ECRLoginCommand).Password | docker login --username AWS --password-stdin $env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com
       - (Get-ECRLoginCommand).Password | docker login --username AWS --password-stdin 654654176582.dkr.ecr.us-east-1.amazonaws.com
       - echo "Pre-build phase completed."
@@ -11,14 +13,14 @@ phases:
   build:
     commands:
       - echo "Build phase -- Building Docker image via docker-compose..."
-      - docker-compose -f docker-compose.windows.yml build
+      - docker-compose -f docker-compose-windows.yml build
       - echo "Tagging the Docker image..."
       - docker tag asp_frontend_service:latest $env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/$env:ECR_REPOSITORY_NAME:autobuild-latest
 
   post_build:
     commands:
       - echo "Post-build phase -- Pushing Docker image to ECR..."
-      - docker push %ACCOUNT_ID%.dkr.ecr.%AWS_DEFAULT_REGION%.amazonaws.com/%ECR_REPOSITORY_NAME%:autobuild-latest
+      - docker push %ACCOUNT_ID%.dkr.ecr.%AWS_DEFAULT_REGION%.amazonaws.com/$env:ECR_REPOSITORY_NAME:autobuild-latest
       - echo "Build completed successfully."
 
 artifacts:

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -1,10 +1,5 @@
 version: 0.2
 
-env:
-  variables:
-    ECR_REPOSITORY_NAME: "appsignals-dotnet-windows-main-service"
-    AWS_DEFAULT_REGION: "us-east-1"
-
 phases:
   pre_build:
     commands:

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -14,7 +14,8 @@ phases:
       - echo "Build phase -- Building Docker image via docker-compose..."
       - docker-compose -f sample-apps/dotnet/docker-compose-windows.yaml build
       - echo "Tagging the Docker image..."
-      - $ecrImageUrl = "$env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/$env:ECR_REPOSITORY_NAME:autobuild-latest"
+      - docker images
+      - $ecrImageUrl = "$env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/appsignals-dotnet-windows-main-service:autobuild-latest"
       - docker tag asp_frontend_service:latest $ecrImageUrl
 
   post_build:

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -5,7 +5,6 @@ phases:
     commands:
       - echo "Pre-build phase -- Logging into Amazon ECR..."
       - $ecrUrl = "$env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com"
-      - Write-Host "$ecrUrl"
 #      - (Get-ECRLoginCommand).Password | docker login --username AWS --password-stdin $env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com
       - (Get-ECRLoginCommand).Password | docker login --username AWS --password-stdin $ecrUrl
       - echo "Pre-build phase completed."
@@ -15,12 +14,13 @@ phases:
       - echo "Build phase -- Building Docker image via docker-compose..."
       - docker-compose -f sample-apps/dotnet/docker-compose-windows.yaml build
       - echo "Tagging the Docker image..."
-      - docker tag asp_frontend_service:latest $env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/$env:ECR_REPOSITORY_NAME:autobuild-latest
+      - $ecrImageUrl = "$env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/$env:ECR_REPOSITORY_NAME:autobuild-latest"
+      - docker tag asp_frontend_service:latest $ecrImageUrl
 
   post_build:
     commands:
       - echo "Post-build phase -- Pushing Docker image to ECR..."
-      - docker push %ACCOUNT_ID%.dkr.ecr.%AWS_DEFAULT_REGION%.amazonaws.com/$env:ECR_REPOSITORY_NAME:autobuild-latest
+      - docker push $ecrImageUrl
       - echo "Build completed successfully."
 
 artifacts:

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -14,8 +14,8 @@ phases:
       - echo "Build phase -- Building Docker image via docker-compose..."
       - docker-compose -f sample-apps/dotnet/docker-compose-windows.yaml build
       - echo "Tagging the Docker image..."
-      - $ecrMainImageUrl = "$env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/appsignals-dotnet-windows-main-service:autobuild-latest"
-      - $ecrRemoteImageUrl = "$env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/appsignals-dotnet-windows-remote-service:autobuild-latest"
+      - $ecrMainImageUrl = "$env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/appsignals-dotnet-windows-main-service:latest"
+      - $ecrRemoteImageUrl = "$env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/appsignals-dotnet-windows-remote-service:latest"
       - docker tag dotnetsampleapp/frontend-service:latest $ecrMainImageUrl
       - docker tag dotnetsampleapp/remote-service:latest $ecrRemoteImageUrl
 

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -3,13 +3,13 @@ version: 0.2
 phases:
   pre_build:
     commands:
+      - echo "$PSVersionTable"
       - echo "Pre-build phase -- Logging into Amazon ECR..."
-      - aws ecr get-login-password --region %AWS_DEFAULT_REGION% | docker login --username AWS --password-stdin %ACCOUNT_ID%.dkr.ecr.%AWS_DEFAULT_REGION%.amazonaws.com
+      - aws ecr get-login-password --region $env:AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com
       - echo "Pre-build phase completed."
 
   build:
     commands:
-      - echo "$PSVersionTable"
       - echo "Build phase -- Building Docker image via docker-compose..."
       - docker-compose -f docker-compose.windows.yml build
       - echo "Tagging the Docker image..."

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -16,8 +16,8 @@ phases:
       - echo "Tagging the Docker image..."
       - $ecrMainImageUrl = "$env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/appsignals-dotnet-windows-main-service:autobuild-latest"
       - $ecrRemoteImageUrl = "$env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/appsignals-dotnet-windows-remote-service:autobuild-latest"
-      - docker tag dotnetsampleapp/asp_frontend_service:latest $ecrMainImageUrl
-      - docker tag dotnetsampleapp/asp_remote_service:latest $ecrRemoteImageUrl
+      - docker tag dotnetsampleapp/frontend_service:latest $ecrMainImageUrl
+      - docker tag dotnetsampleapp/remote_service:latest $ecrRemoteImageUrl
 
   post_build:
     commands:

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -3,7 +3,9 @@ version: 0.2
 phases:
   pre_build:
     commands:
-      - echo "$PSVersionTable"
+      - echo $env:AWS_DEFAULT_REGION
+      - echo $env:ACCOUNT_ID
+      - aws ecr get-login-password --region us-east-1
       - echo "Pre-build phase -- Logging into Amazon ECR..."
       - aws ecr get-login-password --region $env:AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com
       - echo "Pre-build phase completed."

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -9,12 +9,11 @@ phases:
 
   build:
     commands:
-      - $PSVersionTable
-      - ver
+      - echo "$PSVersionTable"
       - echo "Build phase -- Building Docker image via docker-compose..."
       - docker-compose -f docker-compose.windows.yml build
       - echo "Tagging the Docker image..."
-      - docker tag asp_frontend_service:latest %ACCOUNT_ID%.dkr.ecr.%AWS_DEFAULT_REGION%.amazonaws.com/%ECR_REPOSITORY_NAME%:autobuild-latest
+      - docker tag asp_frontend_service:latest $env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/$env:ECR_REPOSITORY_NAME:autobuild-latest
 
   post_build:
     commands:

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -3,9 +3,8 @@ version: 0.2
 phases:
   pre_build:
     commands:
-      - (Get-ECRLoginCommand).Password
       - echo "Pre-build phase -- Logging into Amazon ECR..."
-      - aws ecr get-login-password --region $env:AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/
+      - (Get-ECRLoginCommand).Password | docker login --username AWS --password-stdin $env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com
       - echo "Pre-build phase completed."
 
   build:

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -4,10 +4,10 @@ phases:
   pre_build:
     commands:
       - echo "Pre-build phase -- Logging into Amazon ECR..."
-      - Write-Host "$env:AWS_DEFAULT_REGION"
-      - Write-Host "$env:ACCOUNT_ID"
+      - $ecrUrl = "$env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com"
+      - Write-Host "$ecrUrl"
 #      - (Get-ECRLoginCommand).Password | docker login --username AWS --password-stdin $env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com
-      - (Get-ECRLoginCommand).Password | docker login --username AWS --password-stdin $env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com
+      - (Get-ECRLoginCommand).Password | docker login --username AWS --password-stdin $ecrUrl
       - echo "Pre-build phase completed."
 
   build:

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -3,11 +3,9 @@ version: 0.2
 phases:
   pre_build:
     commands:
-      - echo $env:AWS_DEFAULT_REGION
-      - echo $env:ACCOUNT_ID
-      - aws ecr get-login-password --region us-east-1
+      - (Get-ECRLoginCommand).Password
       - echo "Pre-build phase -- Logging into Amazon ECR..."
-      - aws ecr get-login-password --region $env:AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com
+      - aws ecr get-login-password --region $env:AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/
       - echo "Pre-build phase completed."
 
   build:

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -8,20 +8,20 @@ env:
 phases:
   pre_build:
     commands:
-      - echo "Pre-build phase - Logging into Amazon ECR..."
+      - echo "Pre-build phase -- Logging into Amazon ECR..."
       - aws ecr get-login-password --region %AWS_DEFAULT_REGION% | docker login --username AWS --password-stdin %ACCOUNT_ID%.dkr.ecr.%AWS_DEFAULT_REGION%.amazonaws.com
       - echo "Pre-build phase completed."
 
   build:
     commands:
-      - echo "Build phase - Building Docker image via docker-compose..."
+      - echo "Build phase -- Building Docker image via docker-compose..."
       - docker-compose -f docker-compose.windows.yml build
       - echo "Tagging the Docker image..."
       - docker tag asp_frontend_service:latest %ACCOUNT_ID%.dkr.ecr.%AWS_DEFAULT_REGION%.amazonaws.com/%ECR_REPOSITORY_NAME%:autobuild-latest
 
   post_build:
     commands:
-      - echo "Post-build phase - Pushing Docker image to ECR..."
+      - echo "Post-build phase -- Pushing Docker image to ECR..."
       - docker push %ACCOUNT_ID%.dkr.ecr.%AWS_DEFAULT_REGION%.amazonaws.com/%ECR_REPOSITORY_NAME%:autobuild-latest
       - echo "Build completed successfully."
 

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -8,28 +8,28 @@ env:
 phases:
   install:
     commands:
-      - echo "Install phase: Checking for changes in the 'app/' folder."
+      - echo "Install phase - Checking for changes in the 'app/' folder."
       # 获取上一次提交与当前提交的 diff
       - CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD || true)
-      - echo "Changed files: $CHANGED_FILES"
+      - echo "Changed files - $CHANGED_FILES"
       - if echo "$CHANGED_FILES" | findstr /i "sample-apps/dotnet"; then (echo "Detected changes in Dotnet Sample APP") else (echo "No changes in Dotnet Sample App. Exiting..." & exit 0)  fi
 
   pre_build:
     commands:
-      - echo "Pre-build phase: Logging into Amazon ECR..."
+      - echo "Pre-build phase - Logging into Amazon ECR..."
       - aws ecr get-login-password --region %AWS_DEFAULT_REGION% | docker login --username AWS --password-stdin %ACCOUNT_ID%.dkr.ecr.%AWS_DEFAULT_REGION%.amazonaws.com
       - echo "Pre-build phase completed."
 
   build:
     commands:
-      - echo "Build phase: Building Docker image via docker-compose..."
+      - echo "Build phase - Building Docker image via docker-compose..."
       - docker-compose -f docker-compose.windows.yml build
       - echo "Tagging the Docker image..."
       - docker tag asp_frontend_service:latest %ACCOUNT_ID%.dkr.ecr.%AWS_DEFAULT_REGION%.amazonaws.com/%ECR_REPOSITORY_NAME%:autobuild-latest
 
   post_build:
     commands:
-      - echo "Post-build phase: Pushing Docker image to ECR..."
+      - echo "Post-build phase - Pushing Docker image to ECR..."
       - docker push %ACCOUNT_ID%.dkr.ecr.%AWS_DEFAULT_REGION%.amazonaws.com/%ECR_REPOSITORY_NAME%:autobuild-latest
       - echo "Build completed successfully."
 

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -9,6 +9,8 @@ phases:
 
   build:
     commands:
+      - $PSVersionTable
+      - ver
       - echo "Build phase -- Building Docker image via docker-compose..."
       - docker-compose -f docker-compose.windows.yml build
       - echo "Tagging the Docker image..."

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -7,13 +7,13 @@ phases:
       - Write-Host "$env:AWS_DEFAULT_REGION"
       - Write-Host "$env:ACCOUNT_ID"
 #      - (Get-ECRLoginCommand).Password | docker login --username AWS --password-stdin $env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com
-      - (Get-ECRLoginCommand).Password | docker login --username AWS --password-stdin 654654176582.dkr.ecr.us-east-1.amazonaws.com
+      - (Get-ECRLoginCommand).Password | docker login --username AWS --password-stdin 654654176582.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com
       - echo "Pre-build phase completed."
 
   build:
     commands:
       - echo "Build phase -- Building Docker image via docker-compose..."
-      - docker-compose -f docker-compose-windows.yml build
+      - docker-compose -f sample-apps/dotnet/docker-compose-windows.yml build
       - echo "Tagging the Docker image..."
       - docker tag asp_frontend_service:latest $env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/$env:ECR_REPOSITORY_NAME:autobuild-latest
 

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -1,0 +1,39 @@
+version: 0.2
+
+env:
+  variables:
+    ECR_REPOSITORY_NAME: "appsignals-dotnet-windows-main-service"
+    AWS_DEFAULT_REGION: "us-east-1"
+
+phases:
+  install:
+    commands:
+      - echo "Install phase: Checking for changes in the 'app/' folder."
+      # 获取上一次提交与当前提交的 diff
+      - CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD || true)
+      - echo "Changed files: $CHANGED_FILES"
+      - if echo "$CHANGED_FILES" | findstr /i "sample-apps/dotnet"; then (echo "Detected changes in Dotnet Sample APP") else (echo "No changes in Dotnet Sample App. Exiting..." & exit 0)  fi
+
+  pre_build:
+    commands:
+      - echo "Pre-build phase: Logging into Amazon ECR..."
+      - aws ecr get-login-password --region %AWS_DEFAULT_REGION% | docker login --username AWS --password-stdin %ACCOUNT_ID%.dkr.ecr.%AWS_DEFAULT_REGION%.amazonaws.com
+      - echo "Pre-build phase completed."
+
+  build:
+    commands:
+      - echo "Build phase: Building Docker image via docker-compose..."
+      - docker-compose -f docker-compose.windows.yml build
+      - echo "Tagging the Docker image..."
+      - docker tag asp_frontend_service:latest %ACCOUNT_ID%.dkr.ecr.%AWS_DEFAULT_REGION%.amazonaws.com/%ECR_REPOSITORY_NAME%:autobuild-latest
+
+  post_build:
+    commands:
+      - echo "Post-build phase: Pushing Docker image to ECR..."
+      - docker push %ACCOUNT_ID%.dkr.ecr.%AWS_DEFAULT_REGION%.amazonaws.com/%ECR_REPOSITORY_NAME%:autobuild-latest
+      - echo "Build completed successfully."
+
+artifacts:
+  files:
+    - '**/*'
+  discard-paths: yes

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -7,13 +7,13 @@ phases:
       - Write-Host "$env:AWS_DEFAULT_REGION"
       - Write-Host "$env:ACCOUNT_ID"
 #      - (Get-ECRLoginCommand).Password | docker login --username AWS --password-stdin $env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com
-      - (Get-ECRLoginCommand).Password | docker login --username AWS --password-stdin 654654176582.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com
+      - (Get-ECRLoginCommand).Password | docker login --username AWS --password-stdin $env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com
       - echo "Pre-build phase completed."
 
   build:
     commands:
       - echo "Build phase -- Building Docker image via docker-compose..."
-      - docker-compose -f sample-apps/dotnet/docker-compose-windows.yml build
+      - docker-compose -f sample-apps/dotnet/docker-compose-windows.yaml build
       - echo "Tagging the Docker image..."
       - docker tag asp_frontend_service:latest $env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/$env:ECR_REPOSITORY_NAME:autobuild-latest
 

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -6,14 +6,6 @@ env:
     AWS_DEFAULT_REGION: "us-east-1"
 
 phases:
-  install:
-    commands:
-      - echo "Install phase - Checking for changes in the 'app/' folder."
-      # 获取上一次提交与当前提交的 diff
-      - CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD || true)
-      - echo "Changed files - $CHANGED_FILES"
-      - if echo "$CHANGED_FILES" | findstr /i "sample-apps/dotnet"; then (echo "Detected changes in Dotnet Sample APP") else (echo "No changes in Dotnet Sample App. Exiting..." & exit 0)  fi
-
   pre_build:
     commands:
       - echo "Pre-build phase - Logging into Amazon ECR..."

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -14,14 +14,16 @@ phases:
       - echo "Build phase -- Building Docker image via docker-compose..."
       - docker-compose -f sample-apps/dotnet/docker-compose-windows.yaml build
       - echo "Tagging the Docker image..."
-      - docker images
-      - $ecrImageUrl = "$env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/appsignals-dotnet-windows-main-service:autobuild-latest"
-      - docker tag asp_frontend_service:latest $ecrImageUrl
+      - $ecrMainImageUrl = "$env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/appsignals-dotnet-windows-main-service:autobuild-latest"
+      - $ecrRemoteImageUrl = "$env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/appsignals-dotnet-windows-remote-service:autobuild-latest"
+      - docker tag dotnetsampleapp/asp_frontend_service:latest $ecrMainImageUrl
+      - docker tag dotnetsampleapp/asp_remote_service:latest $ecrRemoteImageUrl
 
   post_build:
     commands:
       - echo "Post-build phase -- Pushing Docker image to ECR..."
-      - docker push $ecrImageUrl
+      - docker push $ecrMainImageUrl
+      - docker push $ecrRemoteImageUrl
       - echo "Build completed successfully."
 
 artifacts:

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -16,8 +16,8 @@ phases:
       - echo "Tagging the Docker image..."
       - $ecrMainImageUrl = "$env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/appsignals-dotnet-windows-main-service:autobuild-latest"
       - $ecrRemoteImageUrl = "$env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/appsignals-dotnet-windows-remote-service:autobuild-latest"
-      - docker tag dotnetsampleapp/frontend_service:latest $ecrMainImageUrl
-      - docker tag dotnetsampleapp/remote_service:latest $ecrRemoteImageUrl
+      - docker tag dotnetsampleapp/frontend-service:latest $ecrMainImageUrl
+      - docker tag dotnetsampleapp/remote-service:latest $ecrRemoteImageUrl
 
   post_build:
     commands:

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -4,7 +4,8 @@ phases:
   pre_build:
     commands:
       - echo "Pre-build phase -- Logging into Amazon ECR..."
-      - (Get-ECRLoginCommand).Password | docker login --username AWS --password-stdin $env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com
+#      - (Get-ECRLoginCommand).Password | docker login --username AWS --password-stdin $env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com
+      - (Get-ECRLoginCommand).Password | docker login --username AWS --password-stdin 654654176582.dkr.ecr.us-east-1.amazonaws.com
       - echo "Pre-build phase completed."
 
   build:

--- a/sample-apps/dotnet/docker-compose-windows.yaml
+++ b/sample-apps/dotnet/docker-compose-windows.yaml
@@ -9,7 +9,7 @@ services:
       - "8.8.6.6"
     build:
       context: .
-      dockerfile: asp_frontend_service/Dockerfile
+      dockerfile: asp_frontend_service/Dockerfile_Windows
     container_name: asp_frontend_service
     restart: always
     ports:
@@ -22,7 +22,7 @@ services:
       - "8.8.6.6"
     build:
       context: .
-      dockerfile: asp_remote_service/Dockerfile
+      dockerfile: asp_remote_service/Dockerfile_Windows
     container_name: asp_remote_service
     restart: always
     ports:


### PR DESCRIPTION
*Description of changes:*
Use AWS CodeBuild to AutoBuild Dotnet Sample Image on Change

*Rollback procedure:*
Revert
<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

Test Runs
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/12590321659/job/35091629726

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
