### PR TITLE
fix: update java/k8s client-call templates to expect port in RemoteService

### DIFF
--- a/validator/src/main/resources/expected-data-template/java/k8s/client-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/java/k8s/client-call-log.mustache
@@ -27,7 +27,7 @@
   "Service": "^{{serviceName}}$",
   "Operation": "InternalOperation",
   "Version": "^1$",
-  "RemoteService": "local-root-client-call",
+  "RemoteService": "local-root-client-call:80",
   "RemoteOperation": "GET /",
   "Telemetry.Source": "^ClientSpan$",
   "Telemetry.Agent": "^CWAgent\/([A-Za-z0-9.-]*)$",

--- a/validator/src/main/resources/expected-data-template/java/k8s/client-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/java/k8s/client-call-metric.mustache
@@ -52,7 +52,7 @@
       value: k8s:{{platformInfo}}/{{appNamespace}}
     -
       name: RemoteService
-      value: local-root-client-call
+      value: local-root-client-call:80
     -
       name: RemoteOperation
       value: GET /
@@ -69,7 +69,7 @@
       value: k8s:{{platformInfo}}/{{appNamespace}}
     -
       name: RemoteService
-      value: local-root-client-call
+      value: local-root-client-call:80
     -
       name: RemoteOperation
       value: GET /
@@ -86,7 +86,7 @@
       value: k8s:{{platformInfo}}/{{appNamespace}}
     -
       name: RemoteService
-      value: local-root-client-call
+      value: local-root-client-call:80
 
 -
   metricName: Error
@@ -142,7 +142,7 @@
       value: k8s:{{platformInfo}}/{{appNamespace}}
     -
       name: RemoteService
-      value: local-root-client-call
+      value: local-root-client-call:80
     -
       name: RemoteOperation
       value: GET /
@@ -159,7 +159,7 @@
       value: k8s:{{platformInfo}}/{{appNamespace}}
     -
       name: RemoteService
-      value: local-root-client-call
+      value: local-root-client-call:80
     -
       name: RemoteOperation
       value: GET /
@@ -176,7 +176,7 @@
       value: k8s:{{platformInfo}}/{{appNamespace}}
     -
       name: RemoteService
-      value: local-root-client-call
+      value: local-root-client-call:80
 
 -
   metricName: Fault
@@ -232,7 +232,7 @@
       value: k8s:{{platformInfo}}/{{appNamespace}}
     -
       name: RemoteService
-      value: local-root-client-call
+      value: local-root-client-call:80
     -
       name: RemoteOperation
       value: GET /
@@ -249,7 +249,7 @@
       value: k8s:{{platformInfo}}/{{appNamespace}}
     -
       name: RemoteService
-      value: local-root-client-call
+      value: local-root-client-call:80
     -
       name: RemoteOperation
       value: GET /
@@ -266,4 +266,4 @@
       value: k8s:{{platformInfo}}/{{appNamespace}}
     -
       name: RemoteService
-      value: local-root-client-call
+      value: local-root-client-call:80

--- a/validator/src/main/resources/expected-data-template/java/k8s/client-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/java/k8s/client-call-trace.mustache
@@ -14,7 +14,7 @@
   },
   "subsegments": [
     {
-      "name": "^local-root-client-call$",
+      "name": "^local-root-client-call:80$",
       "http": {
           "request": {
               "url": "^http://local-root-client-call$",
@@ -24,7 +24,7 @@
       "annotations": {
         "aws.local.service": "^{{serviceName}}$",
         "aws.local.operation": "^InternalOperation$",
-        "aws.remote.service": "^local-root-client-call$",
+        "aws.remote.service": "^local-root-client-call:80$",
         "aws.remote.operation": "GET /",
         "aws.local.environment": "^k8s:{{platformInfo}}/{{appNamespace}}$"
       },
@@ -38,7 +38,7 @@
   ]
 },
 {
-    "name": "^local-root-client-call$",
+    "name": "^local-root-client-call:80$",
     "http": {
         "request": {
             "url": "^http://local-root-client-call$",
@@ -49,7 +49,7 @@
         }
     },
     "annotations": {
-        "aws.local.service": "^local-root-client-call$",
+        "aws.local.service": "^local-root-client-call:80$",
         "aws.local.operation": "^GET /$"
     }
 }]


### PR DESCRIPTION
## Summary
- The CW Agent Operator's default `adot-autoinstrumentation-java:v2.26.2` now includes `server.port` in `RemoteService` for all HTTP client spans.
- The java/k8s `client-call` templates expected `local-root-client-call` but actual telemetry now produces `local-root-client-call:80`.
- Update log, metric, and trace templates to match, aligning with the existing java/eks templates.

## Test plan
- [x] Run java-k8s test and verify client-call log/metric/trace validations pass