### PR TITLE
fix: remove cloud.platform from .NET Lambda log schema validation

### DIFF
--- a/validator/src/main/resources/expected-data-template/java/lambda/log-schema-dotnet.mustache
+++ b/validator/src/main/resources/expected-data-template/java/lambda/log-schema-dotnet.mustache
@@ -3,7 +3,6 @@
     "attributes": {
       "service.name": "^{{serviceName}}$",
       "cloud.region": "^[a-z]{2}-[a-z]+-[0-9]+$",
-      "cloud.platform": "^aws_lambda$",
       "cloud.provider": "^aws$",
       "faas.name": "^{{serviceName}}$",
       "faas.version": "^.+$",


### PR DESCRIPTION
fix: remove cloud.platform from .NET Lambda log schema validation

The .NET ADOT distro does not emit cloud.platform in Lambda environments.
The resource detector defines the constant but never assigns it confirmed [here](https://github.com/aws-observability/aws-otel-dotnet-instrumentation/actions/runs/26644541796/job/78527102107)
by E2E test output showing the attribute absent from actual logs.

Reverting this PR will safely remove this change.

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
