### PR TITLE
[Node] Add ADOT SigV4 Release Test

### DIFF
--- a/.github/workflows/node-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/node-ec2-adot-sigv4-test.yml
@@ -1,0 +1,239 @@
+## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+
+# This is a reusable workflow for running the Enablement test for App Signals.
+# It is meant to be called from another workflow.
+# Read more about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview
+name: Node EC2 ADOT SigV4 Use Case
+on:
+  workflow_call:
+    inputs:
+      caller-workflow-name:
+        required: true
+        type: string
+      node-version:
+        description: "Currently support version 14, 16, 18, 20, 22"
+        required: false
+        type: string
+        # 'none' means to use the node version come with the OS
+        default: 'none'
+      cpu-architecture:
+        description: "Permitted values: x86_64 or arm64"
+        required: false
+        type: string
+        default: "x86_64"
+      staging-instrumentation-name:
+        required: false
+        default: '@aws/aws-distro-opentelemetry-node-autoinstrumentation'
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  E2E_TEST_AWS_REGION: 'us-west-2'
+  CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
+  NODE_VERSION: ${{ inputs.node-version }}
+  CPU_ARCHITECTURE: ${{ inputs.cpu-architecture }}
+  ADOT_INSTRUMENTATION_NAME: ${{ inputs.staging-instrumentation-name }}
+  E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
+  E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
+  METRIC_NAMESPACE: ApplicationSignals
+  LOG_GROUP_NAME: aws/spans
+  TEST_RESOURCES_FOLDER: ${GITHUB_WORKSPACE}
+
+jobs:
+  node-ec2-adot-sigv4:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if the job started
+        id: job-started
+        run: echo "job-started=true" >> $GITHUB_OUTPUT
+
+      - name: Generate testing id
+        run: echo TESTING_ID="${{ github.run_id }}-${{ github.run_number }}-${RANDOM}" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v4
+        with:
+          repository: 'aws-observability/aws-application-signals-test-framework'
+          ref: ${{ env.CALLER_WORKFLOW_NAME == 'main-build' && 'main' || github.ref }}
+          fetch-depth: 0
+
+      # We initialize Gradlew Daemon early on during the workflow because sometimes initialization
+      # fails due to transient issues. If it fails here, then we will try again later before the validators
+      - name: Initiate Gradlew Daemon
+        id: initiate-gradlew
+        uses: ./.github/workflows/actions/execute_and_retry
+        continue-on-error: true
+        with:
+          command: "./gradlew :validator:build"
+          cleanup: "./gradlew clean"
+          max_retry: 3
+          sleep_time: 60
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.E2E_TEST_ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
+          aws-region: ${{ env.E2E_TEST_AWS_REGION }}
+
+      - name: Set Get ADOT Instrumentation command environment variable
+        run: |
+          if [ "${{ github.event.repository.name }}" = "aws-otel-js-instrumentation" ]; then
+            echo GET_ADOT_INSTRUMENTATION_COMMAND="aws s3 cp s3://adot-autoinstrumentation-node-staging/${{ env.ADOT_INSTRUMENTATION_NAME }} ./${{ env.ADOT_INSTRUMENTATION_NAME }} --region us-east-1 && npm install ${{ env.ADOT_INSTRUMENTATION_NAME }}" >> $GITHUB_ENV
+          else
+            echo GET_ADOT_INSTRUMENTATION_COMMAND="npm install ${{ env.ADOT_INSTRUMENTATION_NAME }}" >> $GITHUB_ENV
+          fi
+
+      - name: Set up terraform
+        uses: ./.github/workflows/actions/execute_and_retry
+        with:
+          command: "wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg"
+          post-command: 'echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+              && sudo apt update && sudo apt install terraform'
+          sleep_time: 60
+
+      - name: Initiate Terraform
+        uses: ./.github/workflows/actions/execute_and_retry
+        with:
+          command: "cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/node/ec2/adot-sigv4 && terraform init && terraform validate"
+          cleanup: "rm -rf .terraform && rm -rf .terraform.lock.hcl"
+          max_retry: 6
+          sleep_time: 60
+
+      - name: Deploy sample app via terraform and wait for endpoint to come online
+        working-directory: terraform/node/ec2/adot-sigv4
+        run: |
+          # Attempt to deploy the sample app on an EC2 instance and wait for its endpoint to come online.
+          # There may be occasional failures due to transitivity issues, so try up to 2 times.
+          # deployment_failed of 0 indicates that both the terraform deployment and the endpoint are running, while 1 indicates
+          # that it failed at some point
+          retry_counter=0
+          max_retry=2
+          while [ $retry_counter -lt $max_retry ]; do
+            echo "Attempt $retry_counter"
+            deployment_failed=0
+            terraform apply -auto-approve \
+              -var="aws_region=${{ env.E2E_TEST_AWS_REGION }}" \
+              -var="test_id=${{ env.TESTING_ID }}" \
+              -var="sample_app_zip=s3://aws-appsignals-sample-app-prod-us-east-1/node-sample-app.zip" \
+              -var="get_adot_instrumentation_command=${{ env.GET_ADOT_INSTRUMENTATION_COMMAND }}" \
+              -var="language_version=${{ env.NODE_VERSION }}" \
+              -var="cpu_architecture=${{ env.CPU_ARCHITECTURE }}" \
+            || deployment_failed=$?
+
+            if [ $deployment_failed -eq 1 ]; then
+              echo "Terraform deployment was unsuccessful. Will attempt to retry deployment."
+            fi
+
+            # If the success is 1 then either the terraform deployment or the endpoint connection failed, so first destroy the
+            # resources created from terraform and try again.
+            if [ $deployment_failed -eq 1 ]; then
+              echo "Destroying terraform"
+              terraform destroy -auto-approve \
+                -var="test_id=${{ env.TESTING_ID }}"
+
+              retry_counter=$(($retry_counter+1))
+            else
+              # If deployment succeeded, then exit the loop
+              break
+            fi
+
+            if [ $retry_counter -eq $max_retry ]; then
+              echo "Max retry reached, failed to deploy terraform and connect to the endpoint. Exiting code"
+              exit 1
+            fi
+          done
+
+      - name: Get the ec2 instance ami id
+        working-directory: terraform/node/ec2/adot-sigv4
+        run: |
+          echo "EC2_INSTANCE_AMI=$(terraform output ec2_instance_ami)" >> $GITHUB_ENV
+
+      - name: Get the sample app and EC2 instance information
+        working-directory: terraform/node/ec2/adot-sigv4
+        run: |
+          echo "MAIN_SERVICE_ENDPOINT=localhost:8000" >> $GITHUB_ENV
+          echo "REMOTE_SERVICE_IP=$(terraform output sample_app_remote_service_private_ip)" >> $GITHUB_ENV
+          echo "MAIN_SERVICE_INSTANCE_ID=$(terraform output main_service_instance_id)" >> $GITHUB_ENV
+
+      - name: Initiate Gradlew Daemon
+        if: steps.initiate-gradlew == 'failure'
+        uses: ./.github/workflows/actions/execute_and_retry
+        continue-on-error: true
+        with:
+          command: "./gradlew :validator:build"
+          cleanup: "./gradlew clean"
+          max_retry: 3
+          sleep_time: 60
+
+      # Validation for pulse telemetry data
+      - name: Validate generated EMF logs
+        id: log-validation
+        run: ./gradlew validator:run --args='-c node/ec2/adot-sigv4/log-validation.yml
+          --testing-id ${{ env.TESTING_ID }}
+          --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
+          --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8001
+          --region ${{ env.E2E_TEST_AWS_REGION }}
+          --account-id ${{ env.E2E_TEST_ACCOUNT_ID }}
+          --metric-namespace ${{ env.METRIC_NAMESPACE }}
+          --log-group ${{ env.LOG_GROUP_NAME }}
+          --service-name node-sample-application-${{ env.TESTING_ID }}
+          --remote-service-name node-sample-remote-application-${{ env.TESTING_ID }}
+          --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
+          --instance-ami ${{ env.EC2_INSTANCE_AMI }}
+          --instance-id ${{ env.MAIN_SERVICE_INSTANCE_ID }}
+          --rollup'
+
+      - name: Validate generated metrics
+        id: metric-validation
+        if: (success() || steps.log-validation.outcome == 'failure') && !cancelled()
+        run: ./gradlew validator:run --args='-c node/ec2/adot-sigv4/metric-validation.yml
+          --testing-id ${{ env.TESTING_ID }}
+          --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
+          --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8001
+          --region ${{ env.E2E_TEST_AWS_REGION }}
+          --account-id ${{ env.E2E_TEST_ACCOUNT_ID }}
+          --metric-namespace ${{ env.METRIC_NAMESPACE }}
+          --log-group ${{ env.LOG_GROUP_NAME }}
+          --service-name node-sample-application-${{ env.TESTING_ID }}
+          --remote-service-name node-sample-remote-application-${{ env.TESTING_ID }}
+          --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
+          --instance-ami ${{ env.EC2_INSTANCE_AMI }}
+          --instance-id ${{ env.MAIN_SERVICE_INSTANCE_ID }}
+          --rollup'
+
+      - name: Validate generated traces
+        id: trace-validation
+        if: (success() || steps.log-validation.outcome == 'failure' || steps.metric-validation.outcome == 'failure') && !cancelled()
+        run: ./gradlew validator:run --args='-c node/ec2/adot-sigv4/trace-validation.yml
+          --testing-id ${{ env.TESTING_ID }}
+          --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
+          --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8001
+          --region ${{ env.E2E_TEST_AWS_REGION }}
+          --account-id ${{ env.E2E_TEST_ACCOUNT_ID }}
+          --metric-namespace ${{ env.METRIC_NAMESPACE }}
+          --log-group ${{ env.LOG_GROUP_NAME }}
+          --service-name node-sample-application-${{ env.TESTING_ID }}
+          --remote-service-name node-sample-remote-application-${{ env.TESTING_ID }}
+          --query-string ip=${{ env.REMOTE_SERVICE_IP }}&testingId=${{ env.TESTING_ID }}
+          --instance-ami ${{ env.EC2_INSTANCE_AMI }}
+          --instance-id ${{ env.MAIN_SERVICE_INSTANCE_ID }}
+          --rollup'
+
+      - name: Refresh AWS Credentials
+        if: ${{ always() }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ env.E2E_TEST_ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}
+          aws-region: ${{ env.E2E_TEST_AWS_REGION }}
+
+      # Clean up Procedures
+      - name: Terraform destroy
+        if: always()
+        continue-on-error: true
+        working-directory: terraform/node/ec2/adot-sigv4
+        run: |
+          terraform destroy -auto-approve \
+            -var="test_id=${{ env.TESTING_ID }}"

--- a/terraform/node/ec2/adot-sigv4/main.tf
+++ b/terraform/node/ec2/adot-sigv4/main.tf
@@ -1,0 +1,332 @@
+# ------------------------------------------------------------------------
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+# -------------------------------------------------------------------------
+
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+# Define the provider for AWS
+provider "aws" {}
+
+resource "aws_default_vpc" "default" {}
+
+resource "tls_private_key" "ssh_key" {
+  algorithm = "RSA"
+  rsa_bits = 4096
+}
+
+resource "aws_key_pair" "aws_ssh_key" {
+  key_name = "instance_key-${var.test_id}"
+  public_key = tls_private_key.ssh_key.public_key_openssh
+}
+
+locals {
+  ssh_key_name        = aws_key_pair.aws_ssh_key.key_name
+  private_key_content = tls_private_key.ssh_key.private_key_pem
+}
+
+data "aws_ami" "ami" {
+  owners = ["amazon"]
+  most_recent      = true
+  filter {
+    name = "name"
+    values = ["al20*-ami-minimal-*-${var.cpu_architecture}"]
+  }
+  filter {
+    name   = "state"
+    values = ["available"]
+  }
+  filter {
+    name   = "architecture"
+    values = ["${var.cpu_architecture}"]
+  }
+  filter {
+    name   = "image-type"
+    values = ["machine"]
+  }
+
+  filter {
+    name   = "root-device-name"
+    values = ["/dev/xvda"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_instance" "main_service_instance" {
+  ami                                   = data.aws_ami.ami.id # Amazon Linux 2 (free tier)
+  instance_type                         = var.cpu_architecture == "arm64" ? "t4g.small" : "t3.small"
+  key_name                              = local.ssh_key_name
+  iam_instance_profile                  = "APP_SIGNALS_EC2_TEST_ROLE"
+  vpc_security_group_ids                = [aws_default_vpc.default.default_security_group_id]
+  associate_public_ip_address           = true
+  instance_initiated_shutdown_behavior  = "terminate"
+
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  root_block_device {
+    volume_size = 5
+  }
+
+  tags = {
+    Name = "main-service-${var.test_id}"
+  }
+}
+
+resource "null_resource" "main_service_setup" {
+  connection {
+    type = "ssh"
+    user = var.user
+    private_key = local.private_key_content
+    host = aws_instance.main_service_instance.public_ip
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      <<-EOF
+      #!/bin/bash
+
+      # Set up environment
+      sudo yum install unzip wget tmux aws-cli -y
+
+      # Install nvm
+      wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+      export NVM_DIR="$HOME/.nvm"
+      [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+
+      # Install the specified Node.js version, or use the system's version if 'none'
+      if [[ "${var.language_version}" != "none" ]]; then
+        nvm install ${var.language_version}
+        nvm use ${var.language_version}
+      else
+        sudo yum install nodejs -y
+        echo "Using the default Node.js version provided by the OS"
+      fi
+
+      echo "Node version in use: $(node -v)"
+
+      # enable ec2 instance connect for debug
+      sudo yum install ec2-instance-connect -y
+
+      # Get and run the sample application with configuration
+      aws s3 cp ${var.sample_app_zip} ./node-sample-app.zip
+      unzip -o node-sample-app.zip
+
+      # Enter appropriate service folder
+      cd frontend-service
+
+      # Install sample application
+      npm install
+
+      # Get ADOT instrumentation and install it
+      ${var.get_adot_instrumentation_command}
+
+      # Set up application tmux screen so it keeps running after closing the SSH connection
+      tmux new-session -d -s frontend
+
+      # Export environment variables for instrumentation
+      # Note: We use OTEL_NODE_DISABLED_INSTRUMENTATIONS=fs,dns,express to avoid
+      # having to validate around the telemetry generated for middleware
+      tmux send-keys -t frontend 'export OTEL_AWS_APPLICATION_SIGNALS_ENABLED=false' C-m
+      tmux send-keys -t frontend 'export OTEL_LOGS_EXPORTER=none' C-m
+      tmux send-keys -t frontend 'export OTEL_METRICS_EXPORTER=none' C-m
+      tmux send-keys -t frontend 'export OTEL_TRACES_EXPORTER=otlp' C-m
+      tmux send-keys -t frontend 'export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf' C-m
+      tmux send-keys -t frontend 'export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://xray.${var.aws_region}.amazonaws.com/v1/traces' C-m
+      tmux send-keys -t frontend 'export OTEL_NODE_DISABLED_INSTRUMENTATIONS=fs,dns,express' C-m
+      tmux send-keys -t frontend 'export OTEL_SERVICE_NAME=node-sample-application-${var.test_id}' C-m
+      tmux send-keys -t frontend 'export OTEL_TRACES_SAMPLER=always_on' C-m
+      tmux send-keys -t frontend 'node --require "@aws/aws-distro-opentelemetry-node-autoinstrumentation/register" index.js' C-m
+
+      # Check if the application is up. If it is not up, then exit 1.
+      attempt_counter=0
+      max_attempts=30
+      until $(curl --output /dev/null --silent --head --fail --max-time 5 $(echo "http://localhost:8000/healthcheck" | tr -d '"')); do
+        if [ $attempt_counter -eq $max_attempts ];then
+          echo "Failed to connect to endpoint."
+          exit 1
+        fi
+        echo "Attempting to connect to the main endpoint. Tried $attempt_counter out of $max_attempts"
+        attempt_counter=$(($attempt_counter+1))
+        sleep 10
+      done
+
+      echo "Successfully connected to main endpoint"
+
+      EOF
+    ]
+  }
+
+  depends_on = [aws_instance.main_service_instance]
+}
+
+resource "aws_instance" "remote_service_instance" {
+  ami                                   = data.aws_ami.ami.id # Amazon Linux 2 (free tier)
+  instance_type                         = var.cpu_architecture == "arm64" ? "t4g.small" : "t3.small"
+  key_name                              = local.ssh_key_name
+  iam_instance_profile                  = "APP_SIGNALS_EC2_TEST_ROLE"
+  vpc_security_group_ids                = [aws_default_vpc.default.default_security_group_id]
+  associate_public_ip_address           = true
+  instance_initiated_shutdown_behavior  = "terminate"
+
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  root_block_device {
+    volume_size = 5
+  }
+
+  tags = {
+    Name = "remote-service-${var.test_id}"
+  }
+}
+
+resource "null_resource" "remote_service_setup" {
+  connection {
+    type = "ssh"
+    user = var.user
+    private_key = local.private_key_content
+    host = aws_instance.remote_service_instance.public_ip
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      <<-EOF
+      #!/bin/bash
+
+      # Set up environment
+      sudo yum install unzip wget tmux aws-cli -y
+
+      # Install nvm
+      wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+      export NVM_DIR="$HOME/.nvm"
+      [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+
+      # Install the specified Node.js version, or use the system's version if 'none'
+      if [[ "${var.language_version}" != "none" ]]; then
+        nvm install ${var.language_version}
+        nvm use ${var.language_version}
+      else
+        sudo yum install nodejs -y
+        echo "Using the default Node.js version provided by the OS"
+      fi
+
+      echo "Node version in use: $(node -v)"
+
+      # enable ec2 instance connect for debug
+      sudo yum install ec2-instance-connect -y
+
+      # Get and run the sample application with configuration
+      aws s3 cp ${var.sample_app_zip} ./node-sample-app.zip
+      unzip -o node-sample-app.zip
+
+      # Enter appropriate service folder
+      cd remote-service
+
+      # Install sample application
+      npm install
+
+      # Get ADOT instrumentation and install it
+      ${var.get_adot_instrumentation_command}
+
+      # Set up application tmux screen so it keeps running after closing the SSH connection
+      tmux new-session -d -s remote
+
+      # Export environment variables for instrumentation
+      # Note: We use OTEL_NODE_DISABLED_INSTRUMENTATIONS=fs,dns,express to avoid
+      # having to validate around the telemetry generated for middleware
+      tmux send-keys -t remote 'export OTEL_AWS_APPLICATION_SIGNALS_ENABLED=false' C-m
+      tmux send-keys -t remote 'export OTEL_LOGS_EXPORTER=none' C-m
+      tmux send-keys -t remote 'export OTEL_METRICS_EXPORTER=none' C-m
+      tmux send-keys -t remote 'export OTEL_TRACES_EXPORTER=otlp' C-m
+      tmux send-keys -t remote 'export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf' C-m
+      tmux send-keys -t remote 'export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://xray.${var.aws_region}.amazonaws.com/v1/traces' C-m
+      tmux send-keys -t remote 'export OTEL_NODE_DISABLED_INSTRUMENTATIONS=fs,dns,express' C-m
+      tmux send-keys -t remote 'export OTEL_SERVICE_NAME=node-sample-remote-application-${var.test_id}' C-m
+      tmux send-keys -t remote 'export OTEL_TRACES_SAMPLER=always_on' C-m
+      tmux send-keys -t remote 'node --require "@aws/aws-distro-opentelemetry-node-autoinstrumentation/register" index.js' C-m
+
+      # The application needs time to come up and reach a steady state, this should not take longer than 30 seconds
+      # sleep 30
+
+      # Check if the application is up. If it is not up, then exit 1.
+      attempt_counter=0
+      max_attempts=30
+      until $(curl --output /dev/null --silent --head --fail --max-time 5 $(echo "http://localhost:8001/healthcheck" | tr -d '"')); do
+        if [ $attempt_counter -eq $max_attempts ];then
+          echo "Failed to connect to endpoint."
+          exit 1
+        fi
+        echo "Attempting to connect to the remote endpoint. Tried $attempt_counter out of $max_attempts"
+        attempt_counter=$(($attempt_counter+1))
+        sleep 10
+      done
+
+      echo "Successfully connected to remote endpoint"
+
+      EOF
+    ]
+  }
+
+  depends_on = [aws_instance.remote_service_instance]
+}
+
+resource "null_resource" "traffic_generator_setup" {
+  connection {
+    type = "ssh"
+    user = var.user
+    private_key = local.private_key_content
+    host = aws_instance.main_service_instance.public_ip
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      <<-EOF
+        # Bring in the traffic generator files to EC2 Instance
+        aws s3 cp s3://aws-appsignals-sample-app-prod-us-east-1/traffic-generator.zip ./traffic-generator.zip
+        unzip ./traffic-generator.zip -d ./
+
+        # Install the traffic generator dependencies
+        npm install
+
+        tmux new -s traffic-generator -d
+        tmux send-keys -t traffic-generator "export MAIN_ENDPOINT=\"localhost:8000\"" C-m
+        tmux send-keys -t traffic-generator "export REMOTE_ENDPOINT=\"${aws_instance.remote_service_instance.private_ip}\"" C-m
+        tmux send-keys -t traffic-generator "export ID=\"${var.test_id}\"" C-m
+        tmux send-keys -t traffic-generator "npm start" C-m
+
+        echo "Completed traffic generator set up commands"
+
+      EOF
+    ]
+  }
+
+  depends_on = [null_resource.main_service_setup, null_resource.remote_service_setup]
+}

--- a/terraform/node/ec2/adot-sigv4/output.tf
+++ b/terraform/node/ec2/adot-sigv4/output.tf
@@ -1,0 +1,26 @@
+# ------------------------------------------------------------------------
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+# -------------------------------------------------------------------------
+
+output "sample_app_remote_service_private_ip" {
+  value = aws_instance.remote_service_instance.private_ip
+}
+
+output "main_service_instance_id" {
+  value = aws_instance.main_service_instance.id
+}
+
+output "ec2_instance_ami" {
+  value = data.aws_ami.ami.id
+}

--- a/terraform/node/ec2/adot-sigv4/variables.tf
+++ b/terraform/node/ec2/adot-sigv4/variables.tf
@@ -1,0 +1,48 @@
+# ------------------------------------------------------------------------
+# Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+# -------------------------------------------------------------------------
+
+variable "test_id" {
+  default = "dummy-123"
+}
+
+variable "aws_region" {
+  default = "<aws-region>"
+}
+
+variable "user" {
+  default = "ec2-user"
+}
+
+variable "cpu_architecture" {
+  default = "x86_64" # an alternative value is "arm64"
+}
+
+variable "language_version" {
+  # none means to use the version packaged with the OS
+  # other alternatives are "14", "16", "18", "20", "22"
+  default = "none"
+}
+
+variable "sample_app_zip" {
+  default = "s3://<bucket-name>/<zip>"
+}
+
+variable "get_adot_instrumentation_command" {
+  default = "<get ADOT instrumentation command> && <install/prepare instrumentation command>"
+}
+
+variable "canary_type" {
+  default = "node-ec2-default"
+}

--- a/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
+++ b/validator/src/main/java/com/amazon/aoc/fileconfigs/PredefinedExpectedTemplate.java
@@ -407,6 +407,26 @@ public enum PredefinedExpectedTemplate implements FileConfig {
   NODE_K8S_CLIENT_CALL_METRIC("/expected-data-template/node/k8s/client-call-metric.mustache"),
   NODE_K8S_CLIENT_CALL_TRACE("/expected-data-template/node/k8s/client-call-trace.mustache"),
 
+  /** Python EC2 ADOT SigV4 (Stand Alone ADOT) Test Case Validations */
+  NODE_EC2_ADOT_SIGV4_OUTGOING_HTTP_CALL_LOG(
+      "/expected-data-template/node/ec2/adot-sigv4/outgoing-http-call-log.mustache"),
+  NODE_EC2_ADOT_SIGV4_OUTGOING_HTTP_CALL_METRIC(
+      "/expected-data-template/node/ec2/adot-sigv4/outgoing-http-call-metric.mustache"),
+  NODE_EC2_ADOT_SIGV4_OUTGOING_HTTP_CALL_TRACE(
+      "/expected-data-template/node/ec2/adot-sigv4/outgoing-http-call-trace.mustache"),
+
+  NODE_EC2_ADOT_SIGV4_AWS_SDK_CALL_LOG("/expected-data-template/node/ec2/adot-sigv4/aws-sdk-call-log.mustache"),
+  NODE_EC2_ADOT_SIGV4_AWS_SDK_CALL_METRIC("/expected-data-template/node/ec2/adot-sigv4/aws-sdk-call-metric.mustache"),
+  NODE_EC2_ADOT_SIGV4_AWS_SDK_CALL_TRACE("/expected-data-template/node/ec2/adot-sigv4/aws-sdk-call-trace.mustache"),
+
+  NODE_EC2_ADOT_SIGV4_REMOTE_SERVICE_LOG("/expected-data-template/node/ec2/adot-sigv4/remote-service-log.mustache"),
+  NODE_EC2_ADOT_SIGV4_REMOTE_SERVICE_METRIC("/expected-data-template/node/ec2/adot-sigv4/remote-service-metric.mustache"),
+  NODE_EC2_ADOT_SIGV4_REMOTE_SERVICE_TRACE("/expected-data-template/node/ec2/adot-sigv4/remote-service-trace.mustache"),
+
+  NODE_EC2_ADOT_SIGV4_CLIENT_CALL_LOG("/expected-data-template/node/ec2/adot-sigv4/client-call-log.mustache"),
+  NODE_EC2_ADOT_SIGV4_CLIENT_CALL_METRIC("/expected-data-template/node/ec2/adot-sigv4/client-call-metric.mustache"),
+  NODE_EC2_ADOT_SIGV4_CLIENT_CALL_TRACE("/expected-data-template/node/ec2/adot-sigv4/client-call-trace.mustache"),
+
   /** Node ECS Test Case Validations */
   NODE_ECS_HC_CALL_LOG("/expected-data-template/node/ecs/hc-log.mustache"),
   NODE_ECS_HC_CALL_METRIC("/expected-data-template/node/ecs/hc-metric.mustache"),

--- a/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/aws-sdk-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/aws-sdk-call-log.mustache
@@ -1,0 +1,46 @@
+[{
+  "name": "GET",
+  "kind": "SERVER",
+  "resource": {
+    "attributes": {
+      "service.name": "{{serviceName}}",
+      "cloud.provider": "aws",
+      "cloud.region": "{{region}}",
+      "cloud.account.id": "{{accountId}}",
+      "cloud.platform": "aws_ec2"
+    }
+  },
+  "attributes": {
+    "aws.local.service": "{{serviceName}}",
+    "aws.local.environment": "ec2:default",
+    "aws.local.operation": "GET /aws-sdk-call",
+    "aws.span.kind": "LOCAL_ROOT",
+    "http.url": "^{{endpoint}}/aws-sdk-call\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
+    "http.target": "^/aws-sdk-call\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
+    "http.method": "GET",
+    "PlatformType": "AWS::EC2"
+  }
+},
+{
+  "name": "S3.GetBucketLocation",
+  "kind": "CLIENT",
+  "resource": {
+    "attributes": {
+      "service.name": "{{serviceName}}",
+      "cloud.provider": "aws",
+      "cloud.region": "{{region}}",
+      "cloud.account.id": "{{accountId}}",
+      "cloud.platform": "aws_ec2"
+    }
+  },
+  "attributes": {
+    "aws.local.service": "{{serviceName}}",
+    "aws.local.operation": "UnmappedOperation",
+    "aws.remote.service": "AWS::S3",
+    "aws.remote.operation": "GetBucketLocation",
+    "aws.local.environment": "ec2:default",
+    "aws.s3.bucket": "e2e-test-bucket-name-{{testingId}}",
+    "aws.span.kind": "CLIENT",
+    "PlatformType": "AWS::EC2"
+  }
+}]

--- a/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/aws-sdk-call-metric.mustache
@@ -1,0 +1,227 @@
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: UnmappedOperation
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: UnmappedOperation
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /aws-sdk-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: UnmappedOperation
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3

--- a/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/aws-sdk-call-trace.mustache
@@ -1,0 +1,65 @@
+[{
+  "name": "^{{serviceName}}$",
+  "http": {
+    "request": {
+      "url": "^{{endpoint}}/aws-sdk-call\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
+      "method": "^GET$"
+    }
+  },
+  "aws": {
+    "ec2": {
+      "instance_id": "^{{instanceId}}$"
+    },
+    "span.kind": "^LOCAL_ROOT$"
+  },
+  "annotations": {
+    "aws.local.service": "^{{serviceName}}$",
+    "aws.local.operation": "^GET /aws-sdk-call$",
+    "aws.local.environment": "^ec2:default$",
+    "span.name": "^GET$",
+    "span.kind": "^SERVER$"
+  },
+  "metadata": {
+    "http.url": "^{{endpoint}}/aws-sdk-call\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
+    "http.method": "^GET$",
+    "http.target": "^/aws-sdk-call\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
+    "service.name": "^{{serviceName}}$",
+    "cloud.provider": "^aws$",
+    "cloud.account.id": "^{{accountId}}$",
+    "cloud.region": "^{{region}}$",
+    "cloud.platform": "^aws_ec2$",
+    "PlatformType": "^AWS::EC2$"
+  },
+  "subsegments": [
+    {
+      "name": "^S3$",
+      "aws": {
+        "bucket_name": "^e2e-test-bucket-name-{{testingId}}$",
+        "s3.bucket": "^e2e-test-bucket-name-{{testingId}}$",
+        "span.kind": "^CLIENT$"
+      },
+      "annotations": {
+        "aws.local.service": "^{{serviceName}}$",
+        "aws.local.operation": "^UnmappedOperation$",
+        "aws.remote.service": "^AWS::S3$",
+        "aws.remote.operation": "^GetBucketLocation$",
+        "aws.local.environment": "^ec2:default$",
+        "span.name": "^S3.GetBucketLocation$",
+        "span.kind": "^CLIENT$"
+      },
+      "namespace": "^aws$"
+    }
+  ]
+},
+{
+  "name": "^S3$",
+  "aws": {
+    "bucket_name": "^e2e-test-bucket-name-{{testingId}}$",
+    "s3.bucket": "^e2e-test-bucket-name-{{testingId}}$",
+    "span.kind": "^CLIENT$"
+  },
+  "annotations": {
+    "aws.local.service": "^AWS::S3$",
+    "aws.local.operation": "^GetBucketLocation$"
+  }
+}]

--- a/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/client-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/client-call-log.mustache
@@ -1,0 +1,47 @@
+[{
+  "name": "GET",
+  "kind": "SERVER",
+  "resource": {
+    "attributes": {
+      "service.name": "{{serviceName}}",
+      "cloud.provider": "aws",
+      "cloud.region": "{{region}}",
+      "cloud.account.id": "{{accountId}}",
+      "cloud.platform": "aws_ec2"
+    }
+  },
+  "attributes": {
+    "aws.local.service": "{{serviceName}}",
+    "aws.local.environment": "ec2:default",
+    "aws.local.operation": "GET /client-call",
+    "aws.span.kind": "LOCAL_ROOT",
+    "http.url": "{{endpoint}}/client-call",
+    "http.target": "/client-call",
+    "http.method": "GET",
+    "PlatformType": "AWS::EC2"
+  }
+},
+{
+  "name": "GET",
+  "kind": "CLIENT",
+  "resource": {
+    "attributes": {
+      "service.name": "{{serviceName}}",
+      "cloud.provider": "aws",
+      "cloud.region": "{{region}}",
+      "cloud.account.id": "{{accountId}}",
+      "cloud.platform": "aws_ec2"
+    }
+  },
+  "attributes": {
+    "aws.local.service": "{{serviceName}}",
+    "aws.local.operation": "InternalOperation",
+    "aws.remote.service": "local-root-client-call",
+    "aws.remote.operation": "GET /",
+    "aws.local.environment": "ec2:default",
+    "aws.span.kind": "LOCAL_ROOT",
+    "http.url": "http://local-root-client-call/",
+    "http.method": "GET",
+    "PlatformType": "AWS::EC2"
+  }
+}]

--- a/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/client-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/client-call-metric.mustache
@@ -1,0 +1,227 @@
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: local-root-client-call
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: local-root-client-call
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Operation
+      value: InternalOperation
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: local-root-client-call
+    -
+      name: RemoteOperation
+      value: GET /
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: local-root-client-call

--- a/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/client-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/client-call-trace.mustache
@@ -1,0 +1,72 @@
+[{
+  "name": "^{{serviceName}}$",
+  "aws": {
+    "ec2": {
+      "instance_id": "^{{instanceId}}$"
+    }
+  },
+  "annotations": {
+    "aws.local.service": "^{{serviceName}}$",
+    "aws.local.operation": "^InternalOperation$",
+    "aws.local.environment": "^ec2:default$",
+    "span.name": "^InternalOperation$",
+    "span.kind": "^SERVER$"
+  },
+  "metadata": {
+    "service.name": "^{{serviceName}}$",
+    "cloud.provider": "^aws$",
+    "cloud.account.id": "^{{accountId}}$",
+    "cloud.region": "^{{region}}$",
+    "cloud.platform": "^aws_ec2$"
+  },
+  "subsegments": [
+    {
+      "name": "^local-root-client-call$",
+      "http": {
+        "request": {
+          "url": "^http://local-root-client-call/$",
+          "method": "^GET$"
+        }
+      },
+      "aws": {
+        "ec2": {
+          "instance_id": "^{{instanceId}}$"
+        },
+        "span.kind": "^LOCAL_ROOT$"
+      },
+      "annotations": {
+        "aws.local.service": "^{{serviceName}}$",
+        "aws.local.operation": "^InternalOperation$",
+        "aws.remote.service": "^local-root-client-call$",
+        "aws.remote.operation": "GET /",
+        "aws.local.environment": "^ec2:default$",
+        "span.name": "^GET$",
+        "span.kind": "^CLIENT$"
+      },
+      "metadata": {
+        "service.name": "^{{serviceName}}$",
+        "http.url": "^http://local-root-client-call/$",
+        "http.method": "^GET$",
+        "http.target": "^/$",
+        "cloud.provider": "^aws$",
+        "cloud.account.id": "^{{accountId}}$",
+        "cloud.region": "^{{region}}$",
+        "cloud.platform": "^aws_ec2$"
+      },
+      "namespace": "^remote$"
+    }
+  ]
+},
+{
+  "name": "^local-root-client-call$",
+  "http": {
+    "request": {
+      "url": "^http://local-root-client-call/$",
+      "method": "^GET$"
+    }
+  },
+  "annotations": {
+    "aws.local.service": "^local-root-client-call$",
+    "aws.local.operation": "^GET /$"
+  }
+}]

--- a/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/outgoing-http-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/outgoing-http-call-log.mustache
@@ -1,0 +1,47 @@
+[{
+  "name": "GET",
+  "kind": "SERVER",
+  "resource": {
+    "attributes": {
+      "service.name": "{{serviceName}}",
+      "cloud.provider": "aws",
+      "cloud.region": "{{region}}",
+      "cloud.account.id": "{{accountId}}",
+      "cloud.platform": "aws_ec2"
+    }
+  },
+  "attributes": {
+    "aws.local.service": "{{serviceName}}",
+    "aws.local.environment": "ec2:default",
+    "aws.local.operation": "GET /outgoing-http-call",
+    "aws.span.kind": "LOCAL_ROOT",
+    "http.url": "{{endpoint}}/outgoing-http-call",
+    "http.target": "/outgoing-http-call",
+    "http.method": "GET",
+    "PlatformType": "AWS::EC2"
+  }
+},
+{
+  "name": "GET",
+  "kind": "CLIENT",
+  "resource": {
+    "attributes": {
+      "service.name": "{{serviceName}}",
+      "cloud.provider": "aws",
+      "cloud.region": "{{region}}",
+      "cloud.account.id": "{{accountId}}",
+      "cloud.platform": "aws_ec2"
+    }
+  },
+  "attributes": {
+    "aws.local.service": "{{serviceName}}",
+    "aws.local.operation": "UnmappedOperation",
+    "aws.remote.service": "www.amazon.com:80",
+    "aws.remote.operation": "GET /",
+    "aws.local.environment": "ec2:default",
+    "aws.span.kind": "CLIENT",
+    "http.url": "^http://www.amazon.com/$",
+    "http.method": "GET",
+    "PlatformType": "AWS::EC2"
+  }
+}]

--- a/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/outgoing-http-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/outgoing-http-call-metric.mustache
@@ -1,0 +1,227 @@
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /outgoing-http-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: UnmappedOperation
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /outgoing-http-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: UnmappedOperation
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /outgoing-http-call
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: UnmappedOperation
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com:80
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: www.amazon.com:80

--- a/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/outgoing-http-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/outgoing-http-call-trace.mustache
@@ -1,0 +1,57 @@
+[{
+  "name": "^{{serviceName}}$",
+  "http": {
+    "request": {
+      "url": "^{{endpoint}}/outgoing-http-call$",
+      "method": "^GET$"
+    }
+  },
+  "aws": {
+    "ec2": {
+      "instance_id": "^{{instanceId}}$"
+    },
+    "span.kind": "^LOCAL_ROOT$"
+  },
+  "annotations": {
+    "aws.local.service": "^{{serviceName}}$",
+    "aws.local.operation": "^GET /outgoing-http-call$",
+    "aws.local.environment": "^ec2:default$",
+    "span.name": "^GET$",
+    "span.kind": "^SERVER$"
+  },
+  "metadata": {
+    "http.url": "^{{endpoint}}/outgoing-http-call$",
+    "http.method": "^GET$",
+    "http.target": "^/outgoing-http-call$",
+    "service.name": "^{{serviceName}}$",
+    "cloud.provider": "^aws$",
+    "cloud.account.id": "^{{accountId}}$",
+    "cloud.region": "^{{region}}$",
+    "cloud.platform": "^aws_ec2$",
+    "PlatformType": "^AWS::EC2$"
+  },
+  "subsegments": [
+    {
+      "name": "^www.amazon.com:80$",
+      "http": {
+        "request": {
+          "url": "^http://www.amazon.com/$",
+          "method": "^GET$"
+        }
+      },
+      "annotations": {
+        "aws.local.service": "^{{serviceName}}$",
+        "aws.local.operation": "^UnmappedOperation$",
+        "aws.remote.service": "^www.amazon.com:80$",
+        "aws.remote.operation": "^GET /$",
+        "aws.local.environment": "^ec2:default$",
+        "span.name": "^GET$",
+        "span.kind": "^CLIENT$"
+      },
+      "namespace": "^remote$"
+    }
+  ]
+},
+{
+  "name": "^www.amazon.com:80$"
+}]

--- a/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/remote-service-log.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/remote-service-log.mustache
@@ -1,0 +1,47 @@
+[{
+  "name": "GET",
+  "kind": "SERVER",
+  "resource": {
+    "attributes": {
+      "service.name": "{{serviceName}}",
+      "cloud.provider": "aws",
+      "cloud.region": "{{region}}",
+      "cloud.account.id": "{{accountId}}",
+      "cloud.platform": "aws_ec2"
+    }
+  },
+  "attributes": {
+    "aws.local.service": "{{serviceName}}",
+    "aws.local.environment": "ec2:default",
+    "aws.local.operation": "GET /remote-service",
+    "aws.span.kind": "LOCAL_ROOT",
+    "http.url": "^{{endpoint}}/remote-service\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
+    "http.target": "^/remote-service\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
+    "http.method": "GET",
+    "PlatformType": "AWS::EC2"
+  }
+},
+{
+  "name": "GET",
+  "kind": "CLIENT",
+  "resource": {
+    "attributes": {
+      "service.name": "{{serviceName}}",
+      "cloud.provider": "aws",
+      "cloud.region": "{{region}}",
+      "cloud.account.id": "{{accountId}}",
+      "cloud.platform": "aws_ec2"
+    }
+  },
+  "attributes": {
+    "aws.local.service": "{{serviceName}}",
+    "aws.local.operation": "UnmappedOperation",
+    "aws.remote.service": "{{remoteServiceDeploymentName}}",
+    "aws.remote.operation": "GET /healthcheck",
+    "aws.local.environment": "ec2:default",
+    "aws.span.kind": "CLIENT",
+    "http.url": "http://{{remoteServiceDeploymentName}}/healthcheck",
+    "http.method": "GET",
+    "PlatformType": "AWS::EC2"
+  }
+}]

--- a/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/remote-service-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/remote-service-metric.mustache
@@ -1,0 +1,326 @@
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: UnmappedOperation
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: Operation
+      value: GET /healthcheck
+    -
+      name: Service
+      value: {{remoteServiceName}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{remoteServiceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: UnmappedOperation
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: Operation
+      value: GET /healthcheck
+    -
+      name: Service
+      value: {{remoteServiceName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{remoteServiceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Error
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: GET /remote-service
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Operation
+      value: UnmappedOperation
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: Operation
+      value: GET /healthcheck
+    -
+      name: Service
+      value: {{remoteServiceName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{remoteServiceName}}
+    -
+      name: Environment
+      value: ec2:default
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: ec2:default
+    -
+      name: RemoteOperation
+      value: GET /healthcheck
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}
+
+-
+  metricName: Fault
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: RemoteService
+      value: {{remoteServiceDeploymentName}}

--- a/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/remote-service-trace.mustache
@@ -1,0 +1,72 @@
+[{
+  "name": "^{{serviceName}}$",
+  "http": {
+    "request": {
+      "url": "^{{endpoint}}/remote-service\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
+      "method": "^GET$"
+    },
+    "response": {
+      "status": "^200$"
+    }
+  },
+  "aws": {
+    "ec2": {
+      "instance_id": "^{{instanceId}}$"
+    },
+    "span.kind": "^LOCAL_ROOT$"
+  },
+  "annotations": {
+    "aws.local.service": "^{{serviceName}}$",
+    "aws.local.operation": "^GET /remote-service$",
+    "aws.local.environment": "^ec2:default$",
+    "span.name": "^GET$",
+    "span.kind": "^SERVER$"
+  },
+  "metadata": {
+    "http.url": "^{{endpoint}}/remote-service\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
+    "http.method": "^GET$",
+    "http.target": "^/remote-service\\?ip=(([0-9]{1,3}.){3}[0-9]{1,3})&testingId={{testingId}}$",
+    "service.name": "^{{serviceName}}$",
+    "cloud.provider": "^aws$",
+    "cloud.account.id": "^{{accountId}}$",
+    "cloud.region": "^{{region}}$",
+    "cloud.platform": "^aws_ec2$",
+    "PlatformType": "^AWS::EC2$"
+  },
+  "subsegments": [
+    {
+      "name": "^{{remoteServiceDeploymentName}}$",
+      "http": {
+        "request": {
+          "url": "^http://{{remoteServiceDeploymentName}}/healthcheck$",
+          "method": "^GET$"
+        }
+      },
+      "annotations": {
+        "aws.local.service": "^{{serviceName}}$",
+        "aws.local.operation": "^UnmappedOperation$",
+        "aws.remote.service": "^{{remoteServiceDeploymentName}}$",
+        "aws.remote.operation": "^GET /healthcheck$",
+        "aws.local.environment": "^ec2:default$",
+        "span.name": "^GET$",
+        "span.kind": "^CLIENT$"
+      },
+      "namespace": "^remote$"
+    }
+  ]
+},
+{
+  "name": "^{{remoteServiceName}}$",
+  "http": {
+    "request": {
+      "url": "^http://{{remoteServiceDeploymentName}}/healthcheck$",
+      "method": "^GET$"
+    }
+  },
+  "annotations": {
+    "aws.local.service": "^{{remoteServiceName}}$",
+    "aws.local.operation": "^GET /healthcheck$"
+  }
+}]
+
+

--- a/validator/src/main/resources/validations/node/ec2/adot-sigv4/log-validation.yml
+++ b/validator/src/main/resources/validations/node/ec2/adot-sigv4/log-validation.yml
@@ -1,0 +1,24 @@
+-
+  validationType: "cw-log"
+  httpPath: "outgoing-http-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedLogStructureTemplate: "NODE_EC2_ADOT_SIGV4_OUTGOING_HTTP_CALL_LOG"
+-
+  validationType: "cw-log"
+  httpPath: "aws-sdk-call"
+  httpMethod: "get"
+  callingType: "http-with-query"
+  expectedLogStructureTemplate: "NODE_EC2_ADOT_SIGV4_AWS_SDK_CALL_LOG"
+-
+  validationType: "cw-log"
+  httpPath: "remote-service"
+  httpMethod: "get"
+  callingType: "http-with-query"
+  expectedLogStructureTemplate: "NODE_EC2_ADOT_SIGV4_REMOTE_SERVICE_LOG"
+-
+  validationType: "cw-log"
+  httpPath: "client-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedLogStructureTemplate: "NODE_EC2_ADOT_SIGV4_CLIENT_CALL_LOG"

--- a/validator/src/main/resources/validations/node/ec2/adot-sigv4/metric-validation.yml
+++ b/validator/src/main/resources/validations/node/ec2/adot-sigv4/metric-validation.yml
@@ -1,0 +1,24 @@
+-
+  validationType: "cw-metric"
+  httpPath: "outgoing-http-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedMetricTemplate: "NODE_EC2_ADOT_SIGV4_OUTGOING_HTTP_CALL_METRIC"
+-
+  validationType: "cw-metric"
+  httpPath: "aws-sdk-call"
+  httpMethod: "get"
+  callingType: "http-with-query"
+  expectedMetricTemplate: "NODE_EC2_ADOT_SIGV4_AWS_SDK_CALL_METRIC"
+-
+  validationType: "cw-metric"
+  httpPath: "remote-service"
+  httpMethod: "get"
+  callingType: "http-with-query"
+  expectedMetricTemplate: "NODE_EC2_ADOT_SIGV4_REMOTE_SERVICE_METRIC"
+-
+  validationType: "cw-metric"
+  httpPath: "client-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedMetricTemplate: "NODE_EC2_ADOT_SIGV4_CLIENT_CALL_METRIC"

--- a/validator/src/main/resources/validations/node/ec2/adot-sigv4/trace-validation.yml
+++ b/validator/src/main/resources/validations/node/ec2/adot-sigv4/trace-validation.yml
@@ -1,0 +1,24 @@
+-
+  validationType: "trace"
+  httpPath: "/outgoing-http-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedTraceTemplate: "NODE_EC2_ADOT_SIGV4_OUTGOING_HTTP_CALL_TRACE"
+-
+  validationType: "trace"
+  httpPath: "/aws-sdk-call"
+  httpMethod: "get"
+  callingType: "http-with-query"
+  expectedTraceTemplate: "NODE_EC2_ADOT_SIGV4_AWS_SDK_CALL_TRACE"
+-
+  validationType: "trace"
+  httpPath: "/remote-service"
+  httpMethod: "get"
+  callingType: "http-with-query"
+  expectedTraceTemplate: "NODE_EC2_ADOT_SIGV4_REMOTE_SERVICE_TRACE"
+-
+  validationType: "trace"
+  httpPath: "/client-call"
+  httpMethod: "get"
+  callingType: "http"
+  expectedTraceTemplate: "NODE_EC2_ADOT_SIGV4_CLIENT_CALL_TRACE"


### PR DESCRIPTION
## Background

We recently added the ADOT SigV4 exporter to the aws-otel-js-instrumentation repo that allows users to export spans directly the the X-Ray OTLP endpoint from their application instead of relying on a collector or agent.

## Changes
Added workflow, terraform definitions, and validations

## Notable differences in behaviour between JS and other languages for this use case
- [TRACE] `span.name` always seems to be `GET` instead of `GET api` or `GET /api`
- [LOG] `resource.attributes.["aws.local.service"]` is missing for all APIs
- [LOG] `attributes.["aws.region"]` is missing for `/aws-sdk-call` API (`resource.attributes.["cloud.region"]` is still present)

## Rollback Procedure

Revert

## Testing

Successful run: [link](https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/13911832946)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
