### PR TITLE
Add workflow to Validate E2E Tests Are Accounted For in a Repo

### DIFF
--- a/.github/workflows/validate-e2e-tests-are-accounted-for.yml
+++ b/.github/workflows/validate-e2e-tests-are-accounted-for.yml
@@ -80,6 +80,7 @@ jobs:
               .map { |v| v["uses"] }
               .compact
               .uniq
+              # Ignore the Job that triggers this "validate-e2e-tests-are-accounted-for" validation
               .select { |u| u.include?("aws-application-signals-test-framework/.github/workflows") && !u.include?("validate-e2e-tests-are-accounted-for") }
               .map { |u| u.split("/").last.split("@").first }
               .reject { |w| exclusions.include?(w) }

--- a/.github/workflows/validate-e2e-tests-are-accounted-for.yml
+++ b/.github/workflows/validate-e2e-tests-are-accounted-for.yml
@@ -46,7 +46,7 @@ jobs:
         if: contains(github.repository, 'aws-otel-python-instrumentation')
         run: |
           cd ${{ env.TEST_RESOURCES_FOLDER }}/aws-application-signals-test-framework/.github/workflows/
-          EXCLUSIONS="${{ inputs.exclusions }}"
+          EXCLUSIONS="${{ env.EXCLUSIONS }}"
           [[ -n "$EXCLUSIONS" ]] && echo "Applying exclusions to TESTS_EXPECTED: $EXCLUSIONS"
           echo "TESTS_EXPECTED=$(ls | grep -E '^python-' | grep -v 'lambda-layer-perf-test' | grep -E 'test\.ya?ml$' | { [[ -n "$EXCLUSIONS" ]] && grep -v -F -f <(echo "$EXCLUSIONS" | tr ',' '\n') || cat; } | sort | tr '\n' ' ' | sed 's/ $//')" >> $GITHUB_ENV
 

--- a/.github/workflows/validate-e2e-tests-are-accounted-for.yml
+++ b/.github/workflows/validate-e2e-tests-are-accounted-for.yml
@@ -30,7 +30,7 @@ jobs:
         if: contains(github.repository, 'aws-otel-java-instrumentation')
         run: |
           cd ${{ env.TEST_RESOURCES_FOLDER }}/aws-application-signals-test-framework/.github/workflows/
-          EXCLUSIONS="${{ inputs.exclusions }}"
+          EXCLUSIONS="${{ env.EXCLUSIONS }}"
           [[ -n "$EXCLUSIONS" ]] && echo "Applying exclusions to TESTS_EXPECTED: $EXCLUSIONS"
           echo "TESTS_EXPECTED=$(ls | grep -E '(^java-)|(^metric-limiter-)' | grep -Ev '(lambda-layer-perf-test|otlp-ocb)' | grep -E 'test\.ya?ml$' | { [[ -n "$EXCLUSIONS" ]] && grep -v -F -f <(echo "$EXCLUSIONS" | tr ',' '\n') || cat; } | sort | tr '\n' ' ' | sed 's/ $//')" >> $GITHUB_ENV
 

--- a/.github/workflows/validate-e2e-tests-are-accounted-for.yml
+++ b/.github/workflows/validate-e2e-tests-are-accounted-for.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   TEST_RESOURCES_FOLDER: ${GITHUB_WORKSPACE}
+  EXCLUSIONS: ${{ inputs.exclusions }}
 
 jobs:
   validate-e2e-tests-are-accounted-for:

--- a/.github/workflows/validate-e2e-tests-are-accounted-for.yml
+++ b/.github/workflows/validate-e2e-tests-are-accounted-for.yml
@@ -54,7 +54,7 @@ jobs:
         if: contains(github.repository, 'aws-otel-dotnet-instrumentation')
         run: |
           cd ${{ env.TEST_RESOURCES_FOLDER }}/aws-application-signals-test-framework/.github/workflows/
-          EXCLUSIONS="${{ inputs.exclusions }}"
+          EXCLUSIONS="${{ env.EXCLUSIONS }}"
           [[ -n "$EXCLUSIONS" ]] && echo "Applying exclusions to TESTS_EXPECTED: $EXCLUSIONS"
           echo "TESTS_EXPECTED=$(ls | grep -E '^dotnet-' | grep -v 'lambda-layer-perf-test' | grep -E 'test\.ya?ml$' | { [[ -n "$EXCLUSIONS" ]] && grep -v -F -f <(echo "$EXCLUSIONS" | tr ',' '\n') || cat; } | sort | tr '\n' ' ' | sed 's/ $//')" >> $GITHUB_ENV
 

--- a/.github/workflows/validate-e2e-tests-are-accounted-for.yml
+++ b/.github/workflows/validate-e2e-tests-are-accounted-for.yml
@@ -38,7 +38,7 @@ jobs:
         if: contains(github.repository, 'aws-otel-js-instrumentation')
         run: |
           cd ${{ env.TEST_RESOURCES_FOLDER }}/aws-application-signals-test-framework/.github/workflows/
-          EXCLUSIONS="${{ inputs.exclusions }}"
+          EXCLUSIONS="${{ env.EXCLUSIONS }}"
           [[ -n "$EXCLUSIONS" ]] && echo "Applying exclusions to TESTS_EXPECTED: $EXCLUSIONS"
           echo "TESTS_EXPECTED=$(ls | grep -E '^node-' | grep -v 'lambda-layer-perf-test' | grep -E 'test\.ya?ml$' | { [[ -n "$EXCLUSIONS" ]] && grep -v -F -f <(echo "$EXCLUSIONS" | tr ',' '\n') || cat; } | sort | tr '\n' ' ' | sed 's/ $//')" >> $GITHUB_ENV
 

--- a/.github/workflows/validate-e2e-tests-are-accounted-for.yml
+++ b/.github/workflows/validate-e2e-tests-are-accounted-for.yml
@@ -73,10 +73,10 @@ jobs:
           cd ${{ github.repository }}/.github/workflows/
 
           # Get all test framework workflows actually used in application-signals-e2e-test.yml, with exclusions applied
-          EXCLUSIONS="${{ inputs.exclusions }}"
+          EXCLUSIONS="${{ env.EXCLUSIONS }}"
           [[ -n "$EXCLUSIONS" ]] && echo "Applying exclusions to TESTS_ACTUALLY_USED: $EXCLUSIONS"
           echo "TESTS_ACTUALLY_USED=$(ruby -ryaml -e '
-            exclusions = "${{ inputs.exclusions }}".split(",").map(&:strip).reject(&:empty?)
+            exclusions = "${{ env.EXCLUSIONS }}".split(",").map(&:strip).reject(&:empty?)
             workflows = YAML.load_file("application-signals-e2e-test.yml")["jobs"].values
               .map { |v| v["uses"] }
               .compact

--- a/.github/workflows/validate-e2e-tests-are-accounted-for.yml
+++ b/.github/workflows/validate-e2e-tests-are-accounted-for.yml
@@ -62,7 +62,7 @@ jobs:
         if: contains(github.repository, 'amazon-cloudwatch-agent')
         run: |
           cd ${{ env.TEST_RESOURCES_FOLDER }}/aws-application-signals-test-framework/.github/workflows/
-          EXCLUSIONS="${{ inputs.exclusions }}"
+          EXCLUSIONS="${{ env.EXCLUSIONS }}"
           [[ -n "$EXCLUSIONS" ]] && echo "Applying exclusions to TESTS_EXPECTED: $EXCLUSIONS"
           echo "TESTS_EXPECTED=$(ls | grep -E '(^java-)|(^node-)|(^python-)|(^dotnet-)|(^metric-limiter-)' | grep -Ev '(sigv4|lambda-test|lambda-layer-perf-test|ocb|genesis)' | grep -E 'test\.ya?ml$' | { [[ -n "$EXCLUSIONS" ]] && grep -v -F -f <(echo "$EXCLUSIONS" | tr ',' '\n') || cat; } | sort | tr '\n' ' ' | sed 's/ $//')" >> $GITHUB_ENV
 

--- a/.github/workflows/validate-e2e-tests-are-accounted-for.yml
+++ b/.github/workflows/validate-e2e-tests-are-accounted-for.yml
@@ -1,0 +1,99 @@
+name: Validate E2E Tests Are Accounted For
+on:
+  workflow_call:
+    inputs:
+      exclusions:
+        description: 'Comma-separated list of test files to exclude from validation'
+        type: string
+        required: false
+        default: ''
+
+env:
+  TEST_RESOURCES_FOLDER: ${GITHUB_WORKSPACE}
+
+jobs:
+  validate-e2e-tests-are-accounted-for:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1.221.0
+        with:
+          ruby-version: "3.4"
+
+      - name: Checkout aws-application-signals-test-framework
+        run: |
+          cd ${{ env.TEST_RESOURCES_FOLDER }}
+          git clone https://github.com/aws-observability/aws-application-signals-test-framework.git
+
+      - name: Determine workflow files expected to be used by ADOT Java
+        if: contains(github.repository, 'aws-otel-java-instrumentation')
+        run: |
+          cd ${{ env.TEST_RESOURCES_FOLDER }}/aws-application-signals-test-framework/.github/workflows/
+          EXCLUSIONS="${{ inputs.exclusions }}"
+          [[ -n "$EXCLUSIONS" ]] && echo "Applying exclusions to TESTS_EXPECTED: $EXCLUSIONS"
+          echo "TESTS_EXPECTED=$(ls | grep -E '(^java-)|(^metric-limiter-)' | grep -Ev '(lambda-layer-perf-test|otlp-ocb)' | grep -E 'test\.ya?ml$' | { [[ -n "$EXCLUSIONS" ]] && grep -v -F -f <(echo "$EXCLUSIONS" | tr ',' '\n') || cat; } | sort | tr '\n' ' ' | sed 's/ $//')" >> $GITHUB_ENV
+
+      - name: Determine workflow files expected to be used by ADOT JavaScript
+        if: contains(github.repository, 'aws-otel-js-instrumentation')
+        run: |
+          cd ${{ env.TEST_RESOURCES_FOLDER }}/aws-application-signals-test-framework/.github/workflows/
+          EXCLUSIONS="${{ inputs.exclusions }}"
+          [[ -n "$EXCLUSIONS" ]] && echo "Applying exclusions to TESTS_EXPECTED: $EXCLUSIONS"
+          echo "TESTS_EXPECTED=$(ls | grep -E '^node-' | grep -v 'lambda-layer-perf-test' | grep -E 'test\.ya?ml$' | { [[ -n "$EXCLUSIONS" ]] && grep -v -F -f <(echo "$EXCLUSIONS" | tr ',' '\n') || cat; } | sort | tr '\n' ' ' | sed 's/ $//')" >> $GITHUB_ENV
+
+      - name: Determine workflow files expected to be used by ADOT Python
+        if: contains(github.repository, 'aws-otel-python-instrumentation')
+        run: |
+          cd ${{ env.TEST_RESOURCES_FOLDER }}/aws-application-signals-test-framework/.github/workflows/
+          EXCLUSIONS="${{ inputs.exclusions }}"
+          [[ -n "$EXCLUSIONS" ]] && echo "Applying exclusions to TESTS_EXPECTED: $EXCLUSIONS"
+          echo "TESTS_EXPECTED=$(ls | grep -E '^python-' | grep -v 'lambda-layer-perf-test' | grep -E 'test\.ya?ml$' | { [[ -n "$EXCLUSIONS" ]] && grep -v -F -f <(echo "$EXCLUSIONS" | tr ',' '\n') || cat; } | sort | tr '\n' ' ' | sed 's/ $//')" >> $GITHUB_ENV
+
+      - name: Determine workflow files expected to be used by ADOT .NET
+        if: contains(github.repository, 'aws-otel-dotnet-instrumentation')
+        run: |
+          cd ${{ env.TEST_RESOURCES_FOLDER }}/aws-application-signals-test-framework/.github/workflows/
+          EXCLUSIONS="${{ inputs.exclusions }}"
+          [[ -n "$EXCLUSIONS" ]] && echo "Applying exclusions to TESTS_EXPECTED: $EXCLUSIONS"
+          echo "TESTS_EXPECTED=$(ls | grep -E '^dotnet-' | grep -v 'lambda-layer-perf-test' | grep -E 'test\.ya?ml$' | { [[ -n "$EXCLUSIONS" ]] && grep -v -F -f <(echo "$EXCLUSIONS" | tr ',' '\n') || cat; } | sort | tr '\n' ' ' | sed 's/ $//')" >> $GITHUB_ENV
+
+      - name: Determine workflow files expected to be used by CloudWatch Agent
+        if: contains(github.repository, 'amazon-cloudwatch-agent')
+        run: |
+          cd ${{ env.TEST_RESOURCES_FOLDER }}/aws-application-signals-test-framework/.github/workflows/
+          EXCLUSIONS="${{ inputs.exclusions }}"
+          [[ -n "$EXCLUSIONS" ]] && echo "Applying exclusions to TESTS_EXPECTED: $EXCLUSIONS"
+          echo "TESTS_EXPECTED=$(ls | grep -E '(^java-)|(^node-)|(^python-)|(^dotnet-)|(^metric-limiter-)' | grep -Ev '(sigv4|lambda-test|lambda-layer-perf-test|ocb|genesis)' | grep -E 'test\.ya?ml$' | { [[ -n "$EXCLUSIONS" ]] && grep -v -F -f <(echo "$EXCLUSIONS" | tr ',' '\n') || cat; } | sort | tr '\n' ' ' | sed 's/ $//')" >> $GITHUB_ENV
+
+      - name: Determine workflow files actually being used by ${{ github.repository }}
+        run: |
+          cd ${{ env.TEST_RESOURCES_FOLDER }}
+          git clone -b ${{ github.ref_name }} https://github.com/${{ github.repository }}.git ${{ github.repository }}
+          cd ${{ github.repository }}/.github/workflows/
+
+          # Get all test framework workflows actually used in application-signals-e2e-test.yml, with exclusions applied
+          EXCLUSIONS="${{ inputs.exclusions }}"
+          [[ -n "$EXCLUSIONS" ]] && echo "Applying exclusions to TESTS_ACTUALLY_USED: $EXCLUSIONS"
+          echo "TESTS_ACTUALLY_USED=$(ruby -ryaml -e '
+            exclusions = "${{ inputs.exclusions }}".split(",").map(&:strip).reject(&:empty?)
+            workflows = YAML.load_file("application-signals-e2e-test.yml")["jobs"].values
+              .map { |v| v["uses"] }
+              .compact
+              .uniq
+              .select { |u| u.include?("aws-application-signals-test-framework/.github/workflows") && !u.include?("validate-e2e-tests-are-accounted-for") }
+              .map { |u| u.split("/").last.split("@").first }
+              .reject { |w| exclusions.include?(w) }
+              .sort
+            puts workflows.join(" ")
+          ')" >> $GITHUB_ENV
+
+      - name: Compare TESTS_ACTUALLY_USED and TESTS_EXPECTED
+        run: |
+          echo "Tests being used:"
+          echo "- $TESTS_ACTUALLY_USED"
+          echo "Tests expected to be used:"
+          echo "- $TESTS_EXPECTED"
+          if [[ -z "$TESTS_ACTUALLY_USED" || -z "$TESTS_EXPECTED" || "$TESTS_ACTUALLY_USED" != "$TESTS_EXPECTED" ]]; then
+            echo "Mismatch found!"
+            exit 1
+          fi


### PR DESCRIPTION
*Issue description:*

*Description of changes:*
Add new validation workflow:
- This validation is to ensure that all ApplicationSignals e2e test workflows relevant to this repo are actually being used in this repo.
- This validation supports excluding specific tests via comma-separated input parameter
- Validation is done between `TESTS_EXPECTED` and `TESTS_ACTUALLY_USED`
  - TESTS_EXPECTED: Generated by filtering test framework workflows in `.github/workflows/` by language prefix, excluding perf/lambda tests, and applying exclusions
  - TESTS_ACTUALLY_USED: Generated by parsing `application-signals-e2e-test.yml` to extract workflow references, filtering by test framework, and applying exclusions

*Testing:*

CWAgent:
<img width="3138" height="1872" alt="image" src="https://github.com/user-attachments/assets/37633b33-7798-4d45-825b-62e46b022965" />

ADOT Java:
<img width="3138" height="1712" alt="image" src="https://github.com/user-attachments/assets/1dfab8a9-362f-4d10-b206-e9ed2aa8ac54" />

ADOT Python:
<img width="3138" height="1632" alt="image" src="https://github.com/user-attachments/assets/74251329-857c-47c4-880c-60423d536b2d" />

ADOT JS:
<img width="3138" height="1632" alt="image" src="https://github.com/user-attachments/assets/4325f942-e6d9-4668-a693-a30d34cc089d" />

ADOT .NET:
<img width="3138" height="1712" alt="image" src="https://github.com/user-attachments/assets/fdbb3f31-207a-4950-9c52-140eb16629de" />


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
