### PR TITLE
Update trace validation to handle multiple ?

### DIFF
--- a/validator/src/main/resources/expected-data-template/dotnet/eks/linux/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/eks/linux/aws-sdk-call-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/aws-sdk-call(?:\\?ip=Redacted&testingId=Redacted)?$",
+      "url": "^{{endpoint}}/aws-sdk-call(?:\\?{1,2}ip=Redacted&testingId=Redacted)?$",
       "method": "^GET$"
     }
   },

--- a/validator/src/main/resources/expected-data-template/dotnet/eks/linux/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/eks/linux/remote-service-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/remote-service$",
+      "url": "^{{endpoint}}/remote-service(?:\\?{1,2}ip=Redacted&testingId=Redacted)?$",
       "method": "^GET$"
     }
   },


### PR DESCRIPTION
*Issue description:*
For EKS Dotnet tests, there is currently a known issue where there is two `??` in the http url instead of the expected one. 
Temporarily updating the validation tests to be able to handle 0 to 2 questions marks until the issue is fixed. 

*Test*
https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/16010052322/job/45165626309

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
