### PR TITLE
K8s release testing fix 2

### DIFF
--- a/terraform/dotnet/k8s/deploy/main.tf
+++ b/terraform/dotnet/k8s/deploy/main.tf
@@ -137,7 +137,7 @@ resource "null_resource" "deploy" {
 
         service_part=$(yq eval 'select(.kind == "Service")' dotnet-remote-service-depl.yaml)
         yq eval 'select(.kind == "Deployment") | .spec.template.spec.imagePullSecrets += {"name": "release-testing-ecr-secret"}' -i dotnet-remote-service-depl.yaml
-        echo "$service_part" >> dotnet-remote-service-depl.yaml
+        echo -e "\n---\n$service_part" >> dotnet-remote-service-depl.yaml
       fi
 
       echo "LOG: Applying sample app deployment files"

--- a/terraform/java/k8s/deploy/main.tf
+++ b/terraform/java/k8s/deploy/main.tf
@@ -138,7 +138,7 @@ resource "null_resource" "deploy" {
 
         service_part=$(yq eval 'select(.kind == "Service")' remote-service-depl.yaml)
         yq eval 'select(.kind == "Deployment") | .spec.template.spec.imagePullSecrets += {"name": "release-testing-ecr-secret"}' -i remote-service-depl.yaml
-        echo "$service_part" >> remote-service-depl.yaml
+        echo -e "\n---\n$service_part" >> remote-service-depl.yaml
       fi
 
       echo "LOG: Applying sample app deployment files"

--- a/terraform/node/k8s/deploy/main.tf
+++ b/terraform/node/k8s/deploy/main.tf
@@ -137,10 +137,10 @@ resource "null_resource" "deploy" {
           --docker-password="$${TOKEN}"
 
         yq eval '.spec.template.spec.imagePullSecrets += [{"name": "release-testing-ecr-secret"}]' -i frontend-service-depl.yaml
-        
+
         service_part=$(yq eval 'select(.kind == "Service")' remote-service-depl.yaml)
         yq eval 'select(.kind == "Deployment") | .spec.template.spec.imagePullSecrets += {"name": "release-testing-ecr-secret"}' -i remote-service-depl.yaml
-        echo "$service_part" >> remote-service-depl.yaml
+        echo -e "\n---\n$service_part" >> remote-service-depl.yaml
       fi
 
       echo "LOG: Applying sample app deployment files"

--- a/terraform/python/k8s/deploy/main.tf
+++ b/terraform/python/k8s/deploy/main.tf
@@ -139,7 +139,7 @@ resource "null_resource" "deploy" {
 
         service_part=$(yq eval 'select(.kind == "Service")' python-remote-service-depl.yaml)
         yq eval 'select(.kind == "Deployment") | .spec.template.spec.imagePullSecrets += {"name": "release-testing-ecr-secret"}' -i python-rremote-service-depl.yaml
-        echo "$service_part" >> python-rremote-service-depl.yaml
+        echo -e "\n---\n$service_part" >> python-remote-service-depl.yaml
       fi
 
       echo "LOG: Applying sample app deployment files"


### PR DESCRIPTION
*Issue description:*
Follow up from https://github.com/aws-observability/aws-application-signals-test-framework/pull/375, the `---` was missing between the Service and Deployment kind deployment.

Output:
![image](https://github.com/user-attachments/assets/b81853ee-99e8-406d-878d-d026c294aaf9)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
