### PR TITLE
Java sig v4 test

### DIFF
--- a/.github/workflows/java-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/java-ec2-adot-sigv4-test.yml
@@ -58,6 +58,9 @@ jobs:
         id: job-started
         run: echo "job-started=true" >> $GITHUB_OUTPUT
 
+      - name: Print all environment variables
+        run: env
+
       - name: Generate testing id
         run: echo TESTING_ID="${{ github.run_id }}-${{ github.run_number }}-${RANDOM}" >> $GITHUB_ENV
 
@@ -89,11 +92,11 @@ jobs:
 
       - name: Set ADOT getter command environment variable
         run: |
-          if [ "${{ github.event.repository.name }}" = "aws-otel-java-instrumentation" ]; then
-            echo GET_ADOT_JAR_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/aws-opentelemetry-agent.jar ./adot.jar" >> $GITHUB_ENV
-          else
-            echo GET_ADOT_JAR_COMMAND="wget -O adot.jar https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar" >> $GITHUB_ENV
-          fi
+          # if [ "${{ github.event.repository.name }}" = "aws-otel-java-instrumentation" ]; then
+          echo GET_ADOT_JAR_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/aws-opentelemetry-agent.jar ./adot.jar" >> $GITHUB_ENV
+          # else
+          #   echo GET_ADOT_JAR_COMMAND="wget -O adot.jar https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar" >> $GITHUB_ENV
+          # fi
 
       - name: Set up terraform
         uses: ./.github/workflows/actions/execute_and_retry

--- a/.github/workflows/java-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/java-ec2-adot-sigv4-test.yml
@@ -8,9 +8,6 @@
 # This test case validates ADOT used on its own to send traces to the X-Ray OTLP endpoint with SigV4 authentication
 name: Java EC2 ADOT SigV4 (Stand-Alone ADOT) Use Case
 on:
-  push:
-    branches:
-      - Java_SigV4_Test
   workflow_call:
     inputs:
       caller-workflow-name:
@@ -40,8 +37,8 @@ env:
   E2E_TEST_AWS_REGION: 'us-west-2' # Test uses us-west-2 in the us-east-1 accoun
   CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
   METRIC_NAMESPACE: ApplicationSignals
-  JAVA_VERSION: ${{ inputs.java-version || '11' }}
-  CPU_ARCHITECTURE: ${{ inputs.cpu-architecture  || 'x86_64' }}
+  JAVA_VERSION: ${{ inputs.java-version }}
+  CPU_ARCHITECTURE: ${{ inputs.cpu-architecture }}
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }} # us-east-1 test account
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
   LOG_GROUP_NAME: aws/spans
@@ -57,9 +54,6 @@ jobs:
       - name: Check if the job started
         id: job-started
         run: echo "job-started=true" >> $GITHUB_OUTPUT
-
-      - name: Print all environment variables
-        run: env
 
       - name: Generate testing id
         run: echo TESTING_ID="${{ github.run_id }}-${{ github.run_number }}-${RANDOM}" >> $GITHUB_ENV
@@ -92,11 +86,11 @@ jobs:
 
       - name: Set ADOT getter command environment variable
         run: |
-          # if [ "${{ github.event.repository.name }}" = "aws-otel-java-instrumentation" ]; then
-          echo GET_ADOT_JAR_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/aws-opentelemetry-agent.jar ./adot.jar" >> $GITHUB_ENV
-          # else
-          #   echo GET_ADOT_JAR_COMMAND="wget -O adot.jar https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar" >> $GITHUB_ENV
-          # fi
+          if [ "${{ github.event.repository.name }}" = "aws-otel-java-instrumentation" ]; then
+            echo GET_ADOT_JAR_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/aws-opentelemetry-agent.jar ./adot.jar" >> $GITHUB_ENV
+          else
+            echo GET_ADOT_JAR_COMMAND="wget -O adot.jar https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar" >> $GITHUB_ENV
+          fi
 
       - name: Set up terraform
         uses: ./.github/workflows/actions/execute_and_retry

--- a/.github/workflows/java-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/java-ec2-adot-sigv4-test.yml
@@ -8,6 +8,9 @@
 # This test case validates ADOT used on its own to send traces to the X-Ray OTLP endpoint with SigV4 authentication
 name: Java EC2 ADOT SigV4 (Stand-Alone ADOT) Use Case
 on:
+  push:
+    branches:
+      - Java_SigV4_Test
   workflow_call:
     inputs:
       caller-workflow-name:
@@ -37,8 +40,8 @@ env:
   E2E_TEST_AWS_REGION: 'us-west-2' # Test uses us-west-2 in the us-east-1 accoun
   CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
   METRIC_NAMESPACE: ApplicationSignals
-  JAVA_VERSION: ${{ inputs.java-version }}
-  CPU_ARCHITECTURE: ${{ inputs.cpu-architecture }}
+  JAVA_VERSION: ${{ inputs.java-version || '11' }}
+  CPU_ARCHITECTURE: ${{ inputs.cpu-architecture  || 'x86_64' }}
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }} # us-east-1 test account
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
   LOG_GROUP_NAME: aws/spans
@@ -86,11 +89,11 @@ jobs:
 
       - name: Set ADOT getter command environment variable
         run: |
-          if [ "${{ github.event.repository.name }}" = "aws-otel-java-instrumentation" ]; then
-            echo GET_ADOT_JAR_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/aws-opentelemetry-agent.jar ./adot.jar" >> $GITHUB_ENV
-          else
-            echo GET_ADOT_JAR_COMMAND="wget -O adot.jar https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar" >> $GITHUB_ENV
-          fi
+          # if [ "${{ github.event.repository.name }}" = "aws-otel-java-instrumentation" ]; then
+          echo GET_ADOT_JAR_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/aws-opentelemetry-agent.jar ./adot.jar" >> $GITHUB_ENV
+          # else
+          #   echo GET_ADOT_JAR_COMMAND="wget -O adot.jar https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar" >> $GITHUB_ENV
+          # fi
 
       - name: Set up terraform
         uses: ./.github/workflows/actions/execute_and_retry
@@ -181,7 +184,7 @@ jobs:
         run: ./gradlew validator:run --args='-c java/ec2/adot-sigv4/log-validation.yml
               --testing-id ${{ env.TESTING_ID }}
               --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
-              --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8080
+              --remote-service-deployment-name sample-remote-application-${{ env.TESTING_ID }}
               --region ${{ env.E2E_TEST_AWS_REGION }}
               --account-id ${{ env.E2E_TEST_ACCOUNT_ID }}
               --metric-namespace ${{ env.METRIC_NAMESPACE }}
@@ -217,7 +220,7 @@ jobs:
         run: ./gradlew validator:run --args='-c java/ec2/adot-sigv4/trace-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
-          --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8080
+          --remote-service-deployment-name sample-remote-application-${{ env.TESTING_ID }}
           --region ${{ env.E2E_TEST_AWS_REGION }}
           --account-id ${{ env.E2E_TEST_ACCOUNT_ID }}
           --metric-namespace ${{ env.METRIC_NAMESPACE }}

--- a/.github/workflows/java-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/java-ec2-adot-sigv4-test.yml
@@ -205,7 +205,7 @@ jobs:
         run: ./gradlew validator:run --args='-c java/ec2/adot-sigv4/metric-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
-          --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8080
+          --remote-service-deployment-name sample-remote-application-${{ env.TESTING_ID }}
           --region ${{ env.E2E_TEST_AWS_REGION }}
           --account-id ${{ env.E2E_TEST_ACCOUNT_ID }}
           --metric-namespace ${{ env.METRIC_NAMESPACE }}

--- a/.github/workflows/java-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/java-ec2-adot-sigv4-test.yml
@@ -8,9 +8,6 @@
 # This test case validates ADOT used on its own to send traces to the X-Ray OTLP endpoint with SigV4 authentication
 name: Java EC2 ADOT SigV4 (Stand-Alone ADOT) Use Case
 on:
-  push:
-    branches:
-      - Java_SigV4_Test
   workflow_call:
     inputs:
       caller-workflow-name:
@@ -40,8 +37,8 @@ env:
   E2E_TEST_AWS_REGION: 'us-west-2' # Test uses us-west-2 in the us-east-1 accoun
   CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
   METRIC_NAMESPACE: ApplicationSignals
-  JAVA_VERSION: ${{ inputs.java-version || '11' }}
-  CPU_ARCHITECTURE: ${{ inputs.cpu-architecture  || 'x86_64' }}
+  JAVA_VERSION: ${{ inputs.java-version }}
+  CPU_ARCHITECTURE: ${{ inputs.cpu-architecture }}
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }} # us-east-1 test account
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
   LOG_GROUP_NAME: aws/spans
@@ -89,11 +86,11 @@ jobs:
 
       - name: Set ADOT getter command environment variable
         run: |
-          # if [ "${{ github.event.repository.name }}" = "aws-otel-java-instrumentation" ]; then
-          echo GET_ADOT_JAR_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/aws-opentelemetry-agent.jar ./adot.jar" >> $GITHUB_ENV
-          # else
-          #   echo GET_ADOT_JAR_COMMAND="wget -O adot.jar https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar" >> $GITHUB_ENV
-          # fi
+          if [ "${{ github.event.repository.name }}" = "aws-otel-java-instrumentation" ]; then
+            echo GET_ADOT_JAR_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/aws-opentelemetry-agent.jar ./adot.jar" >> $GITHUB_ENV
+          else
+            echo GET_ADOT_JAR_COMMAND="wget -O adot.jar https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar" >> $GITHUB_ENV
+          fi
 
       - name: Set up terraform
         uses: ./.github/workflows/actions/execute_and_retry
@@ -184,7 +181,7 @@ jobs:
         run: ./gradlew validator:run --args='-c java/ec2/adot-sigv4/log-validation.yml
               --testing-id ${{ env.TESTING_ID }}
               --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
-              --remote-service-deployment-name sample-remote-application-${{ env.TESTING_ID }}
+              --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8080
               --region ${{ env.E2E_TEST_AWS_REGION }}
               --account-id ${{ env.E2E_TEST_ACCOUNT_ID }}
               --metric-namespace ${{ env.METRIC_NAMESPACE }}
@@ -220,7 +217,7 @@ jobs:
         run: ./gradlew validator:run --args='-c java/ec2/adot-sigv4/trace-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
-          --remote-service-deployment-name sample-remote-application-${{ env.TESTING_ID }}
+          --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8080
           --region ${{ env.E2E_TEST_AWS_REGION }}
           --account-id ${{ env.E2E_TEST_ACCOUNT_ID }}
           --metric-namespace ${{ env.METRIC_NAMESPACE }}

--- a/.github/workflows/java-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/java-ec2-adot-sigv4-test.yml
@@ -40,8 +40,8 @@ env:
   E2E_TEST_AWS_REGION: 'us-west-2' # Test uses us-west-2 in the us-east-1 accoun
   CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
   METRIC_NAMESPACE: ApplicationSignals
-  JAVA_VERSION: ${{ inputs.java-version }}
-  CPU_ARCHITECTURE: ${{ inputs.cpu-architecture }}
+  JAVA_VERSION: ${{ inputs.java-version || '11' }}
+  CPU_ARCHITECTURE: ${{ inputs.cpu-architecture  || 'x86_64' }}
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }} # us-east-1 test account
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
   LOG_GROUP_NAME: aws/spans

--- a/.github/workflows/java-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/java-ec2-adot-sigv4-test.yml
@@ -8,6 +8,9 @@
 # This test case validates ADOT used on its own to send traces to the X-Ray OTLP endpoint with SigV4 authentication
 name: Java EC2 ADOT SigV4 (Stand-Alone ADOT) Use Case
 on:
+  push:
+    branches:
+      - Java_SigV4_Test
   workflow_call:
     inputs:
       caller-workflow-name:

--- a/validator/src/main/resources/expected-data-template/java/ec2/adot-sigv4/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/java/ec2/adot-sigv4/aws-sdk-call-metric.mustache
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -94,7 +94,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -170,7 +170,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/java/ec2/adot-sigv4/outgoing-http-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/java/ec2/adot-sigv4/outgoing-http-call-metric.mustache
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -94,7 +94,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -170,7 +170,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /outgoing-http-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/java/ec2/adot-sigv4/remote-service-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/java/ec2/adot-sigv4/remote-service-metric.mustache
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -30,7 +30,7 @@
       value: GET /healthcheck
     -
       name: RemoteService
-      value: {{remoteServiceDeploymentName}}
+      value: {{remoteServiceName}}
 
 -
   metricName: Latency
@@ -80,7 +80,7 @@
       value: ec2:default
     -
       name: RemoteService
-      value: {{remoteServiceDeploymentName}}
+      value: {{remoteServiceName}}
 
 -
   metricName: Latency
@@ -97,7 +97,7 @@
       value: GET /healthcheck
     -
       name: RemoteService
-      value: {{remoteServiceDeploymentName}}
+      value: {{remoteServiceName}}
 
 -
   metricName: Latency
@@ -105,7 +105,7 @@
   dimensions:
     -
       name: RemoteService
-      value: {{remoteServiceDeploymentName}}
+      value: {{remoteServiceName}}
 
 -
   metricName: Error
@@ -127,7 +127,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -139,7 +139,7 @@
       value: GET /healthcheck
     -
       name: RemoteService
-      value: {{remoteServiceDeploymentName}}
+      value: {{remoteServiceName}}
 
 -
   metricName: Error
@@ -189,7 +189,7 @@
       value: ec2:default
     -
       name: RemoteService
-      value: {{remoteServiceDeploymentName}}
+      value: {{remoteServiceName}}
 
 -
   metricName: Error
@@ -206,7 +206,7 @@
       value: GET /healthcheck
     -
       name: RemoteService
-      value: {{remoteServiceDeploymentName}}
+      value: {{remoteServiceName}}
 
 -
   metricName: Error
@@ -214,7 +214,7 @@
   dimensions:
     -
       name: RemoteService
-      value: {{remoteServiceDeploymentName}}
+      value: {{remoteServiceName}}
 
 -
   metricName: Fault
@@ -236,7 +236,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -248,7 +248,7 @@
       value: GET /healthcheck
     -
       name: RemoteService
-      value: {{remoteServiceDeploymentName}}
+      value: {{remoteServiceName}}
 
 -
   metricName: Fault
@@ -298,7 +298,7 @@
       value: ec2:default
     -
       name: RemoteService
-      value: {{remoteServiceDeploymentName}}
+      value: {{remoteServiceName}}
 
 -
   metricName: Fault
@@ -315,7 +315,7 @@
       value: GET /healthcheck
     -
       name: RemoteService
-      value: {{remoteServiceDeploymentName}}
+      value: {{remoteServiceName}}
 
 -
   metricName: Fault
@@ -323,4 +323,4 @@
   dimensions:
     -
       name: RemoteService
-      value: {{remoteServiceDeploymentName}}
+      value: {{remoteServiceName}}

--- a/validator/src/main/resources/expected-data-template/java/ec2/adot-sigv4/remote-service-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/java/ec2/adot-sigv4/remote-service-metric.mustache
@@ -248,7 +248,7 @@
       value: GET /healthcheck
     -
       name: RemoteService
-      value: {{remoteServiceName}}
+      value: {{remoteServiceDeploymentName}}
 
 -
   metricName: Fault
@@ -298,7 +298,7 @@
       value: ec2:default
     -
       name: RemoteService
-      value: {{remoteServiceName}}
+      value: {{remoteServiceDeploymentName}}
 
 -
   metricName: Fault
@@ -315,7 +315,7 @@
       value: GET /healthcheck
     -
       name: RemoteService
-      value: {{remoteServiceName}}
+      value: {{remoteServiceDeploymentName}}
 
 -
   metricName: Fault
@@ -323,4 +323,4 @@
   dimensions:
     -
       name: RemoteService
-      value: {{remoteServiceName}}
+      value: {{remoteServiceDeploymentName}}

--- a/validator/src/main/resources/expected-data-template/java/ec2/adot-sigv4/remote-service-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/java/ec2/adot-sigv4/remote-service-metric.mustache
@@ -30,7 +30,7 @@
       value: GET /healthcheck
     -
       name: RemoteService
-      value: {{remoteServiceName}}
+      value: {{remoteServiceDeploymentName}}
 
 -
   metricName: Latency
@@ -80,7 +80,7 @@
       value: ec2:default
     -
       name: RemoteService
-      value: {{remoteServiceName}}
+      value: {{remoteServiceDeploymentName}}
 
 -
   metricName: Latency
@@ -97,7 +97,7 @@
       value: GET /healthcheck
     -
       name: RemoteService
-      value: {{remoteServiceName}}
+      value: {{remoteServiceDeploymentName}}
 
 -
   metricName: Latency
@@ -105,7 +105,7 @@
   dimensions:
     -
       name: RemoteService
-      value: {{remoteServiceName}}
+      value: {{remoteServiceDeploymentName}}
 
 -
   metricName: Error
@@ -139,7 +139,7 @@
       value: GET /healthcheck
     -
       name: RemoteService
-      value: {{remoteServiceName}}
+      value: {{remoteServiceDeploymentName}}
 
 -
   metricName: Error
@@ -189,7 +189,7 @@
       value: ec2:default
     -
       name: RemoteService
-      value: {{remoteServiceName}}
+      value: {{remoteServiceDeploymentName}}
 
 -
   metricName: Error
@@ -206,7 +206,7 @@
       value: GET /healthcheck
     -
       name: RemoteService
-      value: {{remoteServiceName}}
+      value: {{remoteServiceDeploymentName}}
 
 -
   metricName: Error
@@ -214,7 +214,7 @@
   dimensions:
     -
       name: RemoteService
-      value: {{remoteServiceName}}
+      value: {{remoteServiceDeploymentName}}
 
 -
   metricName: Fault


### PR DESCRIPTION
*Issue description:*
The ADOT Java Sigv4 test was failing because the Xray backend team changed the value of the dimensions of Metric validator.

*Description of changes:*
The dimension values were updated to be consistent with the changes from the backend.

Test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/14766737647/job/41459572332

*Rollback procedure:*

<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
