### PR TITLE
Adding a custom log

### DIFF
--- a/sample-apps/python/django_frontend_service/frontend_service_app/views.py
+++ b/sample-apps/python/django_frontend_service/frontend_service_app/views.py
@@ -56,6 +56,7 @@ def aws_sdk_call(request):
     testing_id = request.GET.get('testingId', None)
     if testing_id is not None:
         bucket_name += "-" + testing_id
+    logger.warning("This is a custom log for validation testing")
     s3_client = boto3.client("s3")
     try:
         s3_client.get_bucket_location(


### PR DESCRIPTION
*Issue description:*
We need a reliable way to validate SigV4 logs across different language implementations (Python, JavaScript, .NET, Java) for our sample applications. The current logging doesn't provide a consistent, easily identifiable log entry for this purpose.

*Description of changes:*
Added a custom WARNING log in the aws_sdk_call function of the Python sample application. This custom log will be present in the log-group and can be used to filter logs from those created while running the sample application. This change provides a consistent log entry that can be replicated across other language implementations for uniform SigV4 log validation.

*Rollback procedure:*
<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>
1. Remove the line logger.warning("This is a custom log for validation testing") from the aws_sdk_call function in views.py
2. Commit and push the change
3. Redeploy the application

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
