### PR TITLE
Append SystemCGroup from containderd config file

### DIFF
--- a/.github/workflows/util/setup-k8s.sh
+++ b/.github/workflows/util/setup-k8s.sh
@@ -92,7 +92,9 @@ function run_k8s_master() {
     sudo systemctl enable docker && sudo systemctl start docker
     sudo containerd config default > config.toml
     sudo cp config.toml /etc/containerd/config.toml
-    sudo sed -i "/^[[:space:]]*\\[plugins\\.'io\\.containerd\\.cri\\.v1\\.runtime'\\.containerd\\.runtimes\\.runc\\.options\\]/a\            SystemdCgroup = true" /etc/containerd/config.toml
+    sudo sed -i 's/SystemdCgroup \= false/SystemdCgroup \= true/' /etc/containerd/config.toml
+    grep -Eq '^[[:space:]]*"?SystemdCgroup"?[[:space:]]*=[[:space:]]*true' /etc/containerd/config.toml || \
+    sudo sed -i "/^[[:space:]]*\\[plugins\\.'io\\.containerd\\.cri\\.v1\\.runtime'\\.containerd\\.runtimes\\.runc\\.options\\]/a\    SystemdCgroup = true" /etc/containerd/config.toml
     sudo systemctl restart containerd && sleep 20
     sudo setenforce 0 && sudo sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
     echo -e "[kubernetes]\nname=Kubernetes\nbaseurl=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/\nenabled=1\ngpgcheck=1\ngpgkey=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/repodata/repomd.xml.key\nexclude=kubelet kubeadm kubectl cri-tools kubernetes-cni" | sudo tee /etc/yum.repos.d/kubernetes.repo
@@ -140,7 +142,9 @@ function run_k8s_worker() {
     sudo systemctl enable docker && sudo systemctl start docker &&  \
     sudo containerd config default > config.toml
     sudo cp config.toml /etc/containerd/config.toml
-    sudo sed -i "/^[[:space:]]*\\[plugins\\.'io\\.containerd\\.cri\\.v1\\.runtime'\\.containerd\\.runtimes\\.runc\\.options\\]/a\            SystemdCgroup = true" /etc/containerd/config.toml
+    sudo sed -i 's/SystemdCgroup \= false/SystemdCgroup \= true/' /etc/containerd/config.toml
+    grep -Eq '^[[:space:]]*"?SystemdCgroup"?[[:space:]]*=[[:space:]]*true' /etc/containerd/config.toml || \
+    sudo sed -i "/^[[:space:]]*\\[plugins\\.'io\\.containerd\\.cri\\.v1\\.runtime'\\.containerd\\.runtimes\\.runc\\.options\\]/a\    SystemdCgroup = true" /etc/containerd/config.toml
     sudo systemctl restart containerd
     sudo setenforce 0 && sudo sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' /etc/selinux/config
     echo -e "[kubernetes]\nname=Kubernetes\nbaseurl=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/\nenabled=1\ngpgcheck=1\ngpgkey=https://pkgs.k8s.io/core:/stable:/v1.29/rpm/repodata/repomd.xml.key\nexclude=kubelet kubeadm kubectl cri-tools kubernetes-cni" | sudo tee /etc/yum.repos.d/kubernetes.repo


### PR DESCRIPTION
*Issue description:*
There was a change in the most recent EC2 AMI such that the config file for containderd has the attribute `SystemdCgroup` missing. (Before the attribute was present with the value set to `SystemdCgroup = false`) This attribute needs to be set to true in order for the k8s cluster to work.

*Description of changes:*
The sed command will initially replace the false value with true for SystemCgroup. If the systemCgroup doesn't exist though, it will try to append the attribute to the `[plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes.runc.options]
` plugin

Ran the script on personal account and verified that k8s is running again
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
