### PR TITLE
[Genesis] update polling `/ai-chat` endpoint over the course of 90s

### DIFF
--- a/terraform/python/ec2/adot-genai/main.tf
+++ b/terraform/python/ec2/adot-genai/main.tf
@@ -113,7 +113,7 @@ done
 # Generate traffic directly
 echo "Starting traffic generator..."
 nohup bash -c '
-for i in {1..5}; do
+for i in {1..9}; do
     message="What is the weather like today?"
     echo "[$(date)] Request $i: $message"
     curl -s -X POST http://localhost:8000/ai-chat \


### PR DESCRIPTION
*Issue description:*
Main build for ADOT Python GenAi test case is flaky, failing most of the time:
- https://github.com/aws-observability/aws-otel-python-instrumentation/actions/runs/16299775127/job/46039999000

This is because metrics are not generated for most of these tests. We know that the conditions to send metrics to CloudWatch is to generate a metric after 60s have passed since the last metric was generated.

Currently, we generate a metrics in a max 50 second interval, which could possibly extend to 60s if the CURL request takes too long. So this PR will change this to generate metrics over 90 seconds instead of 50 seconds to ensure we trigger sending metrics to CloudWatch.

*Description of changes:*

*Rollback procedure:*

We can safely revert this commit if needed.