### PR TITLE
Modify Action to Use Correct Repository

### DIFF
--- a/.github/workflows/python-ec2-genesis-test.yml
+++ b/.github/workflows/python-ec2-genesis-test.yml
@@ -35,6 +35,10 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          repository: 'aws-observability/aws-application-signals-test-framework'
+          ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
+          fetch-depth: 0
 
       - name: Set Get ADOT Wheel command environment variable
         run: |


### PR DESCRIPTION
Genesis test is failing with: `Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/aws-otel-python-instrumentation/aws-otel-python-instrumentation/.github/workflows/actions/execute_and_retry'. Did you forget to run actions/checkout before running your local action?`

Added correct repository for `action/checkout`