### PR TITLE
enable scheduled .net lambda canary workflow

### DIFF
--- a/.github/workflows/dotnet-lambda-canary.yml
+++ b/.github/workflows/dotnet-lambda-canary.yml
@@ -5,8 +5,8 @@
 ## test the artifacts for App Signals enablement.
 name: DotNet Lambda Enablement Canary Testing
 on:
-  #schedule:
-    #- cron: '14,39 * * * *' # run the workflow at 14th and 39th minute of every hour
+  schedule:
+    - cron: '14,39 * * * *' # run the workflow at 14th and 39th minute of every hour
   workflow_dispatch: # be able to run the workflow on demand
 
 permissions:


### PR DESCRIPTION
*Description of changes:*
- Uncommenting the workflow code to run it as canary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
