### PR TITLE
[Dotnet] Fix http url assertion

### DIFF
--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/aws-sdk-call-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/aws-sdk-call$",
+      "url": "^{{endpoint}}/aws-sdk-call(?:\\?ip=Redacted&testingId=Redacted)?$",
       "method": "^GET$"
     }
   },

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/aws-sdk-call$",
+      "url": "^{{endpoint}}/aws-sdk-call(?:\\?ip=Redacted&testingId=Redacted)?$",
       "method": "^GET$"
     }
   },

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/aws-sdk-call-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/aws-sdk-call$",
+      "url": "^{{endpoint}}/aws-sdk-call(?:\\?ip=Redacted&testingId=Redacted)?$",
       "method": "^GET$"
     }
   },

--- a/validator/src/main/resources/expected-data-template/dotnet/eks/linux/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/eks/linux/aws-sdk-call-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/aws-sdk-call$",
+      "url": "^{{endpoint}}/aws-sdk-call(?:\\?ip=Redacted&testingId=Redacted)?$",
       "method": "^GET$"
     }
   },

--- a/validator/src/main/resources/expected-data-template/dotnet/k8s/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/k8s/aws-sdk-call-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/aws-sdk-call$",
+      "url": "^{{endpoint}}/aws-sdk-call(?:\\?ip=Redacted&testingId=Redacted)?$",
       "method": "^GET$"
     }
   },


### PR DESCRIPTION
*Issue description:*
The E2E test failed after fixing the http url generation in awsxrayexporter. 
PR: https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/323

*Description of changes:*
Add query parameters into trace assertion.

*Rollback procedure:*

<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
