### PR TITLE
fix: use prefix-based arg matching for k8s operator image patch

### DIFF
--- a/terraform/dotnet/k8s/deploy/main.tf
+++ b/terraform/dotnet/k8s/deploy/main.tf
@@ -91,8 +91,10 @@ resource "null_resource" "deploy" {
         sleep 10
         kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
       elif [ "${var.repository}" = "aws-otel-dotnet-instrumentation" ]; then
-        kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' \
-        -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/4", "value": "--auto-instrumentation-dotnet-image=${var.patch_image_arn}"}]'
+        kubectl get deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager -o json | \
+          jq '.spec.template.spec.containers[0].args |= map(if test("^--auto-instrumentation-dotnet-image=") then "--auto-instrumentation-dotnet-image=${var.patch_image_arn}" else . end)' | \
+          kubectl apply -f -
+        kubectl rollout status deployment/amazon-cloudwatch-observability-controller-manager -n amazon-cloudwatch --timeout=120s
         kubectl delete pods --all -n amazon-cloudwatch
         sleep 10
         kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch

--- a/terraform/java/k8s/deploy/main.tf
+++ b/terraform/java/k8s/deploy/main.tf
@@ -92,8 +92,10 @@ resource "null_resource" "deploy" {
         sleep 10
         kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
       elif [ "${var.repository}" = "aws-otel-java-instrumentation" ]; then
-        kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' \
-        -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/0", "value": "--auto-instrumentation-java-image=${var.patch_image_arn}"}]'
+        kubectl get deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager -o json | \
+          jq '.spec.template.spec.containers[0].args |= map(if test("^--auto-instrumentation-java-image=") then "--auto-instrumentation-java-image=${var.patch_image_arn}" else . end)' | \
+          kubectl apply -f -
+        kubectl rollout status deployment/amazon-cloudwatch-observability-controller-manager -n amazon-cloudwatch --timeout=120s
         kubectl delete pods --all -n amazon-cloudwatch
         sleep 10
         kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch

--- a/terraform/node/k8s/deploy/main.tf
+++ b/terraform/node/k8s/deploy/main.tf
@@ -94,8 +94,10 @@ resource "null_resource" "deploy" {
         sleep 10
         kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
       elif [ "${var.repository}" = "aws-otel-js-instrumentation" ]; then
-        kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' \
-        -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/5", "value": "--auto-instrumentation-nodejs-image=${var.patch_image_arn}"}]'
+        kubectl get deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager -o json | \
+          jq '.spec.template.spec.containers[0].args |= map(if test("^--auto-instrumentation-nodejs-image=") then "--auto-instrumentation-nodejs-image=${var.patch_image_arn}" else . end)' | \
+          kubectl apply -f -
+        kubectl rollout status deployment/amazon-cloudwatch-observability-controller-manager -n amazon-cloudwatch --timeout=120s
         kubectl delete pods --all -n amazon-cloudwatch
         sleep 10
         kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch

--- a/terraform/python/k8s/deploy/main.tf
+++ b/terraform/python/k8s/deploy/main.tf
@@ -93,8 +93,10 @@ resource "null_resource" "deploy" {
         sleep 10
         kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
       elif [ "${var.repository}" = "aws-otel-python-instrumentation" ]; then
-        kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' \
-        -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/2", "value": "--auto-instrumentation-python-image=${var.patch_image_arn}"}]'
+        kubectl get deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager -o json | \
+          jq '.spec.template.spec.containers[0].args |= map(if test("^--auto-instrumentation-python-image=") then "--auto-instrumentation-python-image=${var.patch_image_arn}" else . end)' | \
+          kubectl apply -f -
+        kubectl rollout status deployment/amazon-cloudwatch-observability-controller-manager -n amazon-cloudwatch --timeout=120s
         kubectl delete pods --all -n amazon-cloudwatch
         sleep 10
         kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch

--- a/validator/src/main/resources/expected-data-template/java/k8s/outgoing-http-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/java/k8s/outgoing-http-call-log.mustache
@@ -27,7 +27,7 @@
   "Service": "^{{serviceName}}$",
   "Operation": "GET /outgoing-http-call",
   "Version": "^1$",
-  "RemoteService": "www.amazon.com",
+  "RemoteService": "www.amazon.com:443",
   "RemoteOperation": "GET /",
   "Telemetry.Source": "^ClientSpan$",
   "Telemetry.Agent": "^CWAgent\/([A-Za-z0-9.-]*)$",

--- a/validator/src/main/resources/expected-data-template/java/k8s/outgoing-http-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/java/k8s/outgoing-http-call-metric.mustache
@@ -30,7 +30,7 @@
       value: GET /
     -
       name: RemoteService
-      value: www.amazon.com
+      value: www.amazon.com:443
 
 -
   metricName: Latency
@@ -58,7 +58,7 @@
       value: GET /
     -
       name: RemoteService
-      value: www.amazon.com
+      value: www.amazon.com:443
 
 -
   metricName: Latency
@@ -72,7 +72,7 @@
       value: k8s:{{platformInfo}}/{{appNamespace}}
     -
       name: RemoteService
-      value: www.amazon.com
+      value: www.amazon.com:443
 
 -
   metricName: Error
@@ -106,7 +106,7 @@
       value: GET /
     -
       name: RemoteService
-      value: www.amazon.com
+      value: www.amazon.com:443
 
 -
   metricName: Error
@@ -134,7 +134,7 @@
       value: GET /
     -
       name: RemoteService
-      value: www.amazon.com
+      value: www.amazon.com:443
 
 -
   metricName: Error
@@ -148,7 +148,7 @@
       value: k8s:{{platformInfo}}/{{appNamespace}}
     -
       name: RemoteService
-      value: www.amazon.com
+      value: www.amazon.com:443
 
 -
   metricName: Fault
@@ -182,7 +182,7 @@
       value: GET /
     -
       name: RemoteService
-      value: www.amazon.com
+      value: www.amazon.com:443
 
 -
   metricName: Fault
@@ -210,7 +210,7 @@
       value: GET /
     -
       name: RemoteService
-      value: www.amazon.com
+      value: www.amazon.com:443
 
 -
   metricName: Fault
@@ -224,4 +224,4 @@
       value: k8s:{{platformInfo}}/{{appNamespace}}
     -
       name: RemoteService
-      value: www.amazon.com
+      value: www.amazon.com:443

--- a/validator/src/main/resources/expected-data-template/java/k8s/outgoing-http-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/java/k8s/outgoing-http-call-trace.mustache
@@ -33,7 +33,7 @@
     {
       "subsegments": [
         {
-          "name": "^www.amazon.com$",
+          "name": "^www.amazon.com:443$",
           "http": {
             "request": {
               "url": "^https://www.amazon.com$",
@@ -43,7 +43,7 @@
           "annotations": {
             "aws.local.service": "^{{serviceName}}$",
             "aws.local.operation": "^GET /outgoing-http-call$",
-            "aws.remote.service": "^www.amazon.com$",
+            "aws.remote.service": "^www.amazon.com:443$",
             "aws.remote.operation": "^GET /$",
             "aws.local.environment": "^k8s:{{platformInfo}}/{{appNamespace}}$"
           },
@@ -62,5 +62,5 @@
   ]
 },
 {
-  "name": "^www.amazon.com$"
+  "name": "^www.amazon.com:443$"
 }]


### PR DESCRIPTION
## Summary
- K8s deploy terraform scripts used hardcoded arg indices (`args/0`, `args/2`, etc.) to patch the auto-instrumentation image on the CW Agent Operator deployment. When the operator added new args (e.g. `--auto-monitor-config`), the indices shifted and the patch overwrote the wrong arg, leaving the actual instrumentation image unchanged.
- This caused k8s tests to silently use the operator's default public image instead of the CI-built staging image, meaning the tests were never actually validating the latest code from the SDK repos.
- Replace the hardcoded JSON patch with the same `jq map/test` approach already used by the EKS `patch_image_and_check_diff` action, which matches args by prefix and is resilient to ordering changes.
- Update `java/k8s` validation templates to expect `www.amazon.com:443` (with port), matching the behavior of the current ADOT Java agent and aligning with the existing `java/eks` templates.

## Test plan
- [ ] Run java-k8s test and verify the staging SNAPSHOT image is actually injected (check `Telemetry.SDK` contains `-SNAPSHOT`)
- [ ] Verify log/metric/trace validations pass with the updated templates
- [ ] Confirm EKS tests are unaffected