### PR TITLE
Remove internal span validation from OCB test

### DIFF
--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/remote-service-trace.mustache
@@ -70,10 +70,7 @@
   },
   "subsegments": [
     {
-      "name": "^RemoteServiceController.healthcheck$",
-      "annotations": {
-        "aws.local.environment": "^eks:{{platformInfo}}/{{appNamespace}}$"
-      }
+      "name": "^RemoteServiceController.healthcheck$"
     }
   ]
 }]


### PR DESCRIPTION
*Issue description:*
Recently, there was a minor backend change that (correctly) set aws.local.environment for all span types (previously only server/client). This caused this workflow to fail: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/16662392099/job/47162204198:

```
 23:57:12.295 [main] ERROR com.amazon.aoc.validators.TraceValidator - Data model validation failed
23:57:12.295 [main] INFO  com.amazon.aoc.validators.TraceValidator - Mismatched data model field list
23:57:12.295 [main] INFO  com.amazon.aoc.validators.TraceValidator - Mismatched data for key: [1].subsegments[0].annotations[\"aws.local.environment\"]
23:57:12.295 [main] INFO  com.amazon.aoc.validators.TraceValidator - Value of stored trace map: ^eks:e2e-java-otlp-ocb-canary-test/ns-16662392099-11037$
23:57:12.295 [main] INFO  com.amazon.aoc.validators.TraceValidator - Value of retrieved map: generic:default
```

*Description of changes:*

In this test, we are sending spans to X-Ray OTLP Endpoint, who will modify the spans for the purposes of generating ApplicationSignals. This test was validating incorrect behaviour and after some discussion, we felt that it was validating behaviour that is not really relevant to the test itself. To prevent future test failures, we are removing this part of the test validation logic.

*Rollback procedure:*

Can we safely revert this commit if needed? Yes.

*Ensure you've run the following tests on your changes and include the link below:*

Tested here: https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/16920194765

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
