### PR TITLE
Add Python 3.13 to Our EC2 and EKS Workflows

### DIFF
--- a/.github/workflows/python-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/python-ec2-adot-sigv4-test.yml
@@ -12,7 +12,7 @@ on:
         required: true
         type: string
       python-version:
-        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12"
+        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12, 3.13"
         required: false
         type: string
         default: '3.9'

--- a/.github/workflows/python-ec2-asg-test.yml
+++ b/.github/workflows/python-ec2-asg-test.yml
@@ -15,7 +15,7 @@ on:
         required: true
         type: string
       python-version:
-        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12"
+        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12, 3.13"
         required: false
         type: string
         default: '3.9'

--- a/.github/workflows/python-ec2-default-test.yml
+++ b/.github/workflows/python-ec2-default-test.yml
@@ -15,7 +15,7 @@ on:
         required: true
         type: string
       python-version:
-        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12"
+        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12, 3.13"
         required: false
         type: string
         default: '3.9'

--- a/.github/workflows/python-ecs-test.yml
+++ b/.github/workflows/python-ecs-test.yml
@@ -15,7 +15,7 @@ on:
         required: true
         type: string
       python-version:
-        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12"
+        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12, 3.13"
         required: false
         type: string
         default: '3.10'

--- a/.github/workflows/python-eks-test.yml
+++ b/.github/workflows/python-eks-test.yml
@@ -18,7 +18,7 @@ on:
         required: true
         type: string
       python-version:
-        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12"
+        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12, 3.13"
         required: false
         type: string
         default: '3.10'

--- a/.github/workflows/python-k8s-test.yml
+++ b/.github/workflows/python-k8s-test.yml
@@ -18,7 +18,7 @@ on:
         required: false
         type: string
       python-version:
-        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12"
+        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12, 3.13"
         required: false
         type: string
         default: '3.10'

--- a/.github/workflows/python-lambda-test.yml
+++ b/.github/workflows/python-lambda-test.yml
@@ -15,7 +15,7 @@ on:
         required: true
         type: string
       python-version:
-        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12"
+        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12, 3.13"
         required: false
         type: string
         default: '3.9'

--- a/.github/workflows/python-sample-app-ecr-deploy.yml
+++ b/.github/workflows/python-sample-app-ecr-deploy.yml
@@ -3,7 +3,7 @@
 
 # This workflow is for building and uploading the Python sample application to ECR.
 # Python 3.10 will be built and uploaded to all regions to be used by the canary while
-# other versions (3.8, 3.9, 3.11, 3.12) will be uploaded to us-east-1 for the purpose of
+# other versions (3.8, 3.9, 3.11, 3.12, 3.13) will be uploaded to us-east-1 for the purpose of
 # testing ADOT Python
 name: Sample App Deployment - Python ECR
 on:
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.9', '3.11', '3.12' ]
+        python-version: [ '3.8', '3.9', '3.11', '3.12', '3.13' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/terraform/python/ec2/adot-sigv4/main.tf
+++ b/terraform/python/ec2/adot-sigv4/main.tf
@@ -116,10 +116,10 @@ resource "null_resource" "main_service_setup" {
       sudo yum install wget -y
       sudo yum install unzip -y
 
-      # Dnf does not have the module for python 3.10, 3,10, 3.12, therefore we need to manually install it by downloading the package from the python website.
+      # Dnf does not have the module for python 3.8, 3.10, 3.12, 3.13, therefore we need to manually install it by downloading the package from the python website.
       # Building and installing the package takes longer then installing it through dnf, so a seperate installation process was made.
       # The canary should run on a version without the manual installation process
-      if [ "${var.language_version}" == "3.8" ] || [ "${var.language_version}" = "3.10" ] || [ "${var.language_version}" = "3.12" ]; then
+      if [ "${var.language_version}" == "3.8" ] || [ "${var.language_version}" = "3.10" ] || [ "${var.language_version}" = "3.12" ] || [ "${var.language_version}" = "3.13" ]; then
           # Install modules required to compile Python and also run the sample app
           sudo dnf groupinstall "Development Tools" -y
           sudo dnf install openssl-devel sqlite-devel libffi-devel -y

--- a/terraform/python/ec2/asg/main.tf
+++ b/terraform/python/ec2/asg/main.tf
@@ -103,10 +103,10 @@ resource "aws_launch_configuration" "launch_configuration" {
     sudo yum install wget -y
     sudo yum install unzip -y
 
-    # Dnf does not have the module for python 3.10, 3,10, 3.12, therefore we need to manually install it by downloading the package from the python website.
+    # Dnf does not have the module for python 3.8, 3.10, 3.12, 3.13, therefore we need to manually install it by downloading the package from the python website.
     # Building and installing the package takes longer then installing it through dnf, so a seperate installation process was made.
     # The canary should run on a version without the manual installation process
-    if [ "${var.language_version}" == "3.8" ] || [ "${var.language_version}" = "3.10" ] || [ "${var.language_version}" = "3.12" ]; then
+    if [ "${var.language_version}" == "3.8" ] || [ "${var.language_version}" = "3.10" ] || [ "${var.language_version}" = "3.12" ] || [ "${var.language_version}" = "3.13" ]; then
         # Install modules required to compile Python and also run the sample app
         sudo dnf groupinstall "Development Tools" -y
         sudo dnf install openssl-devel sqlite-devel libffi-devel -y

--- a/terraform/python/ec2/default/main.tf
+++ b/terraform/python/ec2/default/main.tf
@@ -116,10 +116,10 @@ resource "null_resource" "main_service_setup" {
       sudo yum install wget -y
       sudo yum install unzip -y
 
-      # Dnf does not have the module for python 3.10, 3,10, 3.12, therefore we need to manually install it by downloading the package from the python website.
+      # Dnf does not have the module for python 3.8, 3.10, 3.12, 3.13, therefore we need to manually install it by downloading the package from the python website.
       # Building and installing the package takes longer then installing it through dnf, so a seperate installation process was made.
       # The canary should run on a version without the manual installation process
-      if [ "${var.language_version}" == "3.8" ] || [ "${var.language_version}" = "3.10" ] || [ "${var.language_version}" = "3.12" ]; then
+      if [ "${var.language_version}" == "3.8" ] || [ "${var.language_version}" = "3.10" ] || [ "${var.language_version}" = "3.12" ] || [ "${var.language_version}" = "3.13" ]; then
           # Install modules required to compile Python and also run the sample app
           sudo dnf groupinstall "Development Tools" -y
           sudo dnf install openssl-devel sqlite-devel libffi-devel -y


### PR DESCRIPTION
## What does this pull request do?
Updates our EC2 and EKS workflows to build Python 3.13 so our main build [stops failing](https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/15712902907/job/44284038473) [adding support](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/395) for this runtime version in ADOT Python.

We can safely revert these changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
