### PR TITLE
Revert k8s terraform operator patch changes from #629 and #630

### DIFF
--- a/terraform/dotnet/k8s/deploy/main.tf
+++ b/terraform/dotnet/k8s/deploy/main.tf
@@ -91,10 +91,8 @@ resource "null_resource" "deploy" {
         sleep 10
         kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
       elif [ "${var.repository}" = "aws-otel-dotnet-instrumentation" ]; then
-        kubectl get deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager -o json | \
-          jq '.spec.template.spec.containers[0].args |= map(if test("^--auto-instrumentation-dotnet-image=") then "--auto-instrumentation-dotnet-image=${var.patch_image_arn}" else . end)' | \
-          kubectl apply -f -
-        kubectl rollout status deployment/amazon-cloudwatch-observability-controller-manager -n amazon-cloudwatch --timeout=120s
+        kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' \
+        -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/4", "value": "--auto-instrumentation-dotnet-image=${var.patch_image_arn}"}]'
         kubectl delete pods --all -n amazon-cloudwatch
         sleep 10
         kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch

--- a/terraform/java/k8s/deploy/main.tf
+++ b/terraform/java/k8s/deploy/main.tf
@@ -92,10 +92,8 @@ resource "null_resource" "deploy" {
         sleep 10
         kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
       elif [ "${var.repository}" = "aws-otel-java-instrumentation" ]; then
-        kubectl get deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager -o json | \
-          jq '.spec.template.spec.containers[0].args |= map(if test("^--auto-instrumentation-java-image=") then "--auto-instrumentation-java-image=${var.patch_image_arn}" else . end)' | \
-          kubectl apply -f -
-        kubectl rollout status deployment/amazon-cloudwatch-observability-controller-manager -n amazon-cloudwatch --timeout=120s
+        kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' \
+        -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/0", "value": "--auto-instrumentation-java-image=${var.patch_image_arn}"}]'
         kubectl delete pods --all -n amazon-cloudwatch
         sleep 10
         kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch

--- a/terraform/node/k8s/deploy/main.tf
+++ b/terraform/node/k8s/deploy/main.tf
@@ -94,10 +94,8 @@ resource "null_resource" "deploy" {
         sleep 10
         kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
       elif [ "${var.repository}" = "aws-otel-js-instrumentation" ]; then
-        kubectl get deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager -o json | \
-          jq '.spec.template.spec.containers[0].args |= map(if test("^--auto-instrumentation-nodejs-image=") then "--auto-instrumentation-nodejs-image=${var.patch_image_arn}" else . end)' | \
-          kubectl apply -f -
-        kubectl rollout status deployment/amazon-cloudwatch-observability-controller-manager -n amazon-cloudwatch --timeout=120s
+        kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' \
+        -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/5", "value": "--auto-instrumentation-nodejs-image=${var.patch_image_arn}"}]'
         kubectl delete pods --all -n amazon-cloudwatch
         sleep 10
         kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch

--- a/terraform/python/k8s/deploy/main.tf
+++ b/terraform/python/k8s/deploy/main.tf
@@ -93,10 +93,8 @@ resource "null_resource" "deploy" {
         sleep 10
         kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
       elif [ "${var.repository}" = "aws-otel-python-instrumentation" ]; then
-        kubectl get deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager -o json | \
-          jq '.spec.template.spec.containers[0].args |= map(if test("^--auto-instrumentation-python-image=") then "--auto-instrumentation-python-image=${var.patch_image_arn}" else . end)' | \
-          kubectl apply -f -
-        kubectl rollout status deployment/amazon-cloudwatch-observability-controller-manager -n amazon-cloudwatch --timeout=120s
+        kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' \
+        -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/2", "value": "--auto-instrumentation-python-image=${var.patch_image_arn}"}]'
         kubectl delete pods --all -n amazon-cloudwatch
         sleep 10
         kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch


### PR DESCRIPTION
## Summary
- Reverts the terraform changes from #629 (prefix-based arg matching) and #630 (timeout fix) for all 4 language k8s deploy scripts.
- The patch correctly updates the operator's `--auto-instrumentation-*-image` arg, but the k8s EC2 node cannot pull the private staging image from `611364707713.dkr.ecr.us-west-2.amazonaws.com` without proper ECR authentication, causing sample app pods to remain in ImagePullBackOff.
- Restores the previous behavior where k8s tests use the operator's default public image until the ECR pull credential issue is resolved.
- The validation template updates (`www.amazon.com:443`) from #629 are intentionally kept, as those will be needed when we re-enable the patch with proper credentials.

## Test plan
- [ ] Run java-k8s test and verify it passes with operator default image
- [ ] Verify EKS tests are unaffected (they use a separate patch mechanism)