### PR TITLE
Typo- incorrect java lambda function artifact name in e2e testing

### DIFF
--- a/.github/workflows/java-lambda-test.yml
+++ b/.github/workflows/java-lambda-test.yml
@@ -91,17 +91,18 @@ jobs:
       - name: Set Lambda Layer artifact directory path
         run: echo ARTIFACTS_DIR="${{ github.workspace }}/lambda_artifacts" >> $GITHUB_ENV
 
-      - name: Download Lambda Layer and Function artifacts for E2E Test
+      - name: Download Lambda Layer artifact for E2E Test
         if: ${{ env.CALLER_WORKFLOW_NAME != 'appsignals-java-e2e-lambda-canary-test' }}
         run: |
           aws s3 cp s3://${{ env.STAGING_S3_BUCKET }}/adot-java-lambda-layer-${{ github.run_id }}.zip ${{ env.ARTIFACTS_DIR }}/layer.zip
-          aws s3 cp ${{ env.SAMPLE_APP_ZIP }} ${{ env.ARTIFACTS_DIR }}/java-function.zip
+
+      - name: Download the lambda function artifact for E2E test
+        run: aws s3 cp ${{ env.SAMPLE_APP_ZIP }} ${{ env.ARTIFACTS_DIR }}/java-function.zip
 
       - name: Set Canary Environment Variable
         if: ${{ env.CALLER_WORKFLOW_NAME == 'appsignals-java-e2e-lambda-canary-test' }}
         run: |
-          echo IS_CANARY=true >> $GITHUB_ENV |
-          aws s3 cp ${{ env.SAMPLE_APP_ZIP }} ${{ env.ARTIFACTS_DIR }}/javafunction.zip
+          echo IS_CANARY=true >> $GITHUB_ENV
 
       - name: Set up terraform
         uses: ./.github/workflows/actions/execute_and_retry


### PR DESCRIPTION
The correct name for the Java lambda function artifact is `java-function.zip` ([evidence](https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/12796921402/job/35678934456#step:10:3)) and for the canary step it is misspelled as `javafunction.zip`.

In addition to fixing the typo, I also did a bit of refactoring since whether canary or otherwise we still need to download the function artifact from S3 bucket.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
