### PR TITLE
[OCB] Update ADOT Java version to 2.11.0

### DIFF
--- a/terraform/java/eks-otlp-ocb/util/appsignals-collector.yaml
+++ b/terraform/java/eks-otlp-ocb/util/appsignals-collector.yaml
@@ -161,7 +161,7 @@ spec:
   exporter: 
     endpoint: http://appsignals-collector:4318
   java:
-    image: public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v1.32.5
+    image: public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v2.11.0
     env:
       - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
         value: http://appsignals-collector:4318/v1/traces


### PR DESCRIPTION
### Background
OTLP OCB Canary tests OTel components vended by AWS against the OTLP endpoint and ADOT by building a custom collector using said components. The ADOT version in this test has to refer to the tag of the latest revision of ADOT which does not use `latest`, hence the need for a manual update.

### Changes
Changing version to 2.11.0 for ADOT in OTLP OCB canary deployment configs

### Testing
N/A - Canary shouldn't need config changes for ADOT to work, simply a version bump. If there is an issue, we will see it in our canaries and deal with it as a high severity issue