### PR TITLE
[Java] Fix typo in status code API

### DIFF
--- a/sample-apps/java/springboot-main-service/src/main/java/com/amazon/sampleapp/FrontendServiceController.java
+++ b/sample-apps/java/springboot-main-service/src/main/java/com/amazon/sampleapp/FrontendServiceController.java
@@ -171,7 +171,7 @@ public class FrontendServiceController {
 public ResponseEntity<String> status(@PathVariable int code, @RequestParam(name = "ip", defaultValue = "localhost") String ip) {
     ip = ip.replace("/", "");
     try {
-        HttpGet request = new HttpGet("http://" + ip + ":8081/status/" + code);
+        HttpGet request = new HttpGet("http://" + ip + ":8080/status/" + code);
         httpClient.execute(request).close();
     } catch (Exception e) {
         // Ignore exception


### PR DESCRIPTION
Quick fix for a small typo, see above `/remote-service` API for an example that is correctly configured.

8081 was used for single-machine/local testing, whereas the tests that run through workflows in this test framework use 2 instances so both services can use port 8080 separately.

No tests currently rely on this API - no risk.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
