### PR TITLE
Revert "pin urllib3 version in sample app (#349)"

### DIFF
--- a/sample-apps/python/django_frontend_service/requirements.txt
+++ b/sample-apps/python/django_frontend_service/requirements.txt
@@ -1,5 +1,4 @@
 Django~=4.2.9
-urllib3==2.2.3
 boto3~=1.34.3
 opentelemetry-api~=1.22.0
 pymysql==1.1.1


### PR DESCRIPTION
This reverts commit 4d358c77eda7c3b380a31a23a1dee241ea97f99f.

*Issue description:*
Root cause was found to be another dependency dropping support for python 3.8. This change is no longer needed.

More context [here](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/311).

*Description of changes:*

*Rollback procedure:*

<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
