### PR TITLE
Bump OTel Dependency in EC2 Sample App to 1.33.1

### DIFF
--- a/sample-apps/python/django_frontend_service/ec2-requirements.txt
+++ b/sample-apps/python/django_frontend_service/ec2-requirements.txt
@@ -4,5 +4,5 @@ pymysql==1.1.1
 python-dotenv~=1.0.1
 requests~=2.25.1
 schedule~=1.2.1
-opentelemetry-sdk==1.27.0
-opentelemetry-api==1.27.0
+opentelemetry-sdk==1.33.1
+opentelemetry-api==1.33.1


### PR DESCRIPTION
## What does this pull request do?
Bumps the OTel dependency in our EC2 sample app to resolve dependency collision causing [main build to fail](https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/15767138207/workflow).
```
null_resource.main_service_setup (remote-exec): opentelemetry-instrumentation-flask 0.54b1 requires opentelemetry-semantic-conventions==0.54b1, but you have opentelemetry-semantic-conventions 0.48b0 which is incompatible.
1966
null_resource.main_service_setup (remote-exec): opentelemetry-instrumentation-fastapi 0.54b1 requires opentelemetry-semantic-conventions==0.54b1, but you have opentelemetry-semantic-conventions 0.48b0 which is incompatible.
1967
null_resource.main_service_setup (remote-exec): opentelemetry-instrumentation-falcon 0.54b1 requires opentelemetry-semantic-conventions==0.54b1, but you have opentelemetry-semantic-conventions 0.48b0 which is incompatible.
1968
null_resource.main_service_setup (remote-exec): opentelemetry-instrumentation-django 0.54b1 requires opentelemetry-semantic-conventions==0.54b1, but you have opentelemetry-semantic-conventions 0.48b0 which is incompatible.
1969
null_resource.main_service_setup (remote-exec): aws-opentelemetry-distro 0.9.0.dev0 requires opentelemetry-api==1.33.1, but you have opentelemetry-api 1.27.0 which is incompatible.
1970
null_resource.main_service_setup (remote-exec): aws-opentelemetry-distro 0.9.0.dev0 requires opentelemetry-sdk==1.33.1, but you have opentelemetry-sdk 1.27.0 which is incompatible.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
