### PR TITLE
allow perf test workflows to run from specific ADOT branch

### DIFF
--- a/.github/workflows/dotnet-lambda-layer-perf-test.yml
+++ b/.github/workflows/dotnet-lambda-layer-perf-test.yml
@@ -16,6 +16,12 @@ on:
         required: true
         default: '8.0.x'
         type: string  
+      
+      ADOT-DotNet-Branch:
+        description: 'ADOT branch to use'
+        required: true
+        default: 'main'
+        type: string
     
 jobs:
   dotnet-lambda-layer-performance-test:
@@ -27,6 +33,7 @@ jobs:
     env:
       NUM_TEST_RUNS: ${{ github.event.inputs.test_runs }}
       DOTNET_VERSION: ${{ github.event.inputs.dotnet-version }}
+      ADOT_DOTNET_BRANCH: ${{ github.event.inputs.ADOT-DotNet-Branch }}
   
     steps:
     - name: Configure AWS Credentials
@@ -39,7 +46,14 @@ jobs:
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         repository: aws-observability/aws-otel-dotnet-instrumentation
+        ref: ${{ env.ADOT_DOTNET_BRANCH }}
         path: aws-otel-dotnet-instrumentation
+
+    - name: Log branch and commit info
+      run: |
+        cd aws-otel-dotnet-instrumentation
+        echo "ADOT DotNet Branch: ${{ env.ADOT_DOTNET_BRANCH }}"
+        echo "ADOT DotNet Commit Hash: $(git rev-parse HEAD)"
 
     - name: Setup .NET
       uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5.0.0

--- a/.github/workflows/java-lambda-layer-perf-test.yml
+++ b/.github/workflows/java-lambda-layer-perf-test.yml
@@ -12,7 +12,7 @@ on:
         type: number
 
       ADOT-Java-Branch:
-        description: 'ADOT Java branch to use'
+        description: 'ADOT branch to use'
         required: true
         default: 'main'
         type: string

--- a/.github/workflows/node-lambda-layer-perf-test.yml
+++ b/.github/workflows/node-lambda-layer-perf-test.yml
@@ -15,6 +15,12 @@ on:
         required: true
         default: '22'
         type: string  
+
+      ADOT-Js-Branch:
+        description: 'ADOT branch to use'
+        required: true
+        default: 'main'
+        type: string
     
 jobs:
   node-lambda-layer-performance-test:
@@ -26,6 +32,7 @@ jobs:
     env:
       NUM_TEST_RUNS: ${{ github.event.inputs.test_runs }}
       NODE_VERSION: ${{ github.event.inputs.node_version }}
+      ADOT_JS_BRANCH: ${{ github.event.inputs.ADOT-Js-Branch }}
   
     steps:
     - name: Configure AWS Credentials
@@ -38,7 +45,14 @@ jobs:
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         repository: aws-observability/aws-otel-js-instrumentation
+        ref: ${{ env.ADOT_JS_BRANCH }}
         path: aws-otel-js-instrumentation
+
+    - name: Log branch and commit info
+      run: |
+        cd aws-otel-js-instrumentation
+        echo "ADOT JS Branch: ${{ env.ADOT_JS_BRANCH }}"
+        echo "ADOT JS Commit Hash: $(git rev-parse HEAD)"
 
     - name: Setup Node.js
       uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0

--- a/.github/workflows/python-lambda-layer-perf-test.yml
+++ b/.github/workflows/python-lambda-layer-perf-test.yml
@@ -15,6 +15,12 @@ on:
         required: true
         default: '3.13'
         type: string  
+      
+      ADOT-Python-Branch:
+        description: 'ADOT branch to use'
+        required: true
+        default: 'main'
+        type: string
 
 jobs:
   python-lambda-layer-performance-test:
@@ -26,6 +32,7 @@ jobs:
     env:
       NUM_TEST_RUNS: ${{ github.event.inputs.test_runs }}
       PYTHON_VERSION: ${{ github.event.inputs.python_version }}
+      ADOT_PYTHON_BRANCH: ${{ github.event.inputs.ADOT-Python-Branch }}
   
     steps:
     - name: Configure AWS Credentials
@@ -38,7 +45,14 @@ jobs:
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         repository: aws-observability/aws-otel-python-instrumentation
+        ref: ${{ env.ADOT_PYTHON_BRANCH }}
         path: aws-otel-python-instrumentation
+
+    - name: Log branch and commit info
+      run: |
+        cd aws-otel-python-instrumentation
+        echo "ADOT Python Branch: ${{ env.ADOT_PYTHON_BRANCH }}"
+        echo "ADOT Python Commit Hash: $(git rev-parse HEAD)"
 
     - name: Setup Python
       uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0


### PR DESCRIPTION
*Issue description:*

*Description of changes:*
Sometimes we need to run the Lambda layer performance test from a specific branch of the ADOT repo. Most often this happens for patch releases, where the change is committed to a release branch. Currently this is only implemented for the ADOT Java perf test workflow.

This change allows the other 3 lambda layer performance test workflows to also check out a specific branch of their corresponding ADOT repos, if provided.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
