### PR TITLE
[Python] Fix sig v4 test

### DIFF
--- a/.github/workflows/python-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/python-ec2-adot-sigv4-test.yml
@@ -6,6 +6,9 @@
 # Read more about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview
 name: Python EC2 ADOT SigV4 (Stand-Alone ADOT) Use Case
 on:
+  push:
+    branches:
+      - Python_SigV4_test
   workflow_call:
     inputs:
       caller-workflow-name:
@@ -33,8 +36,8 @@ permissions:
 env:
   E2E_TEST_AWS_REGION: 'us-west-2'
   CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
-  PYTHON_VERSION: ${{ inputs.python-version }}
-  CPU_ARCHITECTURE: ${{ inputs.cpu-architecture }}
+  PYTHON_VERSION: ${{ inputs.python-version || '3.9' }}
+  CPU_ARCHITECTURE: ${{ inputs.cpu-architecture || 'x86_64' }}
   ADOT_WHEEL_NAME: ${{ inputs.staging-wheel-name }}
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
@@ -76,15 +79,15 @@ jobs:
 
       - name: Set Get ADOT Wheel command environment variable
         run: |
-          if [ "${{ github.event.repository.name }}" = "aws-otel-python-instrumentation" ]; then
+          # if [ "${{ github.event.repository.name }}" = "aws-otel-python-instrumentation" ]; then
             # Reusing the adot-main-build-staging-jar bucket to store the python wheel file
-            echo GET_ADOT_WHEEL_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && sudo python${{ env.PYTHON_VERSION }} -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
-          else
-            latest_release_version=$(curl -sL https://github.com/aws-observability/aws-otel-python-instrumentation/releases/latest | grep -oP '/releases/tag/v\K[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
-            echo "The latest version is $latest_release_version"
-            echo GET_ADOT_WHEEL_COMMAND="wget -O ${{ env.ADOT_WHEEL_NAME }} https://github.com/aws-observability/aws-otel-python-instrumentation/releases/latest/download/aws_opentelemetry_distro-$latest_release_version-py3-none-any.whl \
-            && sudo python${{ env.PYTHON_VERSION }} -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
-          fi
+          echo GET_ADOT_WHEEL_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && sudo python${{ env.PYTHON_VERSION }} -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
+          # else
+          #   latest_release_version=$(curl -sL https://github.com/aws-observability/aws-otel-python-instrumentation/releases/latest | grep -oP '/releases/tag/v\K[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
+          #   echo "The latest version is $latest_release_version"
+          #   echo GET_ADOT_WHEEL_COMMAND="wget -O ${{ env.ADOT_WHEEL_NAME }} https://github.com/aws-observability/aws-otel-python-instrumentation/releases/latest/download/aws_opentelemetry_distro-$latest_release_version-py3-none-any.whl \
+          #   && sudo python${{ env.PYTHON_VERSION }} -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
+          # fi
 
       - name: Set up terraform
         uses: ./.github/workflows/actions/execute_and_retry

--- a/.github/workflows/python-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/python-ec2-adot-sigv4-test.yml
@@ -193,7 +193,7 @@ jobs:
         run: ./gradlew validator:run --args='-c python/ec2/adot-sigv4/metric-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://localhost:8000
-          --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8001
+          --remote-service-deployment-name python-sample-remote-application-${{ env.TESTING_ID }}
           --region ${{ env.E2E_TEST_AWS_REGION }}
           --metric-namespace ${{ env.METRIC_NAMESPACE }}
           --log-group ${{ env.LOG_GROUP_NAME }}

--- a/.github/workflows/python-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/python-ec2-adot-sigv4-test.yml
@@ -6,9 +6,6 @@
 # Read more about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview
 name: Python EC2 ADOT SigV4 (Stand-Alone ADOT) Use Case
 on:
-  push:
-    branches:
-      - Python_SigV4_test
   workflow_call:
     inputs:
       caller-workflow-name:
@@ -36,9 +33,9 @@ permissions:
 env:
   E2E_TEST_AWS_REGION: 'us-west-2'
   CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
-  PYTHON_VERSION: ${{ inputs.python-version || '3.9' }}
-  CPU_ARCHITECTURE: ${{ inputs.cpu-architecture || 'x86_64' }}
-  ADOT_WHEEL_NAME: ${{ inputs.staging-wheel-name || 'aws-opentelemetry-distro' }}
+  PYTHON_VERSION: ${{ inputs.python-version }}
+  CPU_ARCHITECTURE: ${{ inputs.cpu-architecture }}
+  ADOT_WHEEL_NAME: ${{ inputs.staging-wheel-name }}
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
   METRIC_NAMESPACE: ApplicationSignals

--- a/.github/workflows/python-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/python-ec2-adot-sigv4-test.yml
@@ -38,7 +38,7 @@ env:
   CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
   PYTHON_VERSION: ${{ inputs.python-version || '3.9' }}
   CPU_ARCHITECTURE: ${{ inputs.cpu-architecture || 'x86_64' }}
-  ADOT_WHEEL_NAME: ${{ inputs.staging-wheel-name }}
+  ADOT_WHEEL_NAME: ${{ inputs.staging-wheel-name || 'aws-opentelemetry-distro' }}
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
   METRIC_NAMESPACE: ApplicationSignals

--- a/.github/workflows/python-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/python-ec2-adot-sigv4-test.yml
@@ -79,15 +79,15 @@ jobs:
 
       - name: Set Get ADOT Wheel command environment variable
         run: |
-          # if [ "${{ github.event.repository.name }}" = "aws-otel-python-instrumentation" ]; then
+          if [ "${{ github.event.repository.name }}" = "aws-otel-python-instrumentation" ]; then
             # Reusing the adot-main-build-staging-jar bucket to store the python wheel file
-          echo GET_ADOT_WHEEL_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && sudo python${{ env.PYTHON_VERSION }} -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
-          # else
-          #   latest_release_version=$(curl -sL https://github.com/aws-observability/aws-otel-python-instrumentation/releases/latest | grep -oP '/releases/tag/v\K[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
-          #   echo "The latest version is $latest_release_version"
-          #   echo GET_ADOT_WHEEL_COMMAND="wget -O ${{ env.ADOT_WHEEL_NAME }} https://github.com/aws-observability/aws-otel-python-instrumentation/releases/latest/download/aws_opentelemetry_distro-$latest_release_version-py3-none-any.whl \
-          #   && sudo python${{ env.PYTHON_VERSION }} -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
-          # fi
+            echo GET_ADOT_WHEEL_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && sudo python${{ env.PYTHON_VERSION }} -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
+          else
+            latest_release_version=$(curl -sL https://github.com/aws-observability/aws-otel-python-instrumentation/releases/latest | grep -oP '/releases/tag/v\K[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
+            echo "The latest version is $latest_release_version"
+            echo GET_ADOT_WHEEL_COMMAND="wget -O ${{ env.ADOT_WHEEL_NAME }} https://github.com/aws-observability/aws-otel-python-instrumentation/releases/latest/download/aws_opentelemetry_distro-$latest_release_version-py3-none-any.whl \
+            && sudo python${{ env.PYTHON_VERSION }} -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> $GITHUB_ENV
+          fi
 
       - name: Set up terraform
         uses: ./.github/workflows/actions/execute_and_retry

--- a/validator/src/main/resources/expected-data-template/python/ec2/adot-sigv4/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/adot-sigv4/aws-sdk-call-metric.mustache
@@ -4,7 +4,7 @@
   dimensions:
     -
       name: Operation
-      value: GET aws-sdk-call
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -80,7 +80,7 @@
   dimensions:
     -
       name: Operation
-      value: GET aws-sdk-call
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -94,7 +94,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -156,7 +156,7 @@
   dimensions:
     -
       name: Operation
-      value: GET aws-sdk-call
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -170,7 +170,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/python/ec2/adot-sigv4/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/adot-sigv4/aws-sdk-call-metric.mustache
@@ -4,7 +4,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -80,7 +80,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -94,7 +94,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -156,7 +156,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -170,7 +170,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /aws-sdk-call
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/python/ec2/adot-sigv4/outgoing-http-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/adot-sigv4/outgoing-http-call-metric.mustache
@@ -4,7 +4,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -80,7 +80,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -94,7 +94,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -156,7 +156,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -170,7 +170,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /outgoing-http-call
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/python/ec2/adot-sigv4/outgoing-http-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/adot-sigv4/outgoing-http-call-metric.mustache
@@ -4,7 +4,7 @@
   dimensions:
     -
       name: Operation
-      value: GET outgoing-http-call
+      value: GET /outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -80,7 +80,7 @@
   dimensions:
     -
       name: Operation
-      value: GET outgoing-http-call
+      value: GET /outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -94,7 +94,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -156,7 +156,7 @@
   dimensions:
     -
       name: Operation
-      value: GET outgoing-http-call
+      value: GET /outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -170,7 +170,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /outgoing-http-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/python/ec2/adot-sigv4/remote-service-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/adot-sigv4/remote-service-metric.mustache
@@ -4,7 +4,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -27,7 +27,7 @@
       value: ec2:default
     -
       name: RemoteOperation
-      value: GET /healthcheck
+      value: GET healthcheck
     -
       name: RemoteService
       value: {{remoteServiceDeploymentName}}
@@ -94,7 +94,7 @@
       value: ec2:default
     -
       name: RemoteOperation
-      value: GET /healthcheck
+      value: GET healthcheck
     -
       name: RemoteService
       value: {{remoteServiceDeploymentName}}
@@ -113,7 +113,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -127,7 +127,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -136,7 +136,7 @@
       value: ec2:default
     -
       name: RemoteOperation
-      value: GET /healthcheck
+      value: GET healthcheck
     -
       name: RemoteService
       value: {{remoteServiceDeploymentName}}
@@ -203,7 +203,7 @@
       value: ec2:default
     -
       name: RemoteOperation
-      value: GET /healthcheck
+      value: GET healthcheck
     -
       name: RemoteService
       value: {{remoteServiceDeploymentName}}
@@ -222,7 +222,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -236,7 +236,7 @@
   dimensions:
     -
       name: Operation
-      value: GET /remote-service
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -245,7 +245,7 @@
       value: ec2:default
     -
       name: RemoteOperation
-      value: GET /healthcheck
+      value: GET healthcheck
     -
       name: RemoteService
       value: {{remoteServiceDeploymentName}}
@@ -312,7 +312,7 @@
       value: ec2:default
     -
       name: RemoteOperation
-      value: GET /healthcheck
+      value: GET healthcheck
     -
       name: RemoteService
       value: {{remoteServiceDeploymentName}}

--- a/validator/src/main/resources/expected-data-template/python/ec2/adot-sigv4/remote-service-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/adot-sigv4/remote-service-metric.mustache
@@ -4,7 +4,7 @@
   dimensions:
     -
       name: Operation
-      value: GET remote-service
+      value: GET /remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -113,7 +113,7 @@
   dimensions:
     -
       name: Operation
-      value: GET remote-service
+      value: GET /remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -127,7 +127,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -222,7 +222,7 @@
   dimensions:
     -
       name: Operation
-      value: GET remote-service
+      value: GET /remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -236,7 +236,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /remote-service
     -
       name: Service
       value: {{serviceName}}


### PR DESCRIPTION
*Issue description:*
The ADOT Python Sigv4 test was failing because the Xray backend team changed the value of the dimensions of Metric validator.

*Description of changes:*
The dimension values were updated to be consistent with the changes from the backend.

Test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/14928565768

*Rollback procedure:*

<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
