### PR TITLE
fix: use --timeout instead of --request-timeout for kubectl wait

### DIFF
--- a/terraform/dotnet/k8s/deploy/main.tf
+++ b/terraform/dotnet/k8s/deploy/main.tf
@@ -148,7 +148,7 @@ resource "null_resource" "deploy" {
 
       echo "Wait for sample app to be reach ready state"
       sleep 10
-      kubectl wait --for=condition=Ready --request-timeout '10m' pod --all -n dotnet-sample-app-namespace
+      kubectl wait --for=condition=Ready --timeout=10m pod --all -n dotnet-sample-app-namespace
 
       # Emit main and remote service pod IP
       echo "LOG: Outputting remote service pod IP to SSM using put-parameter API"

--- a/terraform/java/k8s/deploy/main.tf
+++ b/terraform/java/k8s/deploy/main.tf
@@ -149,7 +149,7 @@ resource "null_resource" "deploy" {
 
       # Wait for sample app to be reach ready state
       sleep 10
-      kubectl wait --for=condition=Ready --request-timeout '5m' pod --all -n sample-app-namespace
+      kubectl wait --for=condition=Ready --timeout=5m pod --all -n sample-app-namespace
 
       # Emit main and remote service pod IP
       echo "LOG: Outputting remote service pod IP to SSM using put-parameter API"

--- a/terraform/node/k8s/deploy/main.tf
+++ b/terraform/node/k8s/deploy/main.tf
@@ -151,7 +151,7 @@ resource "null_resource" "deploy" {
 
       # Wait for sample app to be reach ready state
       sleep 10
-      kubectl wait --for=condition=Ready --request-timeout '5m' pod --all -n sample-app-namespace
+      kubectl wait --for=condition=Ready --timeout=5m pod --all -n sample-app-namespace
 
       # Emit main and remote service pod IP
       echo "LOG: Outputting remote service pod IP to SSM using put-parameter API"

--- a/terraform/python/k8s/deploy/main.tf
+++ b/terraform/python/k8s/deploy/main.tf
@@ -150,7 +150,7 @@ resource "null_resource" "deploy" {
 
       echo "Wait for sample app to be reach ready state"
       sleep 10
-      kubectl wait --for=condition=Ready --request-timeout '10m' pod --all -n python-sample-app-namespace
+      kubectl wait --for=condition=Ready --timeout=10m pod --all -n python-sample-app-namespace
 
       # Emit main and remote service pod IP
       echo "LOG: Outputting remote service pod IP to SSM using put-parameter API"


### PR DESCRIPTION
## Summary
- `kubectl wait --request-timeout` controls the API server request timeout, not the condition wait duration. The default condition timeout is only 30s.
- After the operator image patch fix (#629) started working correctly, the init container now pulls a new staging image which takes longer than 30s. This causes sample app pods to hit the default timeout.
- Change to `--timeout` which properly controls how long `kubectl wait` will wait for the condition (Ready) to be met.

## Test plan
- [ ] Run java-k8s test and verify sample app pods have enough time to start (up to 5m)
- [ ] Verify other k8s tests (python, dotnet, node) are unaffected