### PR TITLE
[Java] Adding a custom log

### DIFF
--- a/sample-apps/java/springboot-main-service/src/main/java/com/amazon/sampleapp/FrontendServiceController.java
+++ b/sample-apps/java/springboot-main-service/src/main/java/com/amazon/sampleapp/FrontendServiceController.java
@@ -94,6 +94,7 @@ public class FrontendServiceController {
     if (testingId != null) {
       bucketName += "-" + testingId;
     }
+    logger.warn("This is a custom log for validation testing");
     GetBucketLocationRequest bucketLocationRequest =
             GetBucketLocationRequest.builder().bucket(bucketName).build();
     try {


### PR DESCRIPTION
*Issue description:*
We need a reliable way to validate SigV4 logs across different language implementations (Python, JavaScript, .NET, Java) for our sample applications. The current logging doesn't provide a consistent, easily identifiable log entry for this purpose. This PR adds a standardized SigV4 logging mechanism to the Java sample application, similar to what was implemented for Python in [[PR #406]](https://github.com/aws-observability/aws-application-signals-test-framework/pull/406). 

*Description of changes:*
Added a custom WARNING log in the aws_sdk_call function of the Python sample application. This custom log will be present in the log-group and can be used to filter logs from those created while running the sample application. This change provides a consistent log entry that can be replicated across other language implementations for uniform SigV4 log validation.

*Rollback procedure:*

1. Remove the line `logger.warn("This is a custom log for validation testing");` from the aws_sdk_call function in views.py.
2. Commit and push the change.
3. Redeploy the application.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
