### PR TITLE
fix: remove condition to fetch adaptive sampling account credentials

### DIFF
--- a/.github/workflows/java-ec2-adaptive-sampling-test.yml
+++ b/.github/workflows/java-ec2-adaptive-sampling-test.yml
@@ -61,8 +61,8 @@ jobs:
           secret-ids: |
             ACCOUNT_ID, adaptive-sampling-region-account/prod-${{ env.E2E_TEST_AWS_REGION }}
 
+      # Get the credentials for the adaptive sampling account specifically
       - name: Configure AWS Credentials
-        if: ${{ github.event.repository.name == 'aws-application-signals-test-framework' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ env.E2E_TEST_ROLE_NAME }}


### PR DESCRIPTION
Small fix to allow java agent main build to work properly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
