### PR TITLE
fix: update genai test env vars

### DIFF
--- a/terraform/python/ec2/adot-genai-v1/main.tf
+++ b/terraform/python/ec2/adot-genai-v1/main.tf
@@ -90,7 +90,6 @@ export OTEL_PYTHON_CONFIGURATOR=aws_configurator
 export OTEL_EXPORTER_OTLP_LOGS_HEADERS="x-aws-log-group=test/genesis,x-aws-log-stream=default,x-aws-metric-namespace=genesis"
 export OTEL_RESOURCE_ATTRIBUTES="service.name=genai-service-v1-${var.test_id}"
 export AGENT_OBSERVABILITY_ENABLED="true"
-export OTEL_PYTHON_DISABLED_INSTRUMENTATIONS=http,sqlalchemy,psycopg2,pymysql,sqlite3,aiopg,asyncpg,mysql_connector,urllib3,requests,system_metrics,google-genai,aws_crewai,aws_langchain
 
 nohup opentelemetry-instrument python3.12 server.py > /var/log/langchain-service.log 2>&1 &
 

--- a/terraform/python/ec2/adot-genai-v2/main.tf
+++ b/terraform/python/ec2/adot-genai-v2/main.tf
@@ -107,8 +107,9 @@ export AWS_DEFAULT_REGION=${var.aws_region}
 export OTEL_PYTHON_DISTRO=aws_distro
 export OTEL_PYTHON_CONFIGURATOR=aws_configurator
 export OTEL_RESOURCE_ATTRIBUTES="service.name=genai-service-v2-${var.test_id}"
-export AWS_AGENTIC_OBSERVABILITY_OPT_IN=true
-export OTEL_PYTHON_DISABLED_INSTRUMENTATIONS=http,sqlalchemy,psycopg2,pymysql,sqlite3,aiopg,asyncpg,mysql_connector,urllib3,requests,system_metrics,google-genai,aws_crewai,aws_langchain
+export AGENT_OBSERVABILITY_ENABLED="true"
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
+export OTEL_METRICS_EXPORTER="otlp"
 
 nohup opentelemetry-instrument python3.12 -m uvicorn server:app --host 0.0.0.0 --port 8000 > /var/log/genai-service.log 2>&1 &
 


### PR DESCRIPTION
- Aligns genai v1 and v2 E2E test Terraform with changes from [aws-otel-python-instrumentation#729](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/729).