### PR TITLE
[Java] Add API for testing downstream error code

### DIFF
--- a/sample-apps/java/springboot-main-service/src/main/java/com/amazon/sampleapp/FrontendServiceController.java
+++ b/sample-apps/java/springboot-main-service/src/main/java/com/amazon/sampleapp/FrontendServiceController.java
@@ -38,7 +38,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Controller;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -163,6 +165,20 @@ public class FrontendServiceController {
     }
     return getXrayTraceId();
   }
+
+@GetMapping("/status/{code}")
+@ResponseBody
+public ResponseEntity<String> status(@PathVariable int code, @RequestParam(name = "ip", defaultValue = "localhost") String ip) {
+    ip = ip.replace("/", "");
+    try {
+        HttpGet request = new HttpGet("http://" + ip + ":8081/status/" + code);
+        httpClient.execute(request).close();
+    } catch (Exception e) {
+        // Ignore exception
+    }
+    logger.info("Service A requested status code {} from Service B", code);
+    return ResponseEntity.ok(getXrayTraceId());
+}
 
   // get x-ray trace id
   private String getXrayTraceId() {

--- a/sample-apps/java/springboot-remote-service/src/main/java/com/amazon/sampleapp/RemoteServiceController.java
+++ b/sample-apps/java/springboot-remote-service/src/main/java/com/amazon/sampleapp/RemoteServiceController.java
@@ -15,8 +15,10 @@
 
 package com.amazon.sampleapp;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 @Controller
@@ -26,5 +28,10 @@ public class RemoteServiceController {
   @ResponseBody
   public String healthcheck() {
     return "Remote service healthcheck";
+  }
+
+  @GetMapping("/status/{code}")
+  public ResponseEntity<String> status(@PathVariable int code) {
+    return ResponseEntity.status(code).build();
   }
 }


### PR DESCRIPTION
## Changes
Adding a new API `/status/{code}?ip=...` that calls the downstream service similar to `/remote-service` and specifies the code it wants the remote service to respond with. The remote service now accepted `/status/{code}` and responds with status code `{code}`. The main service will respond with OK and the trace ID in any case.

## Testing
Built and ran the applications locally, confirming functionality of the new APIs.

## Risks
New API does not change any functionality of old ones. Could cause build issues, but we use other imports from the same dependencies and the same logic in `/remote-service` so there is little to no risk.

## Rollback procedure

Revert commit and rerun sample app deployment script.


#### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
