### PR TITLE
[K8s] Ensure correct k8s workflow is run on patching job

### DIFF
--- a/.github/workflows/k8s-patch-os-jobs.yml
+++ b/.github/workflows/k8s-patch-os-jobs.yml
@@ -123,8 +123,7 @@ jobs:
   run-dotnet-k8s-test:
     if: ${{ inputs.LANGUAGE == 'dotnet' }}
     needs: create-k8s-on-ec2
-    # TODO: Point to REAL K8s implementation after K8s Infra created.
-    uses: ./.github/workflows/dummy-k8s-test.yml
+    uses: ./.github/workflows/dotnet-k8s-test.yml
     secrets: inherit
     with:
       aws-region: 'us-east-1'
@@ -134,8 +133,7 @@ jobs:
   run-node-k8s-test:
     if: ${{ inputs.LANGUAGE == 'node' }}
     needs: create-k8s-on-ec2
-    # TODO: Point to REAL K8s implementation after K8s Infra created.
-    uses: ./.github/workflows/dummy-k8s-test.yml
+    uses: ./.github/workflows/node-k8s-test.yml
     secrets: inherit
     with:
       aws-region: 'us-east-1'


### PR DESCRIPTION
Ensuring we run the appropriate test when creating new k8s clusters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
