### PR TITLE
[Node] Fix sig v4 test

### DIFF
--- a/.github/workflows/node-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/node-ec2-adot-sigv4-test.yml
@@ -195,7 +195,7 @@ jobs:
         run: ./gradlew validator:run --args='-c node/ec2/adot-sigv4/metric-validation.yml
           --testing-id ${{ env.TESTING_ID }}
           --endpoint http://${{ env.MAIN_SERVICE_ENDPOINT }}
-          --remote-service-deployment-name ${{ env.REMOTE_SERVICE_IP }}:8001
+          --remote-service-deployment-name node-sample-remote-application-${{ env.TESTING_ID }}
           --region ${{ env.E2E_TEST_AWS_REGION }}
           --account-id ${{ env.E2E_TEST_ACCOUNT_ID }}
           --metric-namespace ${{ env.METRIC_NAMESPACE }}

--- a/.github/workflows/node-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/node-ec2-adot-sigv4-test.yml
@@ -6,6 +6,9 @@
 # Read more about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview
 name: Node EC2 ADOT SigV4 Use Case
 on:
+  push:
+    branches:
+      - Node_SigV4_test
   workflow_call:
     inputs:
       caller-workflow-name:
@@ -34,9 +37,9 @@ permissions:
 env:
   E2E_TEST_AWS_REGION: 'us-west-2'
   CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
-  NODE_VERSION: ${{ inputs.node-version }}
-  CPU_ARCHITECTURE: ${{ inputs.cpu-architecture }}
-  ADOT_INSTRUMENTATION_NAME: ${{ inputs.staging-instrumentation-name }}
+  NODE_VERSION: ${{ inputs.node-version || 'none' }}
+  CPU_ARCHITECTURE: ${{ inputs.cpu-architecture || 'x86_64' }}
+  ADOT_INSTRUMENTATION_NAME: ${{ inputs.staging-instrumentation-name || '@aws/aws-distro-opentelemetry-node-autoinstrumentation' }}
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
   METRIC_NAMESPACE: ApplicationSignals

--- a/.github/workflows/node-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/node-ec2-adot-sigv4-test.yml
@@ -6,9 +6,6 @@
 # Read more about reusable workflows: https://docs.github.com/en/actions/using-workflows/reusing-workflows#overview
 name: Node EC2 ADOT SigV4 Use Case
 on:
-  push:
-    branches:
-      - Node_SigV4_test
   workflow_call:
     inputs:
       caller-workflow-name:
@@ -37,9 +34,9 @@ permissions:
 env:
   E2E_TEST_AWS_REGION: 'us-west-2'
   CALLER_WORKFLOW_NAME: ${{ inputs.caller-workflow-name }}
-  NODE_VERSION: ${{ inputs.node-version || 'none' }}
-  CPU_ARCHITECTURE: ${{ inputs.cpu-architecture || 'x86_64' }}
-  ADOT_INSTRUMENTATION_NAME: ${{ inputs.staging-instrumentation-name || '@aws/aws-distro-opentelemetry-node-autoinstrumentation' }}
+  NODE_VERSION: ${{ inputs.node-version }}
+  CPU_ARCHITECTURE: ${{ inputs.cpu-architecture }}
+  ADOT_INSTRUMENTATION_NAME: ${{ inputs.staging-instrumentation-name }}
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
   METRIC_NAMESPACE: ApplicationSignals

--- a/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/aws-sdk-call-metric.mustache
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -94,7 +94,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}
@@ -170,7 +170,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /aws-sdk-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/outgoing-http-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/outgoing-http-call-metric.mustache
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -94,7 +94,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /outgoing-http-call
     -
       name: Service
       value: {{serviceName}}
@@ -170,7 +170,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /outgoing-http-call
     -
       name: Service
       value: {{serviceName}}

--- a/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/remote-service-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/node/ec2/adot-sigv4/remote-service-metric.mustache
@@ -18,7 +18,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -127,7 +127,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /remote-service
     -
       name: Service
       value: {{serviceName}}
@@ -236,7 +236,7 @@
   dimensions:
     -
       name: Operation
-      value: UnmappedOperation
+      value: GET /remote-service
     -
       name: Service
       value: {{serviceName}}


### PR DESCRIPTION
*Issue description:*
The ADOT Node Sigv4 test was failing because the Xray backend team changed the value of the dimensions of Metric validator.

*Description of changes:*
The dimension values were updated to be consistent with the changes from the backend.

Test run: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/14939073485

*Rollback procedure:*

<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
