### PR TITLE
Enforce IMDSv2 on EC2 ASG launch configurations

### DIFF
--- a/terraform/dotnet/ec2/asg/main.tf
+++ b/terraform/dotnet/ec2/asg/main.tf
@@ -96,6 +96,11 @@ resource "aws_launch_configuration" "launch_configuration" {
     volume_size = 5
   }
 
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
   user_data = <<-EOF
     #!/bin/bash
     set -o errexit

--- a/terraform/java/ec2/asg/main.tf
+++ b/terraform/java/ec2/asg/main.tf
@@ -96,6 +96,11 @@ resource "aws_launch_configuration" "launch_configuration" {
     volume_size = 5
   }
 
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
   user_data = <<-EOF
     #!/bin/bash
     # Make the Terraform fail if any step throws an error

--- a/terraform/node/ec2/asg/main.tf
+++ b/terraform/node/ec2/asg/main.tf
@@ -96,6 +96,11 @@ resource "aws_launch_configuration" "launch_configuration" {
     volume_size = 5
   }
 
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
   user_data = <<-EOF
     #!/bin/bash
 

--- a/terraform/python/ec2/asg/main.tf
+++ b/terraform/python/ec2/asg/main.tf
@@ -96,6 +96,11 @@ resource "aws_launch_configuration" "launch_configuration" {
     volume_size = 5
   }
 
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
   user_data = <<-EOF
     #!/bin/bash
 


### PR DESCRIPTION
*Issue description:*

PR #528 added `metadata_options { http_tokens = "required" }` to the `aws_instance.remote_service_instance` resource in all four `terraform/*/ec2/asg/main.tf` files, but did not add it to the corresponding `aws_launch_configuration.launch_configuration` resource. As a result, instances spawned by the ASG in the EC2 ASG E2E tests still launch with `HttpTokens: optional` (IMDSv1 enabled), while the remote-service instance launches with IMDSv2 enforced.

*Description of changes:*

Add the following block to each of the four `aws_launch_configuration.launch_configuration` resources, matching the IMDSv2 configuration already present on `aws_instance.remote_service_instance`:

```hcl
metadata_options {
  http_endpoint = "enabled"
  http_tokens   = "required"
}
```

Files changed:
- `terraform/java/ec2/asg/main.tf`
- `terraform/python/ec2/asg/main.tf`
- `terraform/dotnet/ec2/asg/main.tf`
- `terraform/node/ec2/asg/main.tf`

After this change, every ASG-spawned instance in the Java/Python/.NET/Node EC2 ASG E2E tests will launch with IMDSv2 enforced.

*Rollback procedure:*

Safe to revert with a single `git revert`. The change is additive (one `metadata_options` block per file) and only affects IMDS configuration on newly launched EC2 instances. Reverting would restore IMDSv1-optional behavior on ASG-spawned instances — no data migration or cleanup required.

*Ensure you've run the following tests on your changes and include the link below:*

Will run EC2 ASG tests for all four languages after opening the PR and link the run here.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
