### PR TITLE
fix: typo in python k8s terraform file

### DIFF
--- a/terraform/python/k8s/deploy/main.tf
+++ b/terraform/python/k8s/deploy/main.tf
@@ -138,7 +138,7 @@ resource "null_resource" "deploy" {
         yq eval '.spec.template.spec.imagePullSecrets += [{"name": "release-testing-ecr-secret"}]' -i python-frontend-service-depl.yaml
 
         service_part=$(yq eval 'select(.kind == "Service")' python-remote-service-depl.yaml)
-        yq eval 'select(.kind == "Deployment") | .spec.template.spec.imagePullSecrets += {"name": "release-testing-ecr-secret"}' -i python-rremote-service-depl.yaml
+        yq eval 'select(.kind == "Deployment") | .spec.template.spec.imagePullSecrets += {"name": "release-testing-ecr-secret"}' -i python-remote-service-depl.yaml
         echo -e "\n---\n$service_part" >> python-remote-service-depl.yaml
       fi
 


### PR DESCRIPTION
*Issue description:*
Python k8s e2e test in ADOT Python repo started failing ~2 weeks ago. Example [workflow failure](https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/13683146018/job/38261028556).

From workflow error logs:
```
null_resource.deploy (remote-exec): secret/release-testing-ecr-secret created
null_resource.deploy (remote-exec): Error: stat python-rremote-service-depl.yaml: no such file or directory
```

Seems like there is a minor typo for this file name.

*Description of changes:*
One-liner to correct typo

*Rollback procedure:*

<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
