### PR TITLE
 Upgrade to Java 23 support @thpierce

### DIFF
--- a/.github/workflows/java-sample-app-ecr-deploy.yml
+++ b/.github/workflows/java-sample-app-ecr-deploy.yml
@@ -3,7 +3,7 @@
 
 # This workflow is for building and uploading the Java sample application to ECR.
 # Java 11 will be built and uploaded to all regions to be used by the canary while
-# other versions (8, 17, 21, 22) will be uploaded to us-east-1 for the purpose of
+# other versions (8, 17, 21, 23) will be uploaded to us-east-1 for the purpose of
 # testing ADOT Java
 name: Sample App Deployment - Java ECR
 on:
@@ -100,7 +100,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [ '8', '17', '21', '22' ]
+        java-version: [ '8', '17', '21', '23' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -127,8 +127,8 @@ jobs:
         run: |
           # For Java 8, springboot must be lower than version 3
           # For Java 11,17,21, they are compatible with both springboot version
-          # For Java 22 and above, springboot must be version 3 or higher
-          if [ "${{ matrix.java-version }}" = "22" ]; then
+          # For Java 23 and above, springboot must be version 3 or higher
+          if [ "${{ matrix.java-version }}" = "23" ]; then
             sed -i 's/id("org.springframework.boot")/id("org.springframework.boot") version "3.3.4"/' build.gradle.kts
             cat build.gradle.kts
           fi
@@ -140,7 +140,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [ '8', '17', '21', '22' ]
+        java-version: [ '8', '17', '21', '23' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -167,8 +167,8 @@ jobs:
         run: |
           # For Java 8, springboot must be lower than version 3
           # For Java 11,17,21, they are compatible with both springboot version
-          # For Java 22 and above, springboot must be version 3 or higher
-          if [ "${{ matrix.java-version }}" = "22" ]; then
+          # For Java 23 and above, springboot must be version 3 or higher
+          if [ "${{ matrix.java-version }}" = "23" ]; then
             sed -i 's/id("org.springframework.boot")/id("org.springframework.boot") version "3.3.4"/' build.gradle.kts
             cat build.gradle.kts
           fi

--- a/.github/workflows/java-sample-app-s3-deploy.yml
+++ b/.github/workflows/java-sample-app-s3-deploy.yml
@@ -1,7 +1,7 @@
 ## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 ## SPDX-License-Identifier: Apache-2.0
 
-# This workflow is for building and uploading the Java sample application to S3 bucket. Java 11 will be built and uploaded to all regions to be used by the canary while other versions (8, 17, 21, 22)
+# This workflow is for building and uploading the Java sample application to S3 bucket. Java 11 will be built and uploaded to all regions to be used by the canary while other versions (8, 17, 21, 23)
 # will be uploaded to us-east-1 for the purpose of testing ADOT Java
 name: Sample App Deployment - Java S3
 on:
@@ -96,7 +96,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [ '8', '17', '21', '22' ]
+        java-version: [ '8', '17', '21', '23' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -117,8 +117,8 @@ jobs:
         run: |
           # For Java 8, springboot must be lower than version 3
           # For Java 11,17,21, they are compatible with both springboot version
-          # For Java 22 and above, springboot must be version 3 or higher
-          if [ "${{ matrix.java-version }}" = "22" ]; then
+          # For Java 23 and above, springboot must be version 3 or higher
+          if [ "${{ matrix.java-version }}" = "23" ]; then
             sed -i 's/id("org.springframework.boot")/id("org.springframework.boot") version "3.3.4"/' build.gradle.kts
             cat build.gradle.kts
           fi
@@ -130,7 +130,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [ '8', '17', '21', '22' ]
+        java-version: [ '8', '17', '21', '23' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -151,8 +151,8 @@ jobs:
         run: |
           # For Java 8, springboot must be lower than version 3
           # For Java 11,17,21, they are compatible with both springboot version
-          # For Java 22 and above, springboot must be version 3 or higher
-          if [ "${{ matrix.java-version }}" = "22" ]; then
+          # For Java 23 and above, springboot must be version 3 or higher
+          if [ "${{ matrix.java-version }}" = "23" ]; then
             sed -i 's/id("org.springframework.boot")/id("org.springframework.boot") version "3.3.4"/' build.gradle.kts
             cat build.gradle.kts
           fi


### PR DESCRIPTION
Drop v22 and add v23 support for Java - align with https://github.com/aws-observability/aws-otel-java-instrumentation/commit/f39896271386037f98dad4fa1ae4dcb66b1c3967

<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>
Yes

*Ensure you've run the following tests on your changes and include the link below:*
These steps are manually run.

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
