### PR TITLE
Update trace validation to handle multiple ? for all platforms

### DIFF
--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/aws-sdk-call-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/aws-sdk-call(?:\\?ip=Redacted&testingId=Redacted)?$",
+      "url": "^{{endpoint}}/aws-sdk-call(?:\\?{1,2}ip=Redacted&testingId=Redacted)?$",
       "method": "^GET$"
     }
   },

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/asg/remote-service-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/remote-service$",
+      "url": "^{{endpoint}}/remote-service(?:\\?{1,2}ip=Redacted&testingId=Redacted)?$",
       "method": "^GET$"
     }
   },

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/aws-sdk-call-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/aws-sdk-call(?:\\?ip=Redacted&testingId=Redacted)?$",
+      "url": "^{{endpoint}}/aws-sdk-call(?:\\?{1,2}ip=Redacted&testingId=Redacted)?$",
       "method": "^GET$"
     }
   },

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/default/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/default/remote-service-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/remote-service$",
+      "url": "^{{endpoint}}/remote-service(?:\\?{1,2}ip=Redacted&testingId=Redacted)?$",
       "method": "^GET$"
     }
   },

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/aws-sdk-call-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/aws-sdk-call(?:\\?ip=Redacted&testingId=Redacted)?$",
+      "url": "^{{endpoint}}/aws-sdk-call(?:\\?{1,2}ip=Redacted&testingId=Redacted)?$",
       "method": "^GET$"
     }
   },

--- a/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/ec2/windows/remote-service-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/remote-service$",
+      "url": "^{{endpoint}}/remote-service(?:\\?{1,2}ip=Redacted&testingId=Redacted)?$",
       "method": "^GET$"
     }
   },

--- a/validator/src/main/resources/expected-data-template/dotnet/k8s/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/k8s/aws-sdk-call-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/aws-sdk-call(?:\\?ip=Redacted&testingId=Redacted)?$",
+      "url": "^{{endpoint}}/aws-sdk-call(?:\\?{1,2}ip=Redacted&testingId=Redacted)?$",
       "method": "^GET$"
     }
   },

--- a/validator/src/main/resources/expected-data-template/dotnet/k8s/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/dotnet/k8s/remote-service-trace.mustache
@@ -2,7 +2,7 @@
   "name": "^{{serviceName}}$",
   "http": {
     "request": {
-      "url": "^{{endpoint}}/remote-service$",
+      "url": "^{{endpoint}}/remote-service(?:\\?{1,2}ip=Redacted&testingId=Redacted)?$",
       "method": "^GET$"
     }
   },


### PR DESCRIPTION
*Issue description:*
Follow up from this PR: https://github.com/aws-observability/aws-application-signals-test-framework/pull/419

The issue is related to cw agent so all platforms are affected. Adding the REGEX fix to all dotnet validation templates except for adot sigv4 since it does not use cw agent

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
