### PR TITLE
Revert "Rename service name (#369)"

### DIFF
--- a/terraform/dotnet/eks/linux/main.tf
+++ b/terraform/dotnet/eks/linux/main.tf
@@ -153,7 +153,7 @@ resource "kubernetes_service" "dotnet_app_service" {
 resource "kubernetes_deployment" "dotnet_r_app_deployment" {
 
   metadata {
-    name      = "dotnet-remote-${var.test_id}"
+    name      = "dotnet-r-app-deployment-${var.test_id}"
     namespace = var.test_namespace
     labels    = {
       app = "remote-app"

--- a/terraform/java/eks-otlp-ocb/main.tf
+++ b/terraform/java/eks-otlp-ocb/main.tf
@@ -154,7 +154,7 @@ resource "kubernetes_service" "sample_app_service" {
 resource "kubernetes_deployment" "sample_remote_app_deployment" {
 
   metadata {
-    name      = "sample-remote-${var.test_id}"
+    name      = "sample-r-app-deployment-${var.test_id}"
     namespace = var.test_namespace
     labels    = {
       app = "remote-app"

--- a/terraform/java/eks/main.tf
+++ b/terraform/java/eks/main.tf
@@ -205,14 +205,11 @@ resource "kubernetes_deployment" "sample_remote_app_deployment" {
   }
 }
 
-resource "kubernetes_service" "sample_remote_app_deployment" {
+resource "kubernetes_service" "sample_remote_app_service" {
   depends_on = [ kubernetes_deployment.sample_remote_app_deployment ]
 
   metadata {
-    # use the same name as the deployment to handle the edge case when the deployment name is longer than 47 characters
-    # in this edge case, we just use the service name (rather than deployment name) as RemoteService
-    # see https://github.com/aws/amazon-cloudwatch-agent/pull/1553
-    name      = "sample-r-app-deployment-${var.test_id}"
+    name = "sample-remote-app-service"
     namespace = var.test_namespace
   }
   spec {

--- a/terraform/node/eks/main.tf
+++ b/terraform/node/eks/main.tf
@@ -165,7 +165,7 @@ resource "kubernetes_service" "sample_app_service" {
 resource "kubernetes_deployment" "sample_remote_app_deployment" {
 
   metadata {
-    name      = "sample-remote-${var.test_id}"
+    name      = "sample-r-app-deployment-${var.test_id}"
     namespace = var.test_namespace
     labels    = {
       app = "remote-app"

--- a/terraform/python/eks/main.tf
+++ b/terraform/python/eks/main.tf
@@ -170,7 +170,7 @@ resource "kubernetes_service" "python_app_service" {
 resource "kubernetes_deployment" "python_r_app_deployment" {
 
   metadata {
-    name      = "python-remote-${var.test_id}"
+    name      = "python-r-app-deployment-${var.test_id}"
     namespace = var.test_namespace
     labels    = {
       app = "remote-app"


### PR DESCRIPTION
This reverts commit 3d1dc43192520bae17d439f4f8dde965115c4343.

*Issue description:*

*Description of changes:*

*Rollback procedure:*

<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
