### PR TITLE
Update Java EKS OTLP OCB canary test

### DIFF
--- a/.github/workflows/java-eks-otlp-ocb-canary.yml
+++ b/.github/workflows/java-eks-otlp-ocb-canary.yml
@@ -8,6 +8,9 @@
 ## Logs, metrics, and traces are all validated.
 name: Java EKS OTLP/OCB Enablement Canary Test
 on:
+  push:
+    branches:
+      - java-eks-otlp-ocb-test
   schedule:
     - cron: '12,37 * * * *' # run the workflow at 12th and 37th minute of every hour
   workflow_dispatch: # be able to run the workflow on demand

--- a/.github/workflows/java-eks-otlp-ocb-canary.yml
+++ b/.github/workflows/java-eks-otlp-ocb-canary.yml
@@ -8,9 +8,6 @@
 ## Logs, metrics, and traces are all validated.
 name: Java EKS OTLP/OCB Enablement Canary Test
 on:
-  push:
-    branches:
-      - java-eks-otlp-ocb-test
   schedule:
     - cron: '12,37 * * * *' # run the workflow at 12th and 37th minute of every hour
   workflow_dispatch: # be able to run the workflow on demand

--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/aws-sdk-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/aws-sdk-call-log.mustache
@@ -13,7 +13,7 @@
   "Environment": "^generic:default$",
   "PlatformType": "^Generic$",
   "Service": "^{{serviceName}}$",
-  "Operation": "UnmappedOperation",
+  "Operation": "GET /aws-sdk-call",
   "RemoteService": "AWS::S3",
   "RemoteOperation": "GetBucketLocation",
   "RemoteResourceIdentifier": "^e2e-test-bucket-name-{{testingId}}$",

--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/aws-sdk-call-metric.mustache
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -100,7 +100,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -163,7 +163,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -245,7 +245,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -308,7 +308,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -390,7 +390,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/outgoing-http-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/outgoing-http-call-log.mustache
@@ -13,7 +13,7 @@
   "Environment": "^generic:default$",
   "PlatformType": "^Generic$",
   "Service": "^{{serviceName}}$",
-  "Operation": "UnmappedOperation",
+  "Operation": "GET /outgoing-http-call",
   "RemoteService": "www.amazon.com",
   "RemoteOperation": "GET /",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"

--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/outgoing-http-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/outgoing-http-call-metric.mustache
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -94,7 +94,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -170,7 +170,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /outgoing-http-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/remote-service-log.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/remote-service-log.mustache
@@ -13,7 +13,7 @@
   "Environment": "^generic:default$",
   "PlatformType": "^Generic$",
   "Service": "^{{serviceName}}$",
-  "Operation": "UnmappedOperation",
+  "Operation": "GET /remote-service",
   "RemoteService": "{{remoteServiceIp}}:8080",
   "RemoteOperation": "GET /healthcheck",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"

--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/remote-service-log.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/remote-service-log.mustache
@@ -14,7 +14,7 @@
   "PlatformType": "^Generic$",
   "Service": "^{{serviceName}}$",
   "Operation": "GET /remote-service",
-  "RemoteService": "{{remoteServiceIp}}:8080",
+  "RemoteService": "{{remoteServiceDeploymentName}}",
   "RemoteOperation": "GET /healthcheck",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"
 }]

--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/remote-service-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/remote-service-metric.mustache
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -127,7 +127,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -236,7 +236,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /remote-service
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/remote-service-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/remote-service-metric.mustache
@@ -30,7 +30,7 @@
       value: GET /healthcheck
     -
       name: RemoteService
-      value: {{remoteServiceIp}}:8080
+      value: {{remoteServiceDeploymentName}}
 
 -
   metricName: Latency
@@ -80,7 +80,7 @@
       value: generic:default
     -
       name: RemoteService
-      value: {{remoteServiceIp}}:8080
+      value: {{remoteServiceDeploymentName}}
 
 -
   metricName: Latency
@@ -97,7 +97,7 @@
       value: GET /healthcheck
     -
       name: RemoteService
-      value: {{remoteServiceIp}}:8080
+      value: {{remoteServiceDeploymentName}}
 
 -
   metricName: Latency
@@ -105,7 +105,7 @@
   dimensions:
     -
       name: RemoteService
-      value: {{remoteServiceIp}}:8080
+      value: {{remoteServiceDeploymentName}}
 
 -
   metricName: Error
@@ -139,7 +139,7 @@
       value: GET /healthcheck
     -
       name: RemoteService
-      value: {{remoteServiceIp}}:8080
+      value: {{remoteServiceDeploymentName}}
 
 -
   metricName: Error
@@ -189,7 +189,7 @@
       value: generic:default
     -
       name: RemoteService
-      value: {{remoteServiceIp}}:8080
+      value: {{remoteServiceDeploymentName}}
 
 -
   metricName: Error
@@ -206,7 +206,7 @@
       value: GET /healthcheck
     -
       name: RemoteService
-      value: {{remoteServiceIp}}:8080
+      value: {{remoteServiceDeploymentName}}
 
 -
   metricName: Error
@@ -214,7 +214,7 @@
   dimensions:
     -
       name: RemoteService
-      value: {{remoteServiceIp}}:8080
+      value: {{remoteServiceDeploymentName}}
 
 -
   metricName: Fault
@@ -248,7 +248,7 @@
       value: GET /healthcheck
     -
       name: RemoteService
-      value: {{remoteServiceIp}}:8080
+      value: {{remoteServiceDeploymentName}}
 
 -
   metricName: Fault
@@ -298,7 +298,7 @@
       value: generic:default
     -
       name: RemoteService
-      value: {{remoteServiceIp}}:8080
+      value: {{remoteServiceDeploymentName}}
 
 -
   metricName: Fault
@@ -315,7 +315,7 @@
       value: GET /healthcheck
     -
       name: RemoteService
-      value: {{remoteServiceIp}}:8080
+      value: {{remoteServiceDeploymentName}}
 
 -
   metricName: Fault
@@ -323,4 +323,4 @@
   dimensions:
     -
       name: RemoteService
-      value: {{remoteServiceIp}}:8080
+      value: {{remoteServiceDeploymentName}}


### PR DESCRIPTION
*Issue description:*
Canary test failing due to backend team updating values of Operation and RemoteService metrics.

*Description of changes:*
Updated dimension values to correctly validate those generated by the backend.
Passing test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/14804860068

*Rollback procedure:*

<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
