### PR TITLE
update remote deployment names 

### DIFF
--- a/terraform/dotnet/eks/windows/main.tf
+++ b/terraform/dotnet/eks/windows/main.tf
@@ -163,7 +163,7 @@ resource "kubernetes_service" "dotnet_app_service" {
 resource "kubernetes_deployment" "dotnet_r_app_deployment" {
 
   metadata {
-    name      = "dotnet-r-app-deployment-${var.test_id}"
+    name      = "dotnet-remote-${var.test_id}"
     namespace = var.test_namespace
     labels    = {
       app = "remote-app"

--- a/terraform/dotnet/k8s/deploy/resources/dotnet-remote-service-depl.yaml
+++ b/terraform/dotnet/k8s/deploy/resources/dotnet-remote-service-depl.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: dotnet-sample-r-app-deployment-${TESTING_ID}
+  name: dotnet-remote-${TESTING_ID}
   namespace: dotnet-sample-app-namespace
 spec:
   replicas: 1
@@ -30,3 +30,18 @@ spec:
             - containerPort: 8081
       imagePullSecrets:
         - name: ecr-secret
+      
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dotnet-remote-service
+  namespace: dotnet-sample-app-namespace
+spec:
+  selector:
+    app: dotnet-remote-app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8081
+  type: ClusterIP

--- a/terraform/java/k8s/deploy/resources/remote-service-depl.yaml
+++ b/terraform/java/k8s/deploy/resources/remote-service-depl.yaml
@@ -1,8 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: sample-r-app-deployment-${TESTING_ID}
-  namespace: sample-app-namespace
+  name: java-remote-${TESTING_ID}
+  namespace: java-sample-app-namespace
 spec:
   replicas: 1
   selector:
@@ -27,3 +27,18 @@ spec:
               value: "true"
       imagePullSecrets:
         - name: ecr-secret
+      
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: java-remote-service
+  namespace: java-sample-app-namespace
+spec:
+  selector:
+    app: remote-app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8081
+  type: ClusterIP

--- a/terraform/node/k8s/deploy/resources/remote-service-depl.yaml
+++ b/terraform/node/k8s/deploy/resources/remote-service-depl.yaml
@@ -1,8 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: sample-r-app-deployment-${TESTING_ID}
-  namespace: sample-app-namespace
+  name: node-remote-${TESTING_ID}
+  namespace: node-sample-app-namespace
 spec:
   replicas: 1
   selector:
@@ -28,3 +28,18 @@ spec:
               value: "fs,dns,express"
       imagePullSecrets:
         - name: ecr-secret
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-remote-service
+  namespace: node-sample-app-namespace
+spec:
+  selector:
+    app: remote-app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8001
+  type: ClusterIP

--- a/terraform/python/k8s/deploy/resources/python-remote-service-depl.yaml
+++ b/terraform/python/k8s/deploy/resources/python-remote-service-depl.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: python-sample-r-app-deployment-${TESTING_ID}
+  name: python-remote-${TESTING_ID}
   namespace: python-sample-app-namespace
 spec:
   replicas: 1
@@ -33,3 +33,18 @@ spec:
             - containerPort: 8001
       imagePullSecrets:
         - name: ecr-secret
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: python-remote-service
+  namespace: python-sample-app-namespace
+spec:
+  selector:
+    app: python-remote-app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8001
+  type: ClusterIP


### PR DESCRIPTION
*Issue description:*

*Description of changes:*

Shorten the deployment names for k8s and add a Kubernete service for each remote app deployment. This is related to some behavior changes for cloudwatch agent: 

* https://github.com/aws/amazon-cloudwatch-agent/commit/fc535d172b0874ad9b05361d570adc72af170eff
* https://github.com/aws/amazon-cloudwatch-agent/commit/c53bdcbd0ba183317df14b7c161058cbeb45c5bb

**New behavior:** 
* we will only do ip to workload mapping if a workload is associated with a kubernetes service
* if podname doesn't follow regular regex pattern, we will use service name (rather than workload name) as RemoteService

In addition, modify the deployment name in dotnet eks windows test case that I forgot in last PR. 

*Rollback procedure:*

<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
