### PR TITLE
[Dotnet] Fix sig v4 test

### DIFF
--- a/.github/workflows/dotnet-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/dotnet-ec2-adot-sigv4-test.yml
@@ -6,6 +6,9 @@
 # Read more about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview
 name: DotNet EC2 ADOT SigV4 (Stand-Alone ADOT) Use Case
 on:
+  push:
+    branches:
+      - Dotnet_SigV4_Test
   workflow_call:
     inputs:
       caller-workflow-name:
@@ -29,11 +32,11 @@ env:
   E2E_TEST_AWS_REGION: 'us-west-2'
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
-  DOTNET_VERSION: ${{ inputs.dotnet-version }}
-  SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-us-east-1/dotnet-sample-app-${{ inputs.dotnet-version }}.zip
+  DOTNET_VERSION: ${{ inputs.dotnet-version || '8.0' }}
+  SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-us-east-1/dotnet-sample-app-${{ inputs.dotnet-version || '8.0' }}.zip
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: aws/spans
-  ADOT_DISTRO_NAME: ${{ inputs.staging_distro_name }}
+  ADOT_DISTRO_NAME: ${{ inputs.staging_distro_name || 'aws-opentelemetry-distro' }}
   TEST_RESOURCES_FOLDER: ${GITHUB_WORKSPACE}
 
 jobs:

--- a/.github/workflows/dotnet-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/dotnet-ec2-adot-sigv4-test.yml
@@ -6,9 +6,6 @@
 # Read more about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview
 name: DotNet EC2 ADOT SigV4 (Stand-Alone ADOT) Use Case
 on:
-  push:
-    branches:
-      - Dotnet_SigV4_Test
   workflow_call:
     inputs:
       caller-workflow-name:
@@ -32,11 +29,11 @@ env:
   E2E_TEST_AWS_REGION: 'us-west-2'
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
-  DOTNET_VERSION: ${{ inputs.dotnet-version || '8.0' }}
-  SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-us-east-1/dotnet-sample-app-${{ inputs.dotnet-version || '8.0' }}.zip
+  DOTNET_VERSION: ${{ inputs.dotnet-version }}
+  SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-us-east-1/dotnet-sample-app-${{ inputs.dotnet-version }}.zip
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: aws/spans
-  ADOT_DISTRO_NAME: ${{ inputs.staging_distro_name || 'aws-opentelemetry-distro' }}
+  ADOT_DISTRO_NAME: ${{ inputs.staging_distro_name }}
   TEST_RESOURCES_FOLDER: ${GITHUB_WORKSPACE}
 
 jobs:

--- a/.github/workflows/dotnet-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/dotnet-ec2-adot-sigv4-test.yml
@@ -181,7 +181,7 @@ jobs:
         run: ./gradlew validator:run --args='-c dotnet/ec2/adot-sigv4/metric-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://localhost:8080
-          --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8081
+          --remote-service-deployment-name dotnet-sample-remote-application-${{ env.TESTING_ID }}
           --region ${{ env.E2E_TEST_AWS_REGION }}
           --metric-namespace ${{ env.METRIC_NAMESPACE }}
           --log-group ${{ env.LOG_GROUP_NAME }}

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/adot-sigv4/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/adot-sigv4/aws-sdk-call-metric.mustache
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -94,7 +94,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -170,7 +170,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET aws-sdk-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/adot-sigv4/outgoing-http-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/adot-sigv4/outgoing-http-call-metric.mustache
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -94,7 +94,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -170,7 +170,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET outgoing-http-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/adot-sigv4/remote-service-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/adot-sigv4/remote-service-metric.mustache
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -27,7 +27,7 @@
       value: ec2:default
     -
       name: RemoteOperation
-      value: GET /healthcheck
+      value: GET healthcheck
     -
       name: RemoteService
       value: {{remoteServiceDeploymentName}}
@@ -94,7 +94,7 @@
       value: ec2:default
     -
       name: RemoteOperation
-      value: GET /healthcheck
+      value: GET healthcheck
     -
       name: RemoteService
       value: {{remoteServiceDeploymentName}}
@@ -127,7 +127,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -136,7 +136,7 @@
       value: ec2:default
     -
       name: RemoteOperation
-      value: GET /healthcheck
+      value: GET healthcheck
     -
       name: RemoteService
       value: {{remoteServiceDeploymentName}}
@@ -203,7 +203,7 @@
       value: ec2:default
     -
       name: RemoteOperation
-      value: GET /healthcheck
+      value: GET healthcheck
     -
       name: RemoteService
       value: {{remoteServiceDeploymentName}}
@@ -236,7 +236,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -245,7 +245,7 @@
       value: ec2:default
     -
       name: RemoteOperation
-      value: GET /healthcheck
+      value: GET healthcheck
     -
       name: RemoteService
       value: {{remoteServiceDeploymentName}}
@@ -312,7 +312,7 @@
       value: ec2:default
     -
       name: RemoteOperation
-      value: GET /healthcheck
+      value: GET healthcheck
     -
       name: RemoteService
       value: {{remoteServiceDeploymentName}}


### PR DESCRIPTION
*Issue description:*
The ADOT Dotnet Sigv4 test was failing because the Xray backend team changed the value of the dimensions of Metric validator.

*Description of changes:*
The dimension values were updated to be consistent with the changes from the backend.

Test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/14938571788/job/41971542923

*Rollback procedure:*

<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
