### PR TITLE
Fix canary tests failure if the trace validation gets started over 20 sec later than trace end time.

### DIFF
--- a/validator/src/main/java/com/amazon/aoc/services/XRayService.java
+++ b/validator/src/main/java/com/amazon/aoc/services/XRayService.java
@@ -23,6 +23,7 @@ import com.amazonaws.services.xray.model.GetTraceSummariesRequest;
 import com.amazonaws.services.xray.model.GetTraceSummariesResult;
 import com.amazonaws.services.xray.model.Trace;
 import com.amazonaws.services.xray.model.TraceSummary;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import org.joda.time.DateTime;
@@ -53,12 +54,21 @@ public class XRayService {
   public List<TraceSummary> searchTraces(String traceFilter) {
     Date currentDate = new Date();
     Date pastDate = new DateTime(currentDate).minusSeconds(SEARCH_PERIOD).toDate();
-    GetTraceSummariesResult traceSummaryResult =
-            awsxRay.getTraceSummaries(
-                    new GetTraceSummariesRequest()
-                            .withStartTime(pastDate)
-                            .withEndTime(currentDate)
-                            .withFilterExpression(traceFilter));
-    return traceSummaryResult.getTraceSummaries();
+    List<TraceSummary> allSummaries = new ArrayList<>();
+    String nextToken = null;
+    do {
+      GetTraceSummariesResult traceSummaryResult =
+              awsxRay.getTraceSummaries(
+                      new GetTraceSummariesRequest()
+                              .withStartTime(pastDate)
+                              .withEndTime(currentDate)
+                              .withFilterExpression(traceFilter)
+                              .withNextToken(nextToken));
+
+      allSummaries.addAll(traceSummaryResult.getTraceSummaries());
+      nextToken = traceSummaryResult.getNextToken();
+    } while(nextToken != null);
+
+    return allSummaries;
   }
 }


### PR DESCRIPTION
*Issue description:*
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/12600973822/job/35121135907

The issues is noticed in IAD because the test account has a large number of traces in IAD, triggers the pagination when validator calls GetTraceSummaries. Since the targeted trace is not in the first page, validator always failed.

*Description of changes:*

*Rollback procedure:*

<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
