### PR TITLE
Fix: Refresh AWS Token During Lambda Java Performance Test

### DIFF
--- a/.github/workflows/java-lambda-layer-perf-test.yml
+++ b/.github/workflows/java-lambda-layer-perf-test.yml
@@ -38,7 +38,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: arn:aws:iam::${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}:role/${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
-        aws-region: us-east-1     
+        aws-region: us-east-1
 
     - name: Checkout aws-otel-java-instrumentation
       uses: actions/checkout@v4
@@ -82,6 +82,13 @@ jobs:
         cd terraform
         terraform init
         terraform apply -auto-approve -var "adot_layer_arn=${{ env.LAYER_VERSION_ARN }}"
+
+    # Re-authenticate to refresh credentials (important!)
+    - name: Refresh AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}:role/${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
+        aws-region: us-east-1
 
     - name: Checkout current repository
       uses: actions/checkout@v4
@@ -130,6 +137,14 @@ jobs:
             no_layer_results.txt
             layer_results.txt
         retention-days: 90
+
+    # Always re-authenticate to refresh credentials before cleanup
+    - name: Refresh AWS Credentials before cleanup
+      if: success() || failure() || cancelled()
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}:role/${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
+        aws-region: us-east-1
 
     - name: Cleanup Terraform Resources
       if: success() || failure() || cancelled()


### PR DESCRIPTION
Problem:
The Lambda Java performance test can take longer than one hour, but the AWS token is only valid for one hour. If the token expires, the performance test will fail. Additionally, Terraform will fail to delete the AWS resources it created. When this happens, subsequent performance tests are blocked because the AWS resources cannot be manually deleted (attempts to delete them in the AWS Console result in "Access Denied," even with admin permissions).

Fix:
In the performance test workflow, we explicitly renew the AWS token twice: 
Before running the performance tests.
Before tearing down the Terraform-created resources.
