### PR TITLE
Remove usage of aws-appsignals-sample-app-prod (#398)

### DIFF
--- a/.github/workflows/appsignals-e2e-gamma-test.yml
+++ b/.github/workflows/appsignals-e2e-gamma-test.yml
@@ -1,33 +1,169 @@
-## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-## SPDX-License-Identifier: Apache-2.0
-
-## This workflow aims to run the Application Signals end-to-end tests as a canary to
-## test the artifacts for App Signals enablement. It will deploy a sample app and remote
-## service onto an EKS cluster, call the APIs, and validate the generated telemetry,
-## including logs, metrics, and traces.
-name: App Signals Enablement - E2E Gamma Stage Testing
+name: Resource Attributes Test
 on:
-  workflow_dispatch: # be able to run the workflow on demand
-
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
+  workflow_dispatch:
 
 permissions:
   id-token: write
   contents: read
 
 jobs:
-  e2e-eks-test:
-    uses: ./.github/workflows/appsignals-e2e-eks-test.yml
+  java-ec2-default-e2e-test:
+    uses: ./.github/workflows/java-ec2-default-test.yml
     secrets: inherit
     with:
-      aws-region: 'us-east-1'
-      test-cluster-name: 'e2e-canary-test'
-      caller-workflow-name: 'appsignals-e2e-gamma-test'
-  e2e-ec2-test:
-    uses: ./.github/workflows/appsignals-e2e-ec2-test.yml
+      aws-region: us-east-1
+      caller-workflow-name: 'test'
+
+  java-ec2-asg-e2e-test:
+    uses: ./.github/workflows/java-ec2-asg-test.yml
     secrets: inherit
     with:
-      aws-region: 'us-east-1'
-      caller-workflow-name: 'appsignals-e2e-gamma-test'
+      aws-region: us-east-1
+      caller-workflow-name: 'test'
+
+  java-k8s-e2e-test:
+    uses: ./.github/workflows/java-k8s-test.yml
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'test'
+
+  python-ec2-default-e2e-test:
+    uses: ./.github/workflows/python-ec2-default-test.yml
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'test'
+
+  python-ec2-asg-e2e-test:
+    uses: ./.github/workflows/python-ec2-asg-test.yml
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'test'
+
+  python-k8s-e2e-test:
+    needs: [ java-k8s-e2e-test ]
+    uses: ./.github/workflows/python-k8s-test.yml
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'test'
+
+  node-ec2-default-e2e-test:
+    uses: ./.github/workflows/node-ec2-default-test.yml
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'test'
+
+  node-ec2-asg-e2e-test:
+    uses: ./.github/workflows/node-ec2-asg-test.yml
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'test'
+
+  node-k8s-e2e-test:
+    needs: [ python-k8s-e2e-test ]
+    uses: ./.github/workflows/node-k8s-test.yml
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'test'
+
+  dotnet-ec2-default-v8-e2e-test:
+    uses: ./.github/workflows/dotnet-ec2-default-test.yml
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'test'
+      dotnet-version: '8.0'
+
+  dotnet-ec2-windows-e2e-test:
+    uses: ./.github/workflows/dotnet-ec2-windows-test.yml
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'test'
+
+  dotnet-k8s-e2e-test:
+    needs: [ node-k8s-e2e-test ]
+    uses: ./.github/workflows/dotnet-k8s-test.yml
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'test'
+
+  dotnet-ec2-adot-sigv4-test:
+    uses: ./.github/workflows/dotnet-ec2-adot-sigv4-test.yml
+    secrets: inherit
+    with:
+      caller-workflow-name: 'test'
+  
+  dotnet-ec2-asg-test:
+    uses: ./.github/workflows/dotnet-ec2-asg-test.yml
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'test'
+  
+  dotnet-ec2-nuget-test:
+    uses: ./.github/workflows/dotnet-ec2-nuget-test.yml
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'test'
+  
+  dotnet-lambda-test:
+    uses: ./.github/workflows/dotnet-lambda-test.yml
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'test'
+  
+  java-ec2-adot-sigv4-test:
+    uses: ./.github/workflows/java-ec2-adot-sigv4-test.yml
+    secrets: inherit
+    with:
+      caller-workflow-name: 'test'
+  
+  java-ec2-ubuntu-test:
+    uses: ./.github/workflows/java-ec2-ubuntu-test.yml
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'test'
+  
+  java-lambda-test:
+    uses: ./.github/workflows/java-lambda-test.yml
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'test'
+  
+  node-ec2-adot-sigv4-test:
+    uses: ./.github/workflows/node-ec2-adot-sigv4-test.yml
+    secrets: inherit
+    with:
+      caller-workflow-name: 'test'
+  
+  # node-lambda-test
+  #   uses: ./.github/workflows/node-lambda-test.yml
+  #   secrets: inherit
+  #   with:
+  #     aws-region: us-east-1
+  #     caller-workflow-name: 'test'
+  
+  # python-ec2-adot-sigv4-test
+  #   uses: ./.github/workflows/python-ec2-adot-sigv4-test.yml
+  #   secrets: inherit
+  #   with:
+  #     caller-workflow-name: 'test'
+  
+  # python-lambda-test
+  #   uses: ./.github/workflows/python-lambda-test.yml
+  #   secrets: inherit
+  #   with:
+  #     aws-region: us-east-1
+  #     caller-workflow-name: 'test'

--- a/.github/workflows/dotnet-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/dotnet-ec2-adot-sigv4-test.yml
@@ -20,6 +20,11 @@ on:
         required: false
         default: 'aws-opentelemetry-distro'
         type: string
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
 
 permissions:
   id-token: write
@@ -30,7 +35,8 @@ env:
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
   DOTNET_VERSION: ${{ inputs.dotnet-version }}
-  SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-us-east-1/dotnet-sample-app-${{ inputs.dotnet-version }}.zip
+  SAMPLE_APP_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-us-east-1/dotnet-sample-app-${{ inputs.dotnet-version }}.zip
+  TRAFFIC_GENERATOR_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-us-east-1/traffic-generator.zip
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: aws/spans
   ADOT_DISTRO_NAME: ${{ inputs.staging_distro_name }}
@@ -113,6 +119,7 @@ jobs:
               -var="sample_app_zip=${{ env.SAMPLE_APP_ZIP }}" \
               -var="get_adot_distro_command=${{ env.GET_ADOT_DISTRO_COMMAND }}" \
               -var="language_version=${{ env.DOTNET_VERSION }}" \
+              -var="traffic_generator_zip=s3://${{ env.TRAFFIC_GENERATOR_ZIP }}" \
             || deployment_failed=$?
           
             if [ $deployment_failed -eq 1 ]; then

--- a/.github/workflows/dotnet-ec2-asg-test.yml
+++ b/.github/workflows/dotnet-ec2-asg-test.yml
@@ -18,6 +18,11 @@ on:
       caller-workflow-name:
         required: true
         type: string
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
     outputs:
       job-started:
         value: ${{ jobs.dotnet-ec2-asg.outputs.job-started }}
@@ -32,7 +37,8 @@ env:
   E2E_TEST_AWS_REGION: ${{ inputs.aws-region }}
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
-  SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/dotnet-sample-app.zip
+  SAMPLE_APP_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/dotnet-sample-app.zip
+  TRAFFIC_GENERATOR_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/traffic-generator.zip
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: /aws/application-signals/data
   ADOT_DISTRO_NAME: ${{ inputs.staging_distro_name }}
@@ -140,6 +146,7 @@ jobs:
               -var="sample_app_zip=${{ env.SAMPLE_APP_ZIP }}" \
               -var="get_cw_agent_rpm_command=${{ env.GET_CW_AGENT_RPM_COMMAND }}" \
               -var="get_adot_distro_command=${{ env.GET_ADOT_DISTRO_COMMAND }}" \
+              -var="traffic_generator_zip=s3://${{ env.TRAFFIC_GENERATOR_ZIP }}" \
             || deployment_failed=$?
           
             if [ $deployment_failed -eq 1 ]; then

--- a/.github/workflows/dotnet-ec2-default-test.yml
+++ b/.github/workflows/dotnet-ec2-default-test.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: string
         default: '8.0'
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
     outputs:
       job-started:
         value: ${{ jobs.dotnet-ec2-default.outputs.job-started }}
@@ -38,7 +43,8 @@ env:
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
   DOTNET_VERSION: ${{ inputs.dotnet-version }}
-  SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/dotnet-sample-app-${{ inputs.dotnet-version }}.zip
+  SAMPLE_APP_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/dotnet-sample-app-${{ inputs.dotnet-version }}.zip
+  TRAFFIC_GENERATOR_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/traffic-generator.zip
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: /aws/application-signals/data
   ADOT_DISTRO_NAME: ${{ inputs.staging_distro_name }}
@@ -145,6 +151,7 @@ jobs:
               -var="aws_region=${{ env.E2E_TEST_AWS_REGION }}" \
               -var="test_id=${{ env.TESTING_ID }}" \
               -var="sample_app_zip=${{ env.SAMPLE_APP_ZIP }}" \
+              -var="traffic_generator_zip=s3://${{ env.TRAFFIC_GENERATOR_ZIP }}" \
               -var="get_cw_agent_rpm_command=${{ env.GET_CW_AGENT_RPM_COMMAND }}" \
               -var="get_adot_distro_command=${{ env.GET_ADOT_DISTRO_COMMAND }}" \
               -var="language_version=${{ env.DOTNET_VERSION }}" \

--- a/.github/workflows/dotnet-ec2-nuget-test.yml
+++ b/.github/workflows/dotnet-ec2-nuget-test.yml
@@ -18,6 +18,11 @@ on:
       caller-workflow-name:
         required: true
         type: string
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
     outputs:
       job-started:
         value: ${{ jobs.dotnet-ec2-nuget.outputs.job-started }}
@@ -32,7 +37,8 @@ env:
   E2E_TEST_AWS_REGION: ${{ inputs.aws-region }}
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
-  SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/dotnet-sample-app.zip
+  SAMPLE_APP_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/dotnet-sample-app.zip
+  TRAFFIC_GENERATOR_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/traffic-generator.zip
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: /aws/application-signals/data
   ADOT_DISTRO_NAME: ${{ inputs.staging_distro_name }}
@@ -129,6 +135,7 @@ jobs:
               -var="aws_region=${{ env.E2E_TEST_AWS_REGION }}" \
               -var="test_id=${{ env.TESTING_ID }}" \
               -var="sample_app_zip=${{ env.SAMPLE_APP_ZIP }}" \
+              -var="traffic_generator_zip=s3://${{ env.TRAFFIC_GENERATOR_ZIP }}" \
               -var="get_cw_agent_rpm_command=${{ env.GET_CW_AGENT_RPM_COMMAND }}" \
             || deployment_failed=$?
           

--- a/.github/workflows/dotnet-ec2-windows-test.yml
+++ b/.github/workflows/dotnet-ec2-windows-test.yml
@@ -18,6 +18,11 @@ on:
       caller-workflow-name:
         required: true
         type: string
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
     outputs:
       job-started:
         value: ${{ jobs.dotnet-ec2-windows.outputs.job-started }}
@@ -32,7 +37,7 @@ env:
   E2E_TEST_AWS_REGION: ${{ inputs.aws-region }}
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
-  SAMPLE_APP_ZIP: "aws s3 cp s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/dotnet-sample-app.zip ./dotnet-sample-app.zip"
+  SAMPLE_APP_ZIP: "aws s3 cp s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/dotnet-sample-app.zip ./dotnet-sample-app.zip"
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: /aws/application-signals/data
   ADOT_DISTRO_NAME: ${{ inputs.staging_distro_name }}
@@ -140,6 +145,7 @@ jobs:
               -var="sample_app_zip=${{ env.SAMPLE_APP_ZIP }}" \
               -var="get_cw_agent_msi_command=${{ env.GET_CW_AGENT_MSI_COMMAND }}" \
               -var="get_adot_distro_command=${{ env.GET_ADOT_DISTRO_COMMAND }}" \
+              -var="sample_app_bucket_prefix=${{ inputs.sample-app-bucket-prefix }}" \
             || deployment_failed=$?
           
             if [ $deployment_failed -eq 1 ]; then

--- a/.github/workflows/dotnet-k8s-test.yml
+++ b/.github/workflows/dotnet-k8s-test.yml
@@ -23,6 +23,11 @@ on:
       cw-agent-operator-tag:
         required: false
         type: string
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
     outputs:
       job-started:
         value: ${{ jobs.dotnet-k8s.outputs.job-started }}
@@ -117,8 +122,8 @@ jobs:
           sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.DOTNET_MAIN_SAMPLE_APP_IMAGE }}#' dotnet-frontend-service-depl.yaml
           sed -i 's#\${TESTING_ID}#${{ env.TESTING_ID }}#' dotnet-remote-service-depl.yaml
           sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.DOTNET_REMOTE_SAMPLE_APP_IMAGE }}#' dotnet-remote-service-depl.yaml
-          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key dotnet-frontend-service-depl-${{ env.TESTING_ID }}.yaml --body dotnet-frontend-service-depl.yaml
-          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key dotnet-remote-service-depl-${{ env.TESTING_ID }}.yaml --body dotnet-remote-service-depl.yaml
+          aws s3api put-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ env.E2E_TEST_AWS_REGION }} --key dotnet-frontend-service-depl-${{ env.TESTING_ID }}.yaml --body dotnet-frontend-service-depl.yaml
+          aws s3api put-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ env.E2E_TEST_AWS_REGION }} --key dotnet-remote-service-depl-${{ env.TESTING_ID }}.yaml --body dotnet-remote-service-depl.yaml
 
       - name: Set up terraform
         uses: ./.github/workflows/actions/execute_and_retry
@@ -156,7 +161,8 @@ jobs:
             -var="host=${{ env.MAIN_SERVICE_ENDPOINT }}" \
             -var="repository=${{ github.event.repository.name }}" \
             -var="patch_image_arn=${{ env.PATCH_IMAGE_ARN }}" \
-            -var="release_testing_ecr_account=${{ env.RELEASE_TESTING_ECR_ACCOUNT }}"
+            -var="release_testing_ecr_account=${{ env.RELEASE_TESTING_ECR_ACCOUNT }}" \
+            -var="sample_app_bucket_prefix=${{ inputs.sample-app-bucket-prefix }}"
 
       - name: Get Main and Remote Service IP
         run: |
@@ -275,5 +281,5 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          aws s3api delete-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key dotnet-frontend-service-depl-${{ env.TESTING_ID }}.yaml
-          aws s3api delete-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key dotnet-remote-service-depl-${{ env.TESTING_ID }}.yaml
+          aws s3api delete-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ env.E2E_TEST_AWS_REGION }} --key dotnet-frontend-service-depl-${{ env.TESTING_ID }}.yaml
+          aws s3api delete-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ env.E2E_TEST_AWS_REGION }} --key dotnet-remote-service-depl-${{ env.TESTING_ID }}.yaml

--- a/.github/workflows/dotnet-lambda-test.yml
+++ b/.github/workflows/dotnet-lambda-test.yml
@@ -14,6 +14,11 @@ on:
       caller-workflow-name:
         required: true
         type: string
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
     outputs:
       job-started:
         value: ${{ jobs.dotnet-lambda-default.outputs.job-started }}
@@ -29,7 +34,7 @@ env:
   CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
-  SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/dotnet-function.zip
+  SAMPLE_APP_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/dotnet-function.zip
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: /aws/application-signals/data
   TEST_RESOURCES_FOLDER: ${GITHUB_WORKSPACE}

--- a/.github/workflows/dotnet-sample-app-s3-deploy.yml
+++ b/.github/workflows/dotnet-sample-app-s3-deploy.yml
@@ -103,7 +103,7 @@ jobs:
         run: aws s3api put-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ matrix.aws-region }} --body ./dotnet-sample-app-${DOTNET_VERSION}.zip --key dotnet-sample-app-${DOTNET_VERSION}.zip
 
       - name: Upload Windows Script to S3
-        working-directory: sample-apps/dotnet`
+        working-directory: sample-apps/dotnet
         run: |
           aws s3api put-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ matrix.aws-region }} --body ./dotnet-ec2-win-main-setup.ps1 --key dotnet-ec2-win-main-setup.ps1
           aws s3api put-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ matrix.aws-region }} --body ./dotnet-ec2-win-remote-setup.ps1 --key dotnet-ec2-win-remote-setup.ps1

--- a/.github/workflows/dotnet-sample-app-s3-deploy.yml
+++ b/.github/workflows/dotnet-sample-app-s3-deploy.yml
@@ -4,6 +4,12 @@
 name: Sample App Deployment - Dotnet S3
 on:
   workflow_dispatch: # be able to run the workflow on demand
+    inputs:
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
 
 permissions:
   id-token: write
@@ -94,14 +100,14 @@ jobs:
 
       - name: Upload to S3
         working-directory: sample-apps/dotnet
-        run: aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ matrix.aws-region }} --body ./dotnet-sample-app-${DOTNET_VERSION}.zip --key dotnet-sample-app-${DOTNET_VERSION}.zip
+        run: aws s3api put-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ matrix.aws-region }} --body ./dotnet-sample-app-${DOTNET_VERSION}.zip --key dotnet-sample-app-${DOTNET_VERSION}.zip
 
       - name: Upload Windows Script to S3
-        working-directory: sample-apps/dotnet
+        working-directory: sample-apps/dotnet`
         run: |
-          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ matrix.aws-region }} --body ./dotnet-ec2-win-main-setup.ps1 --key dotnet-ec2-win-main-setup.ps1
-          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ matrix.aws-region }} --body ./dotnet-ec2-win-remote-setup.ps1 --key dotnet-ec2-win-remote-setup.ps1
-          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ matrix.aws-region }} --body ./amazon-cloudwatch-agent.json --key amazon-cloudwatch-agent.json
+          aws s3api put-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ matrix.aws-region }} --body ./dotnet-ec2-win-main-setup.ps1 --key dotnet-ec2-win-main-setup.ps1
+          aws s3api put-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ matrix.aws-region }} --body ./dotnet-ec2-win-remote-setup.ps1 --key dotnet-ec2-win-remote-setup.ps1
+          aws s3api put-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ matrix.aws-region }} --body ./amazon-cloudwatch-agent.json --key amazon-cloudwatch-agent.json
 
   build-and-upload-lambda-sample-app:
     strategy:
@@ -153,4 +159,4 @@ jobs:
       
       - name: Upload Lambda Sample App to S3
         working-directory: sample-applications/lambda-test-apps/SimpleLambdaFunction
-        run: aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ matrix.aws-region }} --body ./src/SimpleLambdaFunction/bin/Release/net8.0/SimpleLambdaFunction.zip --key dotnet-function.zip
+        run: aws s3api put-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ matrix.aws-region }} --body ./src/SimpleLambdaFunction/bin/Release/net8.0/SimpleLambdaFunction.zip --key dotnet-function.zip

--- a/.github/workflows/java-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/java-ec2-adot-sigv4-test.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: string
         default: "x86_64"
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
     outputs:
       job-started:
         value: ${{ jobs.java-ec2-adot-sigv4.outputs.job-started }}
@@ -123,11 +128,12 @@ jobs:
             terraform apply -auto-approve \
               -var="aws_region=${{ env.E2E_TEST_AWS_REGION }}" \
               -var="test_id=${{ env.TESTING_ID }}" \
-              -var="sample_app_jar=s3://aws-appsignals-sample-app-prod-us-east-1/java-main-service-v${{ env.JAVA_VERSION }}.jar" \
-              -var="sample_remote_app_jar=s3://aws-appsignals-sample-app-prod-us-east-1/java-remote-service-v${{ env.JAVA_VERSION }}.jar" \
+              -var="sample_app_jar=s3://${{ inputs.sample-app-bucket-prefix }}-us-east-1/java-main-service-v${{ env.JAVA_VERSION }}.jar" \
+              -var="sample_remote_app_jar=s3://${{ inputs.sample-app-bucket-prefix }}-us-east-1/java-remote-service-v${{ env.JAVA_VERSION }}.jar" \
               -var="get_adot_jar_command=${{ env.GET_ADOT_JAR_COMMAND }}" \
               -var="language_version=${{ env.JAVA_VERSION }}" \
               -var="cpu_architecture=${{ env.CPU_ARCHITECTURE }}" \
+              -var="traffic_generator_zip=s3://${{ inputs.sample-app-bucket-prefix }}-us-east-1/traffic-generator.zip" \
             || deployment_failed=$?
 
             if [ $deployment_failed -eq 1 ]; then

--- a/.github/workflows/java-ec2-asg-test.yml
+++ b/.github/workflows/java-ec2-asg-test.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: string
         default: "x86_64"
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
     outputs:
       job-started:
         value: ${{ jobs.java-ec2-asg.outputs.job-started }}
@@ -39,8 +44,9 @@ env:
   CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
   JAVA_VERSION: ${{ inputs.java-version }}
   CPU_ARCHITECTURE: ${{ inputs.cpu-architecture }}
-  SAMPLE_APP_FRONTEND_SERVICE_JAR: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/java-main-service-v${{ inputs.java-version }}.jar
-  SAMPLE_APP_REMOTE_SERVICE_JAR: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/java-remote-service-v${{ inputs.java-version }}.jar
+  SAMPLE_APP_FRONTEND_SERVICE_JAR: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/java-main-service-v${{ inputs.java-version }}.jar
+  SAMPLE_APP_REMOTE_SERVICE_JAR: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/java-remote-service-v${{ inputs.java-version }}.jar
+  TRAFFIC_GENERATOR_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/traffic-generator.zip
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
   METRIC_NAMESPACE: ApplicationSignals
@@ -155,6 +161,7 @@ jobs:
               -var="test_id=${{ env.TESTING_ID }}" \
               -var="sample_app_jar=${{ env.SAMPLE_APP_FRONTEND_SERVICE_JAR }}" \
               -var="sample_remote_app_jar=${{ env.SAMPLE_APP_REMOTE_SERVICE_JAR }}" \
+              -var="traffic_generator_zip=s3://${{ env.TRAFFIC_GENERATOR_ZIP }}" \
               -var="get_cw_agent_rpm_command=${{ env.GET_CW_AGENT_RPM_COMMAND }}" \
               -var="get_adot_jar_command=${{ env.GET_ADOT_JAR_COMMAND }}" \
               -var="language_version=${{ env.JAVA_VERSION }}" \

--- a/.github/workflows/java-ec2-default-test.yml
+++ b/.github/workflows/java-ec2-default-test.yml
@@ -28,6 +28,11 @@ on:
         required: false
         type: string
         default: 'github'
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
     outputs:
       job-started:
         value: ${{ jobs.java-ec2-default.outputs.job-started }}
@@ -44,8 +49,9 @@ env:
   JAVA_VERSION: ${{ inputs.java-version }}
   OTEL_SOURCE: ${{ inputs.otel-source }}
   CPU_ARCHITECTURE: ${{ inputs.cpu-architecture }}
-  SAMPLE_APP_FRONTEND_SERVICE_JAR: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/java-main-service-v${{ inputs.java-version }}.jar
-  SAMPLE_APP_REMOTE_SERVICE_JAR: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/java-remote-service-v${{ inputs.java-version }}.jar
+  SAMPLE_APP_FRONTEND_SERVICE_JAR: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/java-main-service-v${{ inputs.java-version }}.jar
+  SAMPLE_APP_REMOTE_SERVICE_JAR: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/java-remote-service-v${{ inputs.java-version }}.jar
+  TRAFFIC_GENERATOR_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/traffic-generator.zip
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
   METRIC_NAMESPACE: ApplicationSignals
@@ -168,6 +174,7 @@ jobs:
               -var="get_adot_jar_command=${{ env.GET_ADOT_JAR_COMMAND }}" \
               -var="language_version=${{ env.JAVA_VERSION }}" \
               -var="cpu_architecture=${{ env.CPU_ARCHITECTURE }}" \
+              -var="traffic_generator_zip=s3://${{ env.TRAFFIC_GENERATOR_ZIP }}" \
             || deployment_failed=$?
 
             if [ $deployment_failed -eq 1 ]; then

--- a/.github/workflows/java-ec2-ubuntu-test.yml
+++ b/.github/workflows/java-ec2-ubuntu-test.yml
@@ -14,6 +14,11 @@ on:
       caller-workflow-name:
         required: true
         type: string
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
 
     outputs:
       job-started:
@@ -28,8 +33,9 @@ permissions:
 env:
   E2E_TEST_AWS_REGION: ${{ inputs.aws-region }}
   CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
-  SAMPLE_APP_FRONTEND_SERVICE_JAR: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/java-main-service-v11.jar
-  SAMPLE_APP_REMOTE_SERVICE_JAR: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/java-remote-service-v11.jar
+  SAMPLE_APP_FRONTEND_SERVICE_JAR: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/java-main-service-v11.jar
+  SAMPLE_APP_REMOTE_SERVICE_JAR: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/java-remote-service-v11.jar
+  TRAFFIC_GENERATOR_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/traffic-generator.zip
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
   METRIC_NAMESPACE: ApplicationSignals
@@ -140,6 +146,7 @@ jobs:
               -var="sample_remote_app_jar=${{ env.SAMPLE_APP_REMOTE_SERVICE_JAR }}" \
               -var="get_cw_agent_deb_command=${{ env.GET_CW_AGENT_DEB_COMMAND }}" \
               -var="get_adot_jar_command=${{ env.GET_ADOT_JAR_COMMAND }}" \
+              -var="traffic_generator_zip=s3://${{ env.TRAFFIC_GENERATOR_ZIP }}" \
             || deployment_failed=$?
 
             if [ $deployment_failed -eq 1 ]; then

--- a/.github/workflows/java-k8s-test.yml
+++ b/.github/workflows/java-k8s-test.yml
@@ -28,6 +28,11 @@ on:
       cw-agent-operator-tag:
         required: false
         type: string
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
     outputs:
       job-started:
         value: ${{ jobs.java-k8s.outputs.job-started }}
@@ -123,8 +128,8 @@ jobs:
           sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.JAVA_MAIN_SAMPLE_APP_IMAGE }}:v${{ env.JAVA_VERSION }}#' frontend-service-depl.yaml
           sed -i 's#\${TESTING_ID}#${{ env.TESTING_ID }}#' remote-service-depl.yaml
           sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.JAVA_REMOTE_SAMPLE_APP_IMAGE }}:v${{ env.JAVA_VERSION }}#' remote-service-depl.yaml
-          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key frontend-service-depl-${{ env.TESTING_ID }}.yaml --body frontend-service-depl.yaml
-          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key remote-service-depl-${{ env.TESTING_ID }}.yaml --body remote-service-depl.yaml
+          aws s3api put-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ env.E2E_TEST_AWS_REGION }} --key frontend-service-depl-${{ env.TESTING_ID }}.yaml --body frontend-service-depl.yaml
+          aws s3api put-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ env.E2E_TEST_AWS_REGION }} --key remote-service-depl-${{ env.TESTING_ID }}.yaml --body remote-service-depl.yaml
 
       - name: Set up terraform
         uses: ./.github/workflows/actions/execute_and_retry
@@ -162,7 +167,8 @@ jobs:
             -var="host=${{ env.MAIN_SERVICE_ENDPOINT }}" \
             -var="repository=${{ github.event.repository.name }}" \
             -var="patch_image_arn=${{ env.PATCH_IMAGE_ARN }}" \
-            -var="release_testing_ecr_account=${{ env.RELEASE_TESTING_ECR_ACCOUNT }}"
+            -var="release_testing_ecr_account=${{ env.RELEASE_TESTING_ECR_ACCOUNT }}" \
+            -var="sample_app_bucket_prefix=${{ inputs.sample-app-bucket-prefix }}" \
 
       - name: Get Main and Remote Service IP
         run: |

--- a/.github/workflows/java-k8s-test.yml
+++ b/.github/workflows/java-k8s-test.yml
@@ -168,7 +168,7 @@ jobs:
             -var="repository=${{ github.event.repository.name }}" \
             -var="patch_image_arn=${{ env.PATCH_IMAGE_ARN }}" \
             -var="release_testing_ecr_account=${{ env.RELEASE_TESTING_ECR_ACCOUNT }}" \
-            -var="sample_app_bucket_prefix=${{ inputs.sample-app-bucket-prefix }}" \
+            -var="sample_app_bucket_prefix=${{ inputs.sample-app-bucket-prefix }}"
 
       - name: Get Main and Remote Service IP
         run: |

--- a/.github/workflows/java-lambda-test.yml
+++ b/.github/workflows/java-lambda-test.yml
@@ -14,6 +14,11 @@ on:
       caller-workflow-name:
         required: true
         type: string
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
     outputs:
       job-started:
         value: ${{ jobs.java-lambda-default.outputs.job-started }}
@@ -31,7 +36,7 @@ env:
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: /aws/application-signals/data
-  SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/java-lambda-function.zip
+  SAMPLE_APP_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/java-lambda-function.zip
   TEST_RESOURCES_FOLDER: ${GITHUB_WORKSPACE}
   STAGING_S3_BUCKET: ${{ secrets.STAGING_BUCKET_NAME }}
   IS_CANARY: false

--- a/.github/workflows/java-sample-app-s3-deploy.yml
+++ b/.github/workflows/java-sample-app-s3-deploy.yml
@@ -6,6 +6,12 @@
 name: Sample App Deployment - Java S3
 on:
   workflow_dispatch: # be able to run the workflow on demand
+    inputs:
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
 
 permissions:
   id-token: write
@@ -52,8 +58,8 @@ jobs:
         working-directory: sample-apps/java/springboot-main-service
         run: |
           gradle build -P javaVersion=11
-          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ matrix.aws-region }} --body ./build/libs/springboot-*-SNAPSHOT.jar --key java-main-service-v11.jar
 
+          aws s3api put-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ matrix.aws-region }} --body ./build/libs/springboot-*-SNAPSHOT.jar --key java-main-service-v11.jar
   java-v11-remote:
     strategy:
       fail-fast: false
@@ -90,8 +96,8 @@ jobs:
         working-directory: sample-apps/java/springboot-remote-service
         run: |
           gradle build -P javaVersion=11
-          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ matrix.aws-region }} --body build/libs/springboot-remote-service-*-SNAPSHOT.jar --key java-remote-service-v11.jar
 
+          aws s3api put-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ matrix.aws-region }} --body build/libs/springboot-remote-service-*-SNAPSHOT.jar --key java-remote-service-v11.jar
   java-main:
     strategy:
       fail-fast: false
@@ -124,8 +130,8 @@ jobs:
           fi
           
           gradle build -P javaVersion=${{ matrix.java-version }}
-          aws s3api put-object --bucket aws-appsignals-sample-app-prod-us-east-1 --body ./build/libs/springboot-*-SNAPSHOT.jar --key java-main-service-v${{ matrix.java-version }}.jar
 
+          aws s3api put-object --bucket ${{ inputs.sample-app-bucket-prefix }}-us-east-1 --body ./build/libs/springboot-*-SNAPSHOT.jar --key java-main-service-v${{ matrix.java-version }}.jar
   java-remote:
     strategy:
       fail-fast: false
@@ -158,8 +164,8 @@ jobs:
           fi
           
           gradle build -P javaVersion=${{ matrix.java-version }}
-          aws s3api put-object --bucket aws-appsignals-sample-app-prod-us-east-1 --body ./build/libs/springboot-remote-service-*-SNAPSHOT.jar --key java-remote-service-v${{ matrix.java-version }}.jar
 
+          aws s3api put-object --bucket ${{ inputs.sample-app-bucket-prefix }}-us-east-1 --body ./build/libs/springboot-remote-service-*-SNAPSHOT.jar --key java-remote-service-v${{ matrix.java-version }}.jar
   java-lambda:
     strategy:
       fail-fast: false
@@ -205,4 +211,4 @@ jobs:
         run: |
           gradle build
           gradle createLambdaZip
-          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ matrix.aws-region }} --body ./build/distributions/lambda-function.zip --key java-lambda-function.zip
+          aws s3api put-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ matrix.aws-region }} --body ./build/distributions/lambda-function.zip --key java-lambda-function.zip

--- a/.github/workflows/node-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/node-ec2-adot-sigv4-test.yml
@@ -26,6 +26,11 @@ on:
         required: false
         default: '@aws/aws-distro-opentelemetry-node-autoinstrumentation'
         type: string
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
 
 permissions:
   id-token: write
@@ -117,10 +122,11 @@ jobs:
             terraform apply -auto-approve \
               -var="aws_region=${{ env.E2E_TEST_AWS_REGION }}" \
               -var="test_id=${{ env.TESTING_ID }}" \
-              -var="sample_app_zip=s3://aws-appsignals-sample-app-prod-us-east-1/node-sample-app.zip" \
+              -var="sample_app_zip=s3://${{ inputs.sample-app-bucket-prefix }}/node-sample-app.zip" \
               -var="get_adot_instrumentation_command=${{ env.GET_ADOT_INSTRUMENTATION_COMMAND }}" \
               -var="language_version=${{ env.NODE_VERSION }}" \
               -var="cpu_architecture=${{ env.CPU_ARCHITECTURE }}" \
+              -var="traffic_generator_zip=s3://${{ inputs.sample-app-bucket-prefix }}-us-east-1/traffic-generator.zip" \
             || deployment_failed=$?
 
             if [ $deployment_failed -eq 1 ]; then

--- a/.github/workflows/node-ec2-asg-test.yml
+++ b/.github/workflows/node-ec2-asg-test.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: '@aws/aws-distro-opentelemetry-node-autoinstrumentation'
         type: string
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
     outputs:
       job-started:
         value: ${{ jobs.node-ec2-asg.outputs.job-started }}
@@ -32,7 +37,8 @@ env:
   E2E_TEST_AWS_REGION: ${{ inputs.aws-region }}
   CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
   ADOT_INSTRUMENTATION_NAME: ${{ inputs.staging-instrumentation-name }}
-  SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/node-sample-app.zip
+  SAMPLE_APP_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/node-sample-app.zip
+  TRAFFIC_GENERATOR_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/traffic-generator.zip
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
   METRIC_NAMESPACE: ApplicationSignals
@@ -142,6 +148,7 @@ jobs:
               -var="sample_app_zip=${{ env.SAMPLE_APP_ZIP }}" \
               -var="get_cw_agent_rpm_command=${{ env.GET_CW_AGENT_RPM_COMMAND }}" \
               -var="get_adot_instrumentation_command=${{ env.GET_ADOT_INSTRUMENTATION_COMMAND }}" \
+              -var="traffic_generator_zip=s3://${{ env.TRAFFIC_GENERATOR_ZIP }}" \
             || deployment_failed=$?
 
             if [ $deployment_failed -eq 1 ]; then

--- a/.github/workflows/node-ec2-default-test.yml
+++ b/.github/workflows/node-ec2-default-test.yml
@@ -29,6 +29,11 @@ on:
         required: false
         default: '@aws/aws-distro-opentelemetry-node-autoinstrumentation'
         type: string
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
     outputs:
       job-started:
         value: ${{ jobs.node-ec2-default.outputs.job-started }}
@@ -45,7 +50,8 @@ env:
   NODE_VERSION: ${{ inputs.node-version }}
   CPU_ARCHITECTURE: ${{ inputs.cpu-architecture }}
   ADOT_INSTRUMENTATION_NAME: ${{ inputs.staging-instrumentation-name }}
-  SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/node-sample-app.zip
+  SAMPLE_APP_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/node-sample-app.zip
+  TRAFFIC_GENERATOR_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/traffic-generator.zip
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
   METRIC_NAMESPACE: ApplicationSignals
@@ -161,6 +167,7 @@ jobs:
               -var="get_adot_instrumentation_command=${{ env.GET_ADOT_INSTRUMENTATION_COMMAND }}" \
               -var="language_version=${{ env.NODE_VERSION }}" \
               -var="cpu_architecture=${{ env.CPU_ARCHITECTURE }}" \
+              -var="traffic_generator_zip=s3://${{ env.TRAFFIC_GENERATOR_ZIP }}" \
             || deployment_failed=$?
 
             if [ $deployment_failed -eq 1 ]; then

--- a/.github/workflows/node-k8s-test.yml
+++ b/.github/workflows/node-k8s-test.yml
@@ -23,6 +23,11 @@ on:
       cw-agent-operator-tag:
         required: false
         type: string
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
     outputs:
       job-started:
         value: ${{ jobs.node-k8s.outputs.job-started }}
@@ -117,8 +122,8 @@ jobs:
           sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.NODE_MAIN_SAMPLE_APP_IMAGE }}#' frontend-service-depl.yaml
           sed -i 's#\${TESTING_ID}#${{ env.TESTING_ID }}#' remote-service-depl.yaml
           sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.NODE_REMOTE_SAMPLE_APP_IMAGE }}#' remote-service-depl.yaml
-          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key frontend-service-depl-${{ env.TESTING_ID }}.yaml --body frontend-service-depl.yaml
-          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key remote-service-depl-${{ env.TESTING_ID }}.yaml --body remote-service-depl.yaml
+          aws s3api put-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ env.E2E_TEST_AWS_REGION }} --key frontend-service-depl-${{ env.TESTING_ID }}.yaml --body frontend-service-depl.yaml
+          aws s3api put-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ env.E2E_TEST_AWS_REGION }} --key remote-service-depl-${{ env.TESTING_ID }}.yaml --body remote-service-depl.yaml
 
       - name: Set up terraform
         uses: ./.github/workflows/actions/execute_and_retry
@@ -156,7 +161,8 @@ jobs:
             -var="host=${{ env.MAIN_SERVICE_ENDPOINT }}" \
             -var="repository=${{ github.event.repository.name }}" \
             -var="patch_image_arn=${{ env.PATCH_IMAGE_ARN }}" \
-            -var="release_testing_ecr_account=${{ env.RELEASE_TESTING_ECR_ACCOUNT }}"
+            -var="release_testing_ecr_account=${{ env.RELEASE_TESTING_ECR_ACCOUNT }}" \
+            -var="sample_app_bucket_prefix=${{ inputs.sample-app-bucket-prefix }}"
 
       - name: Get Main and Remote Service IP
         run: |

--- a/.github/workflows/node-lambda-test.yml
+++ b/.github/workflows/node-lambda-test.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: '@aws/aws-distro-opentelemetry-node-autoinstrumentation'
         type: string
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
     outputs:
       job-started:
         value: ${{ jobs.node-lambda-default.outputs.job-started }}
@@ -33,7 +38,7 @@ env:
   CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
-  SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/jsfunction.zip
+  SAMPLE_APP_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/jsfunction.zip
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: /aws/application-signals/data
   TEST_RESOURCES_FOLDER: ${GITHUB_WORKSPACE}

--- a/.github/workflows/python-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/python-ec2-adot-sigv4-test.yml
@@ -25,6 +25,11 @@ on:
         required: false
         default: 'aws-opentelemetry-distro'
         type: string
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
 
 permissions:
   id-token: write
@@ -117,10 +122,11 @@ jobs:
             terraform apply -auto-approve \
               -var="aws_region=${{ env.E2E_TEST_AWS_REGION }}" \
               -var="test_id=${{ env.TESTING_ID }}" \
-              -var="sample_app_zip=s3://aws-appsignals-sample-app-prod-us-east-1/python-sample-app.zip" \
+              -var="sample_app_zip=s3://${{ inputs.sample-app-bucket-prefix }}-us-east-1/python-sample-app.zip" \
               -var="get_adot_wheel_command=${{ env.GET_ADOT_WHEEL_COMMAND }}" \
               -var="language_version=${{ env.PYTHON_VERSION }}" \
               -var="cpu_architecture=${{ env.CPU_ARCHITECTURE }}" \
+              -var="traffic_generator_zip=s3://${{ inputs.sample-app-bucket-prefix }}-us-east-1/traffic-generator.zip" \
             || deployment_failed=$?
           
             if [ $deployment_failed -eq 1 ]; then

--- a/.github/workflows/python-ec2-asg-test.yml
+++ b/.github/workflows/python-ec2-asg-test.yml
@@ -28,6 +28,11 @@ on:
         required: false
         default: 'aws-opentelemetry-distro'
         type: string
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
     outputs:
       job-started:
         value: ${{ jobs.python-ec2-asg.outputs.job-started }}
@@ -44,7 +49,8 @@ env:
   PYTHON_VERSION: ${{ inputs.python-version }}
   CPU_ARCHITECTURE: ${{ inputs.cpu-architecture }}
   ADOT_WHEEL_NAME: ${{ inputs.staging-wheel-name }}
-  SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/python-sample-app.zip
+  SAMPLE_APP_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/python-sample-app.zip
+  TRAFFIC_GENERATOR_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/traffic-generator.zip
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
   METRIC_NAMESPACE: ApplicationSignals
@@ -162,6 +168,7 @@ jobs:
               -var="get_adot_wheel_command=${{ env.GET_ADOT_WHEEL_COMMAND }}" \
               -var="language_version=${{ env.PYTHON_VERSION }}" \
               -var="cpu_architecture=${{ env.CPU_ARCHITECTURE }}" \
+              -var="traffic_generator_zip=s3://${{ env.TRAFFIC_GENERATOR_ZIP }}" \
             || deployment_failed=$?
           
             if [ $deployment_failed -eq 1 ]; then

--- a/.github/workflows/python-ec2-default-test.yml
+++ b/.github/workflows/python-ec2-default-test.yml
@@ -32,6 +32,11 @@ on:
         required: false
         type: string
         default: 'github'
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
     outputs:
       job-started:
         value: ${{ jobs.python-ec2-default.outputs.job-started }}
@@ -49,7 +54,8 @@ env:
   CPU_ARCHITECTURE: ${{ inputs.cpu-architecture }}
   ADOT_WHEEL_NAME: ${{ inputs.staging-wheel-name }}
   OTEL_SOURCE: ${{ inputs.otel-source }}
-  SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/python-sample-app.zip
+  SAMPLE_APP_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/python-sample-app.zip
+  TRAFFIC_GENERATOR_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/traffic-generator.zip
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
   METRIC_NAMESPACE: ApplicationSignals
@@ -171,6 +177,7 @@ jobs:
               -var="get_adot_wheel_command=${{ env.GET_ADOT_WHEEL_COMMAND }}" \
               -var="language_version=${{ env.PYTHON_VERSION }}" \
               -var="cpu_architecture=${{ env.CPU_ARCHITECTURE }}" \
+              -var="traffic_generator_zip=s3://${{ env.TRAFFIC_GENERATOR_ZIP }}" \
             || deployment_failed=$?
           
             if [ $deployment_failed -eq 1 ]; then

--- a/.github/workflows/python-k8s-test.yml
+++ b/.github/workflows/python-k8s-test.yml
@@ -28,6 +28,11 @@ on:
       cw-agent-operator-tag:
         required: false
         type: string
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
     outputs:
       job-started:
         value: ${{ jobs.python-k8s.outputs.job-started }}
@@ -123,8 +128,8 @@ jobs:
           sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.PYTHON_MAIN_SAMPLE_APP_IMAGE }}:v${{ env.PYTHON_VERSION }}#' python-frontend-service-depl.yaml
           sed -i 's#\${TESTING_ID}#${{ env.TESTING_ID }}#' python-remote-service-depl.yaml
           sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.PYTHON_REMOTE_SAMPLE_APP_IMAGE }}:v${{ env.PYTHON_VERSION }}#' python-remote-service-depl.yaml
-          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key python-frontend-service-depl-${{ env.TESTING_ID }}.yaml --body python-frontend-service-depl.yaml
-          aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key python-remote-service-depl-${{ env.TESTING_ID }}.yaml --body python-remote-service-depl.yaml
+          aws s3api put-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ env.E2E_TEST_AWS_REGION }} --key python-frontend-service-depl-${{ env.TESTING_ID }}.yaml --body python-frontend-service-depl.yaml
+          aws s3api put-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ env.E2E_TEST_AWS_REGION }} --key python-remote-service-depl-${{ env.TESTING_ID }}.yaml --body python-remote-service-depl.yaml
 
       - name: Set up terraform
         uses: ./.github/workflows/actions/execute_and_retry
@@ -162,7 +167,8 @@ jobs:
             -var="host=${{ env.MAIN_SERVICE_ENDPOINT }}" \
             -var="repository=${{ github.event.repository.name }}" \
             -var="patch_image_arn=${{ env.PATCH_IMAGE_ARN }}" \
-            -var="release_testing_ecr_account=${{ env.RELEASE_TESTING_ECR_ACCOUNT }}"
+            -var="release_testing_ecr_account=${{ env.RELEASE_TESTING_ECR_ACCOUNT }}" \
+            -var="sample_app_bucket_prefix=${{ inputs.sample-app-bucket-prefix }}"
 
       - name: Get Main and Remote Service IP
         run: |
@@ -286,5 +292,5 @@ jobs:
         if: always()
         continue-on-error: true
         run: |
-          aws s3api delete-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key python-frontend-service-depl-${{ env.TESTING_ID }}.yaml
-          aws s3api delete-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key python-remote-service-depl-${{ env.TESTING_ID }}.yaml
+          aws s3api delete-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ env.E2E_TEST_AWS_REGION }} --key python-frontend-service-depl-${{ env.TESTING_ID }}.yaml
+          aws s3api delete-object --bucket ${{ inputs.sample-app-bucket-prefix }}-${{ env.E2E_TEST_AWS_REGION }} --key python-remote-service-depl-${{ env.TESTING_ID }}.yaml

--- a/.github/workflows/python-lambda-test.yml
+++ b/.github/workflows/python-lambda-test.yml
@@ -32,6 +32,11 @@ on:
         required: false
         type: string
         default: 'github'
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
     outputs:
       job-started:
         value: ${{ jobs.python-lambda-default.outputs.job-started }}
@@ -51,7 +56,7 @@ env:
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: /aws/application-signals/data
-  SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/pyfunction.zip
+  SAMPLE_APP_ZIP: s3://${{ inputs.sample-app-bucket-prefix }}-${{ inputs.aws-region }}/pyfunction.zip
   TEST_RESOURCES_FOLDER: ${GITHUB_WORKSPACE}
   STAGING_S3_BUCKET: ${{ secrets.STAGING_BUCKET_NAME }}
   IS_CANARY: false

--- a/.github/workflows/traffic-generator-image-build.yml
+++ b/.github/workflows/traffic-generator-image-build.yml
@@ -4,6 +4,12 @@ name: Create and Push Traffic Generator
 
 on:
   workflow_dispatch:
+    inputs:
+      sample-app-bucket-prefix:
+        description: "Prefix for S3 bucket holding sample app files"
+        required: false
+        default: 'aws-appsignals-sample-app-prod'
+        type: string
   push:
     branches:
       - main
@@ -22,6 +28,7 @@ jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         aws-region: ['af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
                      'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
@@ -66,6 +73,7 @@ jobs:
   upload-files-to-s3:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         aws-region: ['af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
                      'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
@@ -97,4 +105,4 @@ jobs:
         working-directory: sample-apps/traffic-generator
         run: |
           zip traffic-generator.zip ./index.js ./package.json
-          aws s3 cp traffic-generator.zip s3://aws-appsignals-sample-app-prod-${{ matrix.aws-region }}/traffic-generator.zip
+          aws s3 cp traffic-generator.zip s3://${{ inputs.sample-app-bucket-prefix }}-${{ matrix.aws-region }}/traffic-generator.zip

--- a/sample-apps/dotnet/dotnet-ec2-win-main-setup.ps1
+++ b/sample-apps/dotnet/dotnet-ec2-win-main-setup.ps1
@@ -4,7 +4,8 @@ param (
     [string]$GetSampleAppCommand,
     [string]$TestId,
     [string]$RemoteServicePrivateEndpoint,
-    [string]$AWSRegion
+    [string]$AWSRegion,
+    [string]$SampleAppBucketPrefix
 )
 
 # This file is used to deploy and instrumentation main sample app for Dotnet E2E Canary test
@@ -103,7 +104,7 @@ Write-Host $currentdir | %{ "{0:HH:mm:ss:fff}: {1}" -f (Get-Date), $_ }
 $env:Path += ";$currentdir" + "\nodejs\node-v20.16.0-win-x64"
 
 # Bring in the traffic generator files to EC2 Instance
-aws s3 cp "s3://aws-appsignals-sample-app-prod-$AWSRegion/traffic-generator.zip" "./traffic-generator.zip"
+aws s3 cp "s3://$SampleAppBucketPrefix-$AWSRegion/traffic-generator.zip" "./traffic-generator.zip"
 Expand-Archive -Path "./traffic-generator.zip" -DestinationPath "./" -Force | %{ "{0:HH:mm:ss:fff}: {1}" -f (Get-Date), $_ }
 
 # Install the traffic generator dependencies

--- a/terraform/dotnet/ec2/adot-sigv4/main.tf
+++ b/terraform/dotnet/ec2/adot-sigv4/main.tf
@@ -295,7 +295,7 @@ resource "null_resource" "traffic_generator_setup" {
         sudo yum install nodejs aws-cli unzip tmux -y
 
         # Bring in the traffic generator files to EC2 Instance
-        aws s3 cp s3://aws-appsignals-sample-app-prod-us-east-1/traffic-generator.zip ./traffic-generator.zip
+        aws s3 cp ${var.traffic_generator_zip} ./traffic-generator.zip
         unzip ./traffic-generator.zip -d ./
 
         # Install the traffic generator dependencies

--- a/terraform/dotnet/ec2/adot-sigv4/variables.tf
+++ b/terraform/dotnet/ec2/adot-sigv4/variables.tf
@@ -40,3 +40,7 @@ variable "canary_type" {
 variable "language_version" {
   default = "8.0"
 }
+
+variable traffic_generator_zip {
+    default = "s3://aws-appsignals-sample-app-prod-us-east-1/traffic-generator.zip"
+}

--- a/terraform/dotnet/ec2/asg/main.tf
+++ b/terraform/dotnet/ec2/asg/main.tf
@@ -159,7 +159,7 @@ resource "aws_launch_configuration" "launch_configuration" {
     # Deploy Traffic Generator
     sudo yum install nodejs aws-cli unzip tmux -y
     # Bring in the traffic generator files to EC2 Instance
-    aws s3 cp s3://aws-appsignals-sample-app-prod-${var.aws_region}/traffic-generator.zip ./traffic-generator.zip
+    aws s3 cp ${var.traffic_generator_zip} ./traffic-generator.zip
     unzip ./traffic-generator.zip -d ./
     # Install the traffic generator dependencies
     npm install

--- a/terraform/dotnet/ec2/asg/variables.tf
+++ b/terraform/dotnet/ec2/asg/variables.tf
@@ -40,3 +40,7 @@ variable "get_cw_agent_rpm_command" {
 variable "canary_type" {
   default = "dotnet-ec2-asg"
 }
+
+variable traffic_generator_zip {
+    default = "s3://aws-appsignals-sample-app-prod-<aws-region>/traffic-generator.zip"
+}

--- a/terraform/dotnet/ec2/default/main.tf
+++ b/terraform/dotnet/ec2/default/main.tf
@@ -307,7 +307,7 @@ resource "null_resource" "traffic_generator_setup" {
         sudo yum install nodejs aws-cli unzip tmux -y
 
         # Bring in the traffic generator files to EC2 Instance
-        aws s3 cp s3://aws-appsignals-sample-app-prod-${var.aws_region}/traffic-generator.zip ./traffic-generator.zip
+        aws s3 cp ${var.traffic_generator_zip} ./traffic-generator.zip
         unzip ./traffic-generator.zip -d ./
 
         # Install the traffic generator dependencies

--- a/terraform/dotnet/ec2/default/variables.tf
+++ b/terraform/dotnet/ec2/default/variables.tf
@@ -44,3 +44,7 @@ variable "canary_type" {
 variable "language_version" {
   default = "8.0"
 }
+
+variable traffic_generator_zip {
+    default = "s3://aws-appsignals-sample-app-prod-<aws-region>/traffic-generator.zip"
+}

--- a/terraform/dotnet/ec2/nuget/main.tf
+++ b/terraform/dotnet/ec2/nuget/main.tf
@@ -279,7 +279,7 @@ resource "null_resource" "traffic_generator_setup" {
         sudo yum install nodejs aws-cli unzip tmux -y
 
         # Bring in the traffic generator files to EC2 Instance
-        aws s3 cp s3://aws-appsignals-sample-app-prod-${var.aws_region}/traffic-generator.zip ./traffic-generator.zip
+        aws s3 cp ${var.traffic_generator_zip} ./traffic-generator.zip
         unzip ./traffic-generator.zip -d ./
 
         # Install the traffic generator dependencies

--- a/terraform/dotnet/ec2/nuget/variables.tf
+++ b/terraform/dotnet/ec2/nuget/variables.tf
@@ -36,3 +36,7 @@ variable "get_cw_agent_rpm_command" {
 variable "canary_type" {
   default = "dotnet-ec2-default"
 }
+
+variable traffic_generator_zip {
+    default = "s3://aws-appsignals-sample-app-prod-<aws-region>/traffic-generator.zip"
+}

--- a/terraform/dotnet/ec2/windows/main.tf
+++ b/terraform/dotnet/ec2/windows/main.tf
@@ -170,10 +170,10 @@ resource "aws_ssm_document" "main_service_setup" {
         "name": "setupMainService",
         "inputs": {
           "runCommand": [
-            "aws s3 cp s3://aws-appsignals-sample-app-prod-${var.aws_region}/amazon-cloudwatch-agent.json ./amazon-cloudwatch-agent.json",
+            "aws s3 cp s3://${var.sample_app_bucket_prefix}-${var.aws_region}/amazon-cloudwatch-agent.json ./amazon-cloudwatch-agent.json",
             "powershell -Command \"(Get-Content -Path 'amazon-cloudwatch-agent.json') -replace 'REGION', 'us-east-1' | Set-Content -Path 'amazon-cloudwatch-agent.json'\"",
-            "aws s3 cp s3://aws-appsignals-sample-app-prod-${var.aws_region}/dotnet-ec2-win-main-setup.ps1 ./dotnet-ec2-win-main-setup.ps1",
-            "powershell -ExecutionPolicy Bypass -File ./dotnet-ec2-win-main-setup.ps1 -GetCloudwatchAgentCommand \"${var.get_cw_agent_msi_command}\" -GetAdotDistroCommand \"${var.get_adot_distro_command}\" -GetSampleAppCommand \"${var.sample_app_zip}\" -TestId \"${var.test_id}\" -RemoteServicePrivateEndpoint \"${aws_instance.remote_service_instance.private_ip}\" -AWSRegion \"${var.aws_region}\""
+            "aws s3 cp s3://${var.sample_app_bucket_prefix}-${var.aws_region}/dotnet-ec2-win-main-setup.ps1 ./dotnet-ec2-win-main-setup.ps1",
+            "powershell -ExecutionPolicy Bypass -File ./dotnet-ec2-win-main-setup.ps1 -GetCloudwatchAgentCommand \"${var.get_cw_agent_msi_command}\" -GetAdotDistroCommand \"${var.get_adot_distro_command}\" -GetSampleAppCommand \"${var.sample_app_zip}\" -TestId \"${var.test_id}\" -RemoteServicePrivateEndpoint \"${aws_instance.remote_service_instance.private_ip}\" -AWSRegion \"${var.aws_region}\" -SampleAppBucketPrefix \"${var.sample_app_bucket_prefix}\""
           ]
         }
       }
@@ -197,9 +197,9 @@ resource "aws_ssm_document" "remote_service_setup" {
         "name": "setupRemoteService",
         "inputs": {
           "runCommand": [
-            "aws s3 cp s3://aws-appsignals-sample-app-prod-${var.aws_region}/amazon-cloudwatch-agent.json ./amazon-cloudwatch-agent.json",
+            "aws s3 cp s3://${var.sample_app_bucket_prefix}-${var.aws_region}/amazon-cloudwatch-agent.json ./amazon-cloudwatch-agent.json",
             "powershell -Command \"(Get-Content -Path 'amazon-cloudwatch-agent.json') -replace 'REGION', 'us-east-1' | Set-Content -Path 'amazon-cloudwatch-agent.json'\"",
-            "aws s3 cp s3://aws-appsignals-sample-app-prod-${var.aws_region}/dotnet-ec2-win-remote-setup.ps1 ./dotnet-ec2-win-remote-setup.ps1",
+            "aws s3 cp s3://${var.sample_app_bucket_prefix}-${var.aws_region}/dotnet-ec2-win-remote-setup.ps1 ./dotnet-ec2-win-remote-setup.ps1",
             "powershell -ExecutionPolicy Bypass -File ./dotnet-ec2-win-remote-setup.ps1 -GetCloudwatchAgentCommand \"${var.get_cw_agent_msi_command}\" -GetAdotDistroCommand \"${var.get_adot_distro_command}\" -GetSampleAppCommand \"${var.sample_app_zip}\" -TestId \"${var.test_id}\""
           ]
         }

--- a/terraform/dotnet/ec2/windows/variables.tf
+++ b/terraform/dotnet/ec2/windows/variables.tf
@@ -36,3 +36,7 @@ variable "get_adot_distro_command" {
 variable "get_cw_agent_msi_command" {
   default = "wget -O ./amazon-cloudwatch-agent.msi https://amazoncloudwatch-agent.s3.amazonaws.com/windows/amd64/latest/amazon-cloudwatch-agent.msi"
 }
+
+variable "sample_app_bucket_prefix" {
+    default = "aws-appsignals-sample-app-prod"
+}

--- a/terraform/dotnet/k8s/deploy/main.tf
+++ b/terraform/dotnet/k8s/deploy/main.tf
@@ -121,8 +121,8 @@ resource "null_resource" "deploy" {
       echo "LOG: Pulling sample app deployment files"
       # cd to ensure everything is downloaded into root directory so cleanup is each
       cd ~
-      aws s3api get-object --bucket aws-appsignals-sample-app-prod-us-east-1 --key dotnet-frontend-service-depl-${var.test_id}.yaml dotnet-frontend-service-depl.yaml
-      aws s3api get-object --bucket aws-appsignals-sample-app-prod-us-east-1 --key dotnet-remote-service-depl-${var.test_id}.yaml dotnet-remote-service-depl.yaml
+      aws s3api get-object --bucket ${var.sample_app_bucket_prefix}-us-east-1 --key dotnet-frontend-service-depl-${var.test_id}.yaml dotnet-frontend-service-depl.yaml
+      aws s3api get-object --bucket ${var.sample_app_bucket_prefix}-us-east-1 --key dotnet-remote-service-depl-${var.test_id}.yaml dotnet-remote-service-depl.yaml
 
       # Patch the staging image if this is running as part of release testing
       if [ "${var.repository}" = "aws-otel-dotnet-instrumentation" ]; then

--- a/terraform/dotnet/k8s/deploy/variables.tf
+++ b/terraform/dotnet/k8s/deploy/variables.tf
@@ -47,3 +47,7 @@ variable "release_testing_ecr_account" {
   default = "<aws-account-id>"
   description = "This variable is to give the k8s cluster ecr secret to pull image from the staging image ecr"
 }
+
+variable "sample_app_bucket_prefix" {
+    default = "aws-appsignals-sample-app-prod"
+}

--- a/terraform/java/ec2/adot-sigv4/main.tf
+++ b/terraform/java/ec2/adot-sigv4/main.tf
@@ -271,7 +271,7 @@ resource "null_resource" "traffic_generator_setup" {
         sudo yum install nodejs aws-cli unzip tmux -y
 
         # Bring in the traffic generator files to EC2 Instance
-        aws s3 cp s3://aws-appsignals-sample-app-prod-us-east-1/traffic-generator.zip ./traffic-generator.zip --region us-east-1
+        aws s3 cp ${var.traffic_generator_zip} ./traffic-generator.zip --region us-east-1
         unzip ./traffic-generator.zip -d ./
 
         # Install the traffic generator dependencies

--- a/terraform/java/ec2/adot-sigv4/variables.tf
+++ b/terraform/java/ec2/adot-sigv4/variables.tf
@@ -48,3 +48,7 @@ variable "language_version" {
 variable "cpu_architecture" {
   default = "x86_64"
 }
+
+variable traffic_generator_zip {
+    default = "s3://aws-appsignals-sample-app-prod-us-east-1/traffic-generator.zip"
+}

--- a/terraform/java/ec2/asg/main.tf
+++ b/terraform/java/ec2/asg/main.tf
@@ -145,7 +145,7 @@ resource "aws_launch_configuration" "launch_configuration" {
     sudo yum install nodejs aws-cli unzip tmux -y
 
     # Bring in the traffic generator files to EC2 Instance
-    aws s3 cp s3://aws-appsignals-sample-app-prod-${var.aws_region}/traffic-generator.zip ./traffic-generator.zip
+    aws s3 cp ${var.traffic_generator_zip} ./traffic-generator.zip
     unzip ./traffic-generator.zip -d ./
 
     # Install the traffic generator dependencies

--- a/terraform/java/ec2/asg/variables.tf
+++ b/terraform/java/ec2/asg/variables.tf
@@ -52,3 +52,7 @@ variable "language_version" {
   variable "cpu_architecture" {
   default = "x86_64"
 }
+
+variable traffic_generator_zip {
+    default = "s3://aws-appsignals-sample-app-prod-<aws-region>/traffic-generator.zip"
+}

--- a/terraform/java/ec2/default/main.tf
+++ b/terraform/java/ec2/default/main.tf
@@ -285,7 +285,7 @@ resource "null_resource" "traffic_generator_setup" {
         sudo yum install nodejs aws-cli unzip tmux -y
 
         # Bring in the traffic generator files to EC2 Instance
-        aws s3 cp s3://aws-appsignals-sample-app-prod-${var.aws_region}/traffic-generator.zip ./traffic-generator.zip
+        aws s3 cp ${var.traffic_generator_zip} ./traffic-generator.zip
         unzip ./traffic-generator.zip -d ./
 
         # Install the traffic generator dependencies

--- a/terraform/java/ec2/default/variables.tf
+++ b/terraform/java/ec2/default/variables.tf
@@ -52,3 +52,7 @@ variable "language_version" {
 variable "cpu_architecture" {
   default = "x86_64"
 }
+
+variable traffic_generator_zip {
+    default = "s3://aws-appsignals-sample-app-prod-<aws-region>/traffic-generator.zip"
+}

--- a/terraform/java/ec2/ubuntu/main.tf
+++ b/terraform/java/ec2/ubuntu/main.tf
@@ -303,7 +303,7 @@ resource "null_resource" "traffic_generator_setup" {
         sudo apt-get install -y awscli unzip tmux
 
         # Bring in the traffic generator files to EC2 Instance
-        aws s3 cp s3://aws-appsignals-sample-app-prod-${var.aws_region}/traffic-generator.zip ./traffic-generator.zip
+        aws s3 cp ${var.traffic_generator_zip} ./traffic-generator.zip
         unzip ./traffic-generator.zip -d ./
 
         # Install the traffic generator dependencies

--- a/terraform/java/ec2/ubuntu/variables.tf
+++ b/terraform/java/ec2/ubuntu/variables.tf
@@ -44,3 +44,7 @@ variable "get_adot_jar_command" {
 variable "canary_type" {
   default = "java-ec2-ubuntu"
 }
+
+variable traffic_generator_zip {
+    default = "s3://aws-appsignals-sample-app-prod-<aws-region>/traffic-generator.zip"
+}

--- a/terraform/java/k8s/deploy/main.tf
+++ b/terraform/java/k8s/deploy/main.tf
@@ -122,8 +122,8 @@ resource "null_resource" "deploy" {
 
       # cd to ensure everything is downloaded into root directory so cleanup is each
       cd ~
-      aws s3api get-object --bucket aws-appsignals-sample-app-prod-us-east-1 --key frontend-service-depl-${var.test_id}.yaml frontend-service-depl.yaml
-      aws s3api get-object --bucket aws-appsignals-sample-app-prod-us-east-1 --key remote-service-depl-${var.test_id}.yaml remote-service-depl.yaml
+      aws s3api get-object --bucket ${var.sample_app_bucket_prefix}-us-east-1 --key frontend-service-depl-${var.test_id}.yaml frontend-service-depl.yaml
+      aws s3api get-object --bucket ${var.sample_app_bucket_prefix}-us-east-1 --key remote-service-depl-${var.test_id}.yaml remote-service-depl.yaml
 
       # Patch the staging image if this is running as part of release testing
       if [ "${var.repository}" = "aws-otel-java-instrumentation" ]; then

--- a/terraform/java/k8s/deploy/variables.tf
+++ b/terraform/java/k8s/deploy/variables.tf
@@ -47,3 +47,7 @@ variable "release_testing_ecr_account" {
   default = "<aws-account-id>"
   description = "This variable is to give the k8s cluster ecr secret to pull image from the staging image ecr"
 }
+
+variable "sample_app_bucket_prefix" {
+    default = "aws-appsignals-sample-app-prod"
+}

--- a/terraform/node/ec2/adot-sigv4/main.tf
+++ b/terraform/node/ec2/adot-sigv4/main.tf
@@ -310,7 +310,7 @@ resource "null_resource" "traffic_generator_setup" {
     inline = [
       <<-EOF
         # Bring in the traffic generator files to EC2 Instance
-        aws s3 cp s3://aws-appsignals-sample-app-prod-us-east-1/traffic-generator.zip ./traffic-generator.zip
+        aws s3 cp ${var.traffic_generator_zip} ./traffic-generator.zip
         unzip ./traffic-generator.zip -d ./
 
         # Install the traffic generator dependencies

--- a/terraform/node/ec2/adot-sigv4/variables.tf
+++ b/terraform/node/ec2/adot-sigv4/variables.tf
@@ -46,3 +46,7 @@ variable "get_adot_instrumentation_command" {
 variable "canary_type" {
   default = "node-ec2-default"
 }
+
+variable traffic_generator_zip {
+    default = "s3://aws-appsignals-sample-app-prod-us-east-1/traffic-generator.zip"
+}

--- a/terraform/node/ec2/asg/main.tf
+++ b/terraform/node/ec2/asg/main.tf
@@ -162,7 +162,7 @@ resource "aws_launch_configuration" "launch_configuration" {
 
     # Bring in the traffic generator files to EC2 Instance
     cd ..
-    aws s3 cp s3://aws-appsignals-sample-app-prod-${var.aws_region}/traffic-generator.zip ./traffic-generator.zip
+    aws s3 cp ${var.traffic_generator_zip} ./traffic-generator.zip
     unzip ./traffic-generator.zip -d ./
 
     # Install the traffic generator dependencies

--- a/terraform/node/ec2/asg/variables.tf
+++ b/terraform/node/ec2/asg/variables.tf
@@ -40,3 +40,7 @@ variable "get_cw_agent_rpm_command" {
 variable "canary_type" {
   default = "node-ec2-default"
 }
+
+variable traffic_generator_zip {
+    default = "s3://aws-appsignals-sample-app-prod-<aws-region>/traffic-generator.zip"
+}

--- a/terraform/node/ec2/default/main.tf
+++ b/terraform/node/ec2/default/main.tf
@@ -326,7 +326,7 @@ resource "null_resource" "traffic_generator_setup" {
     inline = [
       <<-EOF
         # Bring in the traffic generator files to EC2 Instance
-        aws s3 cp s3://aws-appsignals-sample-app-prod-${var.aws_region}/traffic-generator.zip ./traffic-generator.zip
+        aws s3 cp ${var.traffic_generator_zip} ./traffic-generator.zip
         unzip ./traffic-generator.zip -d ./
 
         # Install the traffic generator dependencies

--- a/terraform/node/ec2/default/variables.tf
+++ b/terraform/node/ec2/default/variables.tf
@@ -50,3 +50,7 @@ variable "get_cw_agent_rpm_command" {
 variable "canary_type" {
   default = "node-ec2-default"
 }
+
+variable traffic_generator_zip {
+    default = "s3://aws-appsignals-sample-app-prod-<aws-region>/traffic-generator.zip"
+}

--- a/terraform/node/k8s/deploy/main.tf
+++ b/terraform/node/k8s/deploy/main.tf
@@ -124,8 +124,8 @@ resource "null_resource" "deploy" {
 
       # cd to ensure everything is downloaded into root directory so cleanup is each
       cd ~
-      aws s3api get-object --bucket aws-appsignals-sample-app-prod-us-east-1 --key frontend-service-depl-${var.test_id}.yaml frontend-service-depl.yaml
-      aws s3api get-object --bucket aws-appsignals-sample-app-prod-us-east-1 --key remote-service-depl-${var.test_id}.yaml remote-service-depl.yaml
+      aws s3api get-object --bucket ${var.sample_app_bucket_prefix}-us-east-1 --key frontend-service-depl-${var.test_id}.yaml frontend-service-depl.yaml
+      aws s3api get-object --bucket ${var.sample_app_bucket_prefix}-us-east-1 --key remote-service-depl-${var.test_id}.yaml remote-service-depl.yaml
 
       # Patch the staging image if this is running as part of release testing
       if [ "${var.repository}" = "aws-otel-js-instrumentation" ]; then

--- a/terraform/node/k8s/deploy/variables.tf
+++ b/terraform/node/k8s/deploy/variables.tf
@@ -47,3 +47,7 @@ variable "release_testing_ecr_account" {
   default = "<aws-account-id>"
   description = "This variable is to give the k8s cluster ecr secret to pull image from the staging image ecr"
 }
+
+variable "sample_app_bucket_prefix" {
+    default = "aws-appsignals-sample-app-prod"
+}

--- a/terraform/python/ec2/adot-sigv4/main.tf
+++ b/terraform/python/ec2/adot-sigv4/main.tf
@@ -334,7 +334,7 @@ resource "null_resource" "traffic_generator_setup" {
         sudo yum install nodejs aws-cli unzip tmux -y
 
         # Bring in the traffic generator files to EC2 Instance
-        aws s3 cp s3://aws-appsignals-sample-app-prod-us-east-1/traffic-generator.zip ./traffic-generator.zip
+        aws s3 cp ${var.traffic_generator_zip} ./traffic-generator.zip
         unzip ./traffic-generator.zip -d ./
 
         # Install the traffic generator dependencies

--- a/terraform/python/ec2/adot-sigv4/variables.tf
+++ b/terraform/python/ec2/adot-sigv4/variables.tf
@@ -44,3 +44,7 @@ variable "language_version" {
 variable "cpu_architecture" {
   default = "x86_64"
 }
+
+variable traffic_generator_zip {
+    default = "s3://aws-appsignals-sample-app-prod-us-east-1/traffic-generator.zip"
+}

--- a/terraform/python/ec2/asg/main.tf
+++ b/terraform/python/ec2/asg/main.tf
@@ -176,7 +176,7 @@ resource "aws_launch_configuration" "launch_configuration" {
     sudo yum install nodejs aws-cli unzip tmux -y
 
     # Bring in the traffic generator files to EC2 Instance
-    aws s3 cp s3://aws-appsignals-sample-app-prod-${var.aws_region}/traffic-generator.zip ./traffic-generator.zip
+    aws s3 cp ${var.traffic_generator_zip} ./traffic-generator.zip
     unzip ./traffic-generator.zip -d ./
 
     # Install the traffic generator dependencies

--- a/terraform/python/ec2/asg/variables.tf
+++ b/terraform/python/ec2/asg/variables.tf
@@ -48,3 +48,7 @@ variable "language_version" {
 variable "cpu_architecture" {
   default = "x86_64"
 }
+
+variable traffic_generator_zip {
+    default = "s3://aws-appsignals-sample-app-prod-<aws-region>/traffic-generator.zip"
+}

--- a/terraform/python/ec2/default/main.tf
+++ b/terraform/python/ec2/default/main.tf
@@ -351,7 +351,7 @@ resource "null_resource" "traffic_generator_setup" {
         sudo yum install nodejs aws-cli unzip tmux -y
 
         # Bring in the traffic generator files to EC2 Instance
-        aws s3 cp s3://aws-appsignals-sample-app-prod-${var.aws_region}/traffic-generator.zip ./traffic-generator.zip
+        aws s3 cp ${var.traffic_generator_zip} ./traffic-generator.zip
         unzip ./traffic-generator.zip -d ./
 
         # Install the traffic generator dependencies

--- a/terraform/python/ec2/default/variables.tf
+++ b/terraform/python/ec2/default/variables.tf
@@ -48,3 +48,7 @@ variable "language_version" {
 variable "cpu_architecture" {
   default = "x86_64"
 }
+
+variable traffic_generator_zip {
+    default = "s3://aws-appsignals-sample-app-prod-<aws-region>/traffic-generator.zip"
+}

--- a/terraform/python/k8s/deploy/main.tf
+++ b/terraform/python/k8s/deploy/main.tf
@@ -123,8 +123,8 @@ resource "null_resource" "deploy" {
       echo "LOG: Pulling sample app deployment files"
       # cd to ensure everything is downloaded into root directory so cleanup is each
       cd ~
-      aws s3api get-object --bucket aws-appsignals-sample-app-prod-us-east-1 --key python-frontend-service-depl-${var.test_id}.yaml python-frontend-service-depl.yaml
-      aws s3api get-object --bucket aws-appsignals-sample-app-prod-us-east-1 --key python-remote-service-depl-${var.test_id}.yaml python-remote-service-depl.yaml
+      aws s3api get-object --bucket ${var.sample_app_bucket_prefix}-us-east-1 --key python-frontend-service-depl-${var.test_id}.yaml python-frontend-service-depl.yaml
+      aws s3api get-object --bucket ${var.sample_app_bucket_prefix}-us-east-1 --key python-remote-service-depl-${var.test_id}.yaml python-remote-service-depl.yaml
 
       # Patch the staging image if this is running as part of release testing
       if [ "${var.repository}" = "aws-otel-python-instrumentation" ]; then

--- a/terraform/python/k8s/deploy/variables.tf
+++ b/terraform/python/k8s/deploy/variables.tf
@@ -47,3 +47,7 @@ variable "release_testing_ecr_account" {
   default = "<aws-account-id>"
   description = "This variable is to give the k8s cluster ecr secret to pull image from the staging image ecr"
 }
+
+variable "sample_app_bucket_prefix" {
+    default = "aws-appsignals-sample-app-prod"
+}


### PR DESCRIPTION
*Issue description:*

We have a hard dependency on the `aws-appsignals-sample-app-prod-region` bucket, which made running anything in personal repos impossible.

*Description of changes:*
Replace all references to bucket with input (with default). Also disables fail-fast in traffic-generator-image-build.yml, which was another thing that would fail in personal repos.

*Rollback procedure:*

Simple revert.

*Ensure you've run the following tests on your changes and include the link below:*

### Tested:
* dotnet-sample-app-s3-deploy.yml - https://github.com/thpierce/aws-application-signals-test-framework/actions/runs/14917895356 (only passes in us-east-1, because I only created that bucket)
* ava-sample-app-s3-deploy.yml - https://github.com/thpierce/aws-application-signals-test-framework/actions/runs/14916546220 (only passes in us-east-1, because I only created that bucket)
* traffic-generator-image-build.yml - https://github.com/thpierce/aws-application-signals-test-framework/actions/runs/14917895356 (only passes in us-east-1, because I only created that bucket)
* https://github.com/aws/amazon-cloudwatch-agent/actions/runs/14918129559
   * java-ec2-default-test.yml
   * java-ec2-asg-test.yml
   * java-k8s-test.yml
   * python-ec2-default-test.yml
   * python-ec2-asg-test.yml
   * python-k8s-test.yml
   * node-ec2-default-test.yml
   * node-ec2-asg-test.yml
   * node-k8s-test.yml
   * dotnet-ec2-default-test.yml
   * dotnet-ec2-windows-test.yml
   * dotnet-k8s-test.yml
* dotnet-ec2-adot-sigv4-test.yml - PENDING
* dotnet-ec2-asg-test.yml - PENDING
* dotnet-ec2-nuget-test.yml - PENDING
* dotnet-lambda-test.yml - PENDING
* java-ec2-adot-sigv4-test.yml - PENDING
* java-ec2-ubuntu-test.yml - PENDING
* java-lambda-test.yml - PENDING
* node-ec2-adot-sigv4-test.yml - PENDING
* node-lambda-test.yml - PENDING
* python-ec2-adot-sigv4-test.yml - PENDING
* python-lambda-test.yml - PENDING

### Not tested (not impacted by changes)
* Unrelated workflows/no relevant S3 usage:
   * appsignals-e2e-gamma-test.yml
   * dummy-k8s-test.yml
   * enablement-test-publish-result.yml
   * k8s-patch-os-jobs.yml
   * k8s-patch-os-matrix.yml
   * pr-build.yml
* EKS/ECR tests don't use S3 bucket:
   * dotnet-eks-test.yml
   * dotnet-eks-windows-test.yml
   * dotnet-sample-app-ecr-deploy.yml
   * java-ecs-test.yml
   * java-eks-otlp-ocb-canary.yml
   * java-eks-otlp-ocb-retry.yml
   * java-eks-otlp-ocb-test.yml
   * java-eks-test.yml
   * java-sample-app-ecr-deploy.yml
   * node-ecs-test.yml
   * node-eks-test.yml
   * metric-limiter-test.yml
   * node-sample-app-ecr-deploy.yml
   * python-ecs-test.yml
   * python-eks-test.yml
   * python-sample-app-ecr-deploy.yml
* Lambda perf tests don't use S3 bucket:
   * dotnet-lambda-layer-perf-test.yml
   * java-lambda-layer-perf-test.yml
   * node-lambda-layer-perf-test.yml
   * python-lambda-layer-perf-test.yml
* Uses a different S3 bucket (or possibly the same? Need to look at secret val)
   * node-sample-app-s3-deploy.yml
   * python-sample-app-s3-deploy.yml
   * resource-cleanup.yml


NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
