### PR TITLE
Enable Perf Testing Workflow for Lambda Java Layer v2

### DIFF
--- a/.github/workflows/java-lambda-layer-perf-test.yml
+++ b/.github/workflows/java-lambda-layer-perf-test.yml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: aws-observability/aws-otel-java-instrumentation
-        ref: release/v1.33.x
+        ref: release/v2.11.x
         path: aws-otel-java-instrumentation
 
     - name: Setup Terraform


### PR DESCRIPTION
The current Lambda Java Layer performance testing workflow is hard-coded to use the ADOT v1.33 branch. This PR updates the workflow to use the ADOT v2.11.x branch, which will unblock the release process for Lambda Java Layer v2.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
