### PR TITLE
[.NET] Add Performance Testing Workflow for Lambda Layer

### DIFF
--- a/.github/workflows/dotnet-lambda-layer-perf-test.yml
+++ b/.github/workflows/dotnet-lambda-layer-perf-test.yml
@@ -3,9 +3,6 @@
 
 name: DotNet Lambda Layer Performance Test
 on:
-  push:
-    branches: 
-        - perf_testing_lambda_layer_dotnet
   workflow_dispatch:
     inputs:
       test_runs:
@@ -13,6 +10,12 @@ on:
         required: true
         default: 20
         type: number
+        
+      dotnet-version:
+        description: 'dotnet version to use'
+        required: true
+        default: '8.0.x'
+        type: string  
     
 jobs:
   dotnet-lambda-layer-performance-test:
@@ -37,10 +40,18 @@ jobs:
         repository: aws-observability/aws-otel-dotnet-instrumentation
         path: aws-otel-dotnet-instrumentation
 
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ github.event.inputs.dotnet-version }}
+    
+    - name: Setup AWS Lambda Tools
+      run: dotnet tool install -g Amazon.Lambda.Tools
+
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v2
 
-    - name: Build and Deploy DotNet Sample App and Lambda Layer
+    - name: Build and Deploy .NET Sample App and Lambda Layer
       run: |
         cd aws-otel-dotnet-instrumentation/sample-applications/lambda-test-apps/SimpleLambdaFunction/
         ./build-and-deploy.sh
@@ -87,7 +98,7 @@ jobs:
     - name: Upload test results
       uses: actions/upload-artifact@v4
       with:
-        name: performance-test-results
+        name: dotnet-performance-test-results
         path: |
             no_layer_results.txt
             layer_results.txt

--- a/.github/workflows/dotnet-lambda-layer-perf-test.yml
+++ b/.github/workflows/dotnet-lambda-layer-perf-test.yml
@@ -1,0 +1,102 @@
+## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+
+name: DotNet Lambda Layer Performance Test
+on:
+  push:
+    branches: 
+        - perf_testing_lambda_layer_dotnet
+  workflow_dispatch:
+    inputs:
+      test_runs:
+        description: 'Number of test runs to perform'
+        required: true
+        default: 20
+        type: number
+    
+jobs:
+  dotnet-lambda-layer-performance-test:
+    runs-on: ubuntu-latest 
+    permissions:
+        id-token: write
+        contents: read   
+
+    env:
+      NUM_TEST_RUNS: ${{ github.event.inputs.test_runs }}
+  
+    steps:
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}:role/${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
+        aws-region: us-east-1     
+
+    - name: Checkout aws-otel-dotnet-instrumentation
+      uses: actions/checkout@v4
+      with:
+        repository: aws-observability/aws-otel-dotnet-instrumentation
+        path: aws-otel-dotnet-instrumentation
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v2
+
+    - name: Build and Deploy DotNet Sample App and Lambda Layer
+      run: |
+        cd aws-otel-dotnet-instrumentation/sample-applications/lambda-test-apps/SimpleLambdaFunction/
+        ./build-and-deploy.sh
+
+    - name: Checkout current repository
+      uses: actions/checkout@v4
+      with:
+        path: current-repo
+    
+    - name: Run Cold Start Iterations for Base Lambda + Lambda Layer
+      run: |
+        cd current-repo
+        chmod +x lambda-layer-perf-test/lambda-layer-run.sh
+        ./lambda-layer-perf-test/lambda-layer-run.sh false SimpleLambdaFunction
+
+    - name: Remove Application Signals Lambda Layer
+      run: |
+          echo "Removing Lambda layer..."
+          
+          OUTPUT=$(aws lambda update-function-configuration \
+              --function-name SimpleLambdaFunction \
+              --layers [])
+  
+          echo "Lambda configuration:"
+          echo "$OUTPUT"
+  
+          LAYERS=$(echo "$OUTPUT" | jq -r '.Layers | length')
+  
+          if [ "$LAYERS" -ne 0 ]; then
+              echo "::error::Found $LAYERS layer(s) still attached to the function"
+              echo "::error::Layer details:"
+              echo "$OUTPUT" | jq -r '.Layers'
+              exit 1
+          else
+              echo "✅ Layers successfully removed"
+          fi
+ 
+    - name: Run Cold Start Iterations for Base Lambda
+      run: |
+        cd current-repo
+        chmod +x lambda-layer-perf-test/lambda-layer-run.sh
+        ./lambda-layer-perf-test/lambda-layer-run.sh true SimpleLambdaFunction
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v4
+      with:
+        name: performance-test-results
+        path: |
+            no_layer_results.txt
+            layer_results.txt
+        retention-days: 90
+
+    - name: Cleanup Terraform Resources
+      if: success() || failure() || cancelled()
+      run: |
+        cd aws-otel-dotnet-instrumentation/sample-applications/lambda-test-apps/SimpleLambdaFunction/terraform/lambda
+        echo "Starting Terraform cleanup..."
+        terraform init
+        terraform destroy -auto-approve

--- a/.github/workflows/node-lambda-layer-perf-test.yml
+++ b/.github/workflows/node-lambda-layer-perf-test.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Upload test results
       uses: actions/upload-artifact@v4
       with:
-        name: performance-test-results
+        name: js-performance-test-results
         path: |
             no_layer_results.txt
             layer_results.txt

--- a/.github/workflows/python-lambda-layer-perf-test.yml
+++ b/.github/workflows/python-lambda-layer-perf-test.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Upload test results
       uses: actions/upload-artifact@v4
       with:
-        name: performance-test-results
+        name: python-performance-test-results
         path: |
           no_layer_results.txt
           layer_results.txt


### PR DESCRIPTION
**Issue description:**
Added a workflow to automatically performance test and gather the results for the unreleased .NET Lambda Layer.

**The GitHub workflow does the following:**
1. Deploy and setup the .NET Lambda sample application instrumented with the Application Signals Lambda Layer on the AppSignals e2e testing aws account.
2. Record the start time of the test and run the specified amount (default: 20) Lambda cold start iterations on the sample application
3. Record the end time of the test
4. Query CW Logs Insights for the aggregated performance testing metrics with the following query:
```
fields @timestamp, @message, @initDuration
| filter @message like "REPORT RequestId"
| stats
    count(@initDuration) as Sample_Count,
    avg(@initDuration) as Average_Init_Duration,
    min(@initDuration) as Min_Init_Duration,
    max(@initDuration) as Max_Init_Duration,
    pct(@initDuration, 50) as P50_Init_Duration,
    pct(@initDuration, 90) as P90_Init_Duration,
    pct(@initDuration, 99) as P99_Init_Duration'
```
5. Parse and flatten the result from the query call and save it in a file.
6. Clean and destroy the deployed lambda resources upon completion, cancellation, or failure.

**Testing**
Testing was done on a personal aws dev account with the exact IAM permissions as the e2e testing aws account.
Example of a successful job:

https://github.com/liustve/aws-application-signals-test-framework/actions/runs/14389946356