### PR TITLE
fix: remove me-south-1 from sample app deploy regions

### DIFF
--- a/.github/workflows/dotnet-sample-app-ecr-deploy.yml
+++ b/.github/workflows/dotnet-sample-app-ecr-deploy.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         aws-region: [ 'af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
                       'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','sa-east-1',
                       'us-east-1','us-east-2','us-west-1','us-west-2' ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dotnet-sample-app-s3-deploy.yml
+++ b/.github/workflows/dotnet-sample-app-s3-deploy.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         aws-region: [ 'af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
                       'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','sa-east-1',
                       'us-east-1','us-east-2', 'us-west-1', 'us-west-2' ]
         dotnet-version: [ '8.0', '9.0', '10.0' ]
     runs-on: ubuntu-latest
@@ -109,7 +109,7 @@ jobs:
       matrix:
         aws-region: [ 'af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
                       'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','sa-east-1',
                       'us-east-1','us-east-2', 'us-west-1', 'us-west-2' ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/java-sample-app-ecr-deploy.yml
+++ b/.github/workflows/java-sample-app-ecr-deploy.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         aws-region: [ 'af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
                       'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','sa-east-1',
                       'us-east-1','us-east-2','us-west-1','us-west-2' ]
     runs-on: ubuntu-latest
     steps:
@@ -68,7 +68,7 @@ jobs:
       matrix:
         aws-region: [ 'af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
                       'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','sa-east-1',
                       'us-east-1','us-east-2','us-west-1','us-west-2' ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/java-sample-app-s3-deploy.yml
+++ b/.github/workflows/java-sample-app-s3-deploy.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         aws-region: [ 'af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
                       'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','sa-east-1',
                       'us-east-1','us-east-2','us-west-1','us-west-2' ]
     runs-on: ubuntu-latest
     steps:
@@ -65,7 +65,7 @@ jobs:
       matrix:
         aws-region: [ 'af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
                       'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','sa-east-1',
                       'us-east-1','us-east-2','us-west-1','us-west-2' ]
     runs-on: ubuntu-latest
     steps:
@@ -200,7 +200,7 @@ jobs:
       matrix:
         aws-region: [ 'af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
                       'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','sa-east-1',
                       'us-east-1','us-east-2','us-west-1','us-west-2' ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/node-sample-app-ecr-deploy.yml
+++ b/.github/workflows/node-sample-app-ecr-deploy.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         aws-region: [ 'af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
                       'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','sa-east-1',
                       'us-east-1','us-east-2','us-west-1','us-west-2' ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/node-sample-app-s3-deploy.yml
+++ b/.github/workflows/node-sample-app-s3-deploy.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         aws-region: [ 'af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
                       'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','sa-east-1',
                       'us-east-1','us-east-2', 'us-west-1', 'us-west-2' ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/python-sample-app-ecr-deploy.yml
+++ b/.github/workflows/python-sample-app-ecr-deploy.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         aws-region: [ 'af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
                       'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','sa-east-1',
                       'us-east-1','us-east-2','us-west-1','us-west-2' ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/python-sample-app-s3-deploy.yml
+++ b/.github/workflows/python-sample-app-s3-deploy.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         aws-region: [ 'af-south-1','ap-east-1','ap-northeast-1','ap-northeast-2','ap-northeast-3','ap-south-1','ap-south-2','ap-southeast-1',
                       'ap-southeast-2','ap-southeast-3','ap-southeast-4','ca-central-1','eu-central-1','eu-central-2','eu-north-1',
-                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','me-south-1', 'sa-east-1',
+                      'eu-south-1','eu-south-2','eu-west-1','eu-west-2','eu-west-3','il-central-1','me-central-1','sa-east-1',
                       'us-east-1','us-east-2', 'us-west-1', 'us-west-2' ]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
- Remove `me-south-1` from the region matrix in all sample app deploy workflows
