### PR TITLE
[CWAgent][TEMP] Add permissions patching to CW Agent release tests

### DIFF
--- a/.github/workflows/actions/patch_image_and_check_diff/action.yml
+++ b/.github/workflows/actions/patch_image_and_check_diff/action.yml
@@ -140,6 +140,8 @@ runs:
       if: ${{ inputs.repository == 'amazon-cloudwatch-agent' }}
       shell: bash
       run: |
+        kubectl patch clusterrole cloudwatch-agent-role --type=json \
+        -p='[{"op": "add", "path": "/rules/-", "value": {"apiGroups": ["discovery.k8s.io"], "resources": ["endpointslices"], "verbs": ["list", "watch", "get"]}}]'
         kubectl patch amazoncloudwatchagents -n amazon-cloudwatch cloudwatch-agent --type='json' -p='[{"op": "replace", "path": "/spec/image", "value": ${{ inputs.patch-image-arn }}}]'
         kubectl delete pods --all -n amazon-cloudwatch
         sleep 10


### PR DESCRIPTION
Notes:
- New changes in CW Agent require permissions to be updated in the addon, which cannot be done without a release
- As such, we introduce this temporary fix to have the permissions added manually until the CW Agent can be verified and released through the impacted release tests
- Not tested, will run the release tests after merging