### PR TITLE
Revert "Temporarily use Java K8s Canary Infrastructure for Node.js K8s e2e tests"

### DIFF
--- a/.github/workflows/node-k8s-test.yml
+++ b/.github/workflows/node-k8s-test.yml
@@ -94,17 +94,13 @@ jobs:
             NODE_REMOTE_SAMPLE_APP_IMAGE, e2e-test/node-remote-sample-app-image
             RELEASE_TESTING_ECR_ACCOUNT, e2e-test/${{ github.event.repository.name }}/node-k8s-release-testing-account
 
-      # Temporarily use Java K8s Canary Cluster for Node.js e2e tests
       - name: Retrieve K8s EC2 Secrets
         if: ${{ env.CALLER_WORKFLOW_NAME != 'k8s-os-patching' }}
         uses: aws-actions/aws-secretsmanager-get-secrets@v1
         with:
-          # secret-ids: |
-          #   MAIN_SERVICE_ENDPOINT, e2e-test/${{ github.event.repository.name }}/node-k8s-master-node-endpoint
-          #   MASTER_NODE_SSH_KEY, e2e-test/${{ github.event.repository.name }}/node-k8s-ssh-key
           secret-ids: |
-            MAIN_SERVICE_ENDPOINT, e2e-test/aws-application-signals-test-framework/java-k8s-master-node-endpoint
-            MASTER_NODE_SSH_KEY, e2e-test/aws-application-signals-test-framework/java-k8s-ssh-key
+            MAIN_SERVICE_ENDPOINT, e2e-test/${{ github.event.repository.name }}/node-k8s-master-node-endpoint
+            MASTER_NODE_SSH_KEY, e2e-test/${{ github.event.repository.name }}/node-k8s-ssh-key
 
       - name: Retrieve K8s EC2 OS Patching Secrets
         if: ${{ env.CALLER_WORKFLOW_NAME == 'k8s-os-patching' }}


### PR DESCRIPTION
Reverts aws-observability/aws-application-signals-test-framework#427

This was a temporary measure while we were fixing the K8s OS patching mechanism.