### PR TITLE
fix: migrate RDS DB instances to MySQL

### DIFF
--- a/.github/workflows/java-eks-test.yml
+++ b/.github/workflows/java-eks-test.yml
@@ -180,45 +180,6 @@ jobs:
               && sudo apt update && sudo apt install terraform'
           sleep_time: 60
 
-      - name: Get RDS database cluster metadata
-        continue-on-error: true
-        run: |
-          if [ "${{ env.CLUSTER_NAME }}" = "e2e-enablement-script-test" ]; then
-            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroraenablementscriptpythone2eclusterformysql"
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-cw-agent-test" ]; then
-            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroracwagente2eclusterformysql"
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-adot-test" ]; then
-            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroraadote2eclusterformysql"
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-cw-agent-operator-test" ]; then
-            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroracwagentoperatore2eclusterformysql"
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-canary-test" ]; then
-            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsaurorajavaclusterformysql"
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-playground" ]; then
-            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroraplaygroundclusterformysql"
-          else
-            echo "${{ env.CLUSTER_NAME }} is not a known cluster name"
-            exit 1
-          fi
-          RDS_MYSQL_CLUSTER_ENDPOINT=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier $RDS_MYSQL_CLUSTER_IDENTIFIER --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].Endpoint" --output text)
-          echo RDS_MYSQL_CLUSTER_ENDPOINT="$RDS_MYSQL_CLUSTER_ENDPOINT" >> "$GITHUB_ENV"
-          RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME=$(aws secretsmanager list-secrets --region ${{inputs.aws-region}} --query "SecretList[?Tags[?Value=='arn:aws:rds:${{inputs.aws-region}}:${{env.ACCOUNT_ID}}:cluster:$RDS_MYSQL_CLUSTER_IDENTIFIER']].Name" --output text)
-          echo RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME="$RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME" >> "$GITHUB_ENV"
-
-      - name: Get RDS database credentials from SecretsManager
-        continue-on-error: true
-        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2.0.10
-        env:
-          NODE_OPTIONS: "--network-family-autoselection-attempt-timeout=1000"
-        with:
-          secret-ids:
-            RDS_MYSQL_CLUSTER_SECRETS, ${{env.RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME}}
-          parse-json-secrets: true
-
-      - name: Convert RDS database credentials to base64
-        continue-on-error: true
-        run: |
-          echo "RDS_MYSQL_CLUSTER_SECRETS_PASSWORD_BASE64=$(echo -n '${{env.RDS_MYSQL_CLUSTER_SECRETS_PASSWORD}}' | base64)" >> "$GITHUB_ENV"
-
       - name: Initiate Terraform
         uses: ./.github/workflows/actions/execute_and_retry
         with:
@@ -255,9 +216,6 @@ jobs:
               -var="service_account_aws_access=service-account-${{ env.TESTING_ID }}" \
               -var="sample_app_image=${{ env.MAIN_SAMPLE_APP_IMAGE_ARN }}" \
               -var="sample_remote_app_image=${{ env.REMOTE_SAMPLE_APP_IMAGE_ARN }}" \
-              -var="rds_mysql_cluster_endpoint=${{env.RDS_MYSQL_CLUSTER_ENDPOINT}}" \
-              -var="rds_mysql_cluster_username=${{env.RDS_MYSQL_CLUSTER_SECRETS_USERNAME}}" \
-              -var='rds_mysql_cluster_password=${{env.RDS_MYSQL_CLUSTER_SECRETS_PASSWORD_BASE64}}' \
               -var='account_id=${{ env.ACCOUNT_ID }}' \
             || deployment_failed=$?          
 
@@ -400,8 +358,8 @@ jobs:
           --platform-info ${{ env.CLUSTER_NAME }}
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --remote-resource-identifier "information_schema|${{env.RDS_MYSQL_CLUSTER_ENDPOINT}}|3306"
-          --remote-db-user ${{ env.RDS_MYSQL_CLUSTER_SECRETS_USERNAME }}
+          --remote-resource-identifier "information_schema|mysql-service.${{ env.SAMPLE_APP_NAMESPACE }}.svc.cluster.local|3306"
+          --remote-db-user root
           --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
@@ -420,7 +378,7 @@ jobs:
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-name sample-remote-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --remote-resource-identifier "information_schema|${{env.RDS_MYSQL_CLUSTER_ENDPOINT}}|3306"
+          --remote-resource-identifier "information_schema|mysql-service.${{ env.SAMPLE_APP_NAMESPACE }}.svc.cluster.local|3306"
           --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
@@ -438,7 +396,7 @@ jobs:
           --platform-info ${{ env.CLUSTER_NAME }}
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --remote-resource-identifier "information_schema|${{env.RDS_MYSQL_CLUSTER_ENDPOINT}}|3306"
+          --remote-resource-identifier "information_schema|mysql-service.${{ env.SAMPLE_APP_NAMESPACE }}.svc.cluster.local|3306"
           --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 

--- a/.github/workflows/node-eks-test.yml
+++ b/.github/workflows/node-eks-test.yml
@@ -174,40 +174,6 @@ jobs:
               && sudo apt update && sudo apt install terraform'
           sleep_time: 60
 
-      - name: Get RDS database cluster metadata
-        continue-on-error: true
-        run: |
-          if [ "${{ env.CLUSTER_NAME }}" = "e2e-enablement-script-test" ]; then
-            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroraenablementscriptpythone2eclusterformysql"
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-cw-agent-test" ]; then
-            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroracwagente2eclusterformysql"
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-node-adot-test" ]; then
-            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroraadotnodee2eclusterformysql"
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-cw-agent-operator-test" ]; then
-            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroracwagentoperatore2eclusterformysql"
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-node-canary-test" ]; then
-            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroranodeclusterformysql"
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-playground" ]; then
-            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroraplaygroundclusterformysql"
-          else
-            echo "${{ env.CLUSTER_NAME }} is not a known cluster name"
-            exit 1
-          fi
-          RDS_MYSQL_CLUSTER_ENDPOINT=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier $RDS_MYSQL_CLUSTER_IDENTIFIER --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].Endpoint" --output text)
-          echo RDS_MYSQL_CLUSTER_ENDPOINT="$RDS_MYSQL_CLUSTER_ENDPOINT" >> "$GITHUB_ENV"
-          RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME=$(aws secretsmanager list-secrets --region ${{inputs.aws-region}} --query "SecretList[?Tags[?Value=='arn:aws:rds:${{inputs.aws-region}}:${{env.ACCOUNT_ID}}:cluster:$RDS_MYSQL_CLUSTER_IDENTIFIER']].Name" --output text)
-          echo RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME="$RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME" >> "$GITHUB_ENV"
-
-      - name: Get RDS database credentials from SecretsManager
-        continue-on-error: true
-        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2.0.10
-        env:
-          NODE_OPTIONS: "--network-family-autoselection-attempt-timeout=1000"
-        with:
-          secret-ids:
-            RDS_MYSQL_CLUSTER_SECRETS, ${{env.RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME}}
-          parse-json-secrets: true
-
       - name: Initiate Terraform
         uses: ./.github/workflows/actions/execute_and_retry
         with:
@@ -244,9 +210,6 @@ jobs:
               -var="service_account_aws_access=service-account-${{ env.TESTING_ID }}" \
               -var="sample_app_image=${{ env.MAIN_SAMPLE_APP_IMAGE_ARN }}" \
               -var="sample_remote_app_image=${{ env.REMOTE_SAMPLE_APP_IMAGE_ARN }}" \
-              -var="rds_mysql_cluster_endpoint=${{env.RDS_MYSQL_CLUSTER_ENDPOINT}}" \
-              -var="rds_mysql_cluster_username=${{env.RDS_MYSQL_CLUSTER_SECRETS_USERNAME}}" \
-              -var='rds_mysql_cluster_password=${{env.RDS_MYSQL_CLUSTER_SECRETS_PASSWORD}}' \
               -var='account_id=${{ env.ACCOUNT_ID }}' \
             || deployment_failed=$?          
 
@@ -389,8 +352,8 @@ jobs:
           --platform-info ${{ env.CLUSTER_NAME }}
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --remote-resource-identifier "information_schema|${{env.RDS_MYSQL_CLUSTER_ENDPOINT}}|3306"
-          --remote-db-user ${{ env.RDS_MYSQL_CLUSTER_SECRETS_USERNAME }}
+          --remote-resource-identifier "information_schema|mysql-service.${{ env.SAMPLE_APP_NAMESPACE }}.svc.cluster.local|3306"
+          --remote-db-user root
           --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
@@ -409,7 +372,7 @@ jobs:
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-name sample-remote-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --remote-resource-identifier "information_schema|${{env.RDS_MYSQL_CLUSTER_ENDPOINT}}|3306"
+          --remote-resource-identifier "information_schema|mysql-service.${{ env.SAMPLE_APP_NAMESPACE }}.svc.cluster.local|3306"
           --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
@@ -427,7 +390,7 @@ jobs:
           --platform-info ${{ env.CLUSTER_NAME }}
           --service-name sample-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --remote-resource-identifier "information_schema|${{env.RDS_MYSQL_CLUSTER_ENDPOINT}}|3306"
+          --remote-resource-identifier "information_schema|mysql-service.${{ env.SAMPLE_APP_NAMESPACE }}.svc.cluster.local|3306"
           --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 

--- a/.github/workflows/python-eks-test.yml
+++ b/.github/workflows/python-eks-test.yml
@@ -181,45 +181,6 @@ jobs:
               && sudo apt update && sudo apt install terraform'
           sleep_time: 60
 
-      - name: Get RDS database cluster metadata
-        continue-on-error: true
-        run: |
-          if [ "${{ env.CLUSTER_NAME }}" = "e2e-enablement-script-test" ]; then
-            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroraenablementscriptpythone2eclusterformysql"
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-cw-agent-test" ]; then
-            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroracwagente2eclusterformysql"
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-python-adot-test" ]; then
-            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroraadotpythone2eclusterformysql"
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-cw-agent-operator-python-test" ]; then
-            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroracwagentoperatorpythone2eclusterformysql"
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-python-canary-test" ]; then
-            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsaurorapythonclusterformysql"
-          elif [ "${{ env.CLUSTER_NAME }}" = "e2e-playground" ]; then
-            RDS_MYSQL_CLUSTER_IDENTIFIER="rdsauroraplaygroundclusterformysql"
-          else
-            echo "${{ env.CLUSTER_NAME }} is not a known cluster name"
-            exit 1
-          fi
-          RDS_MYSQL_CLUSTER_ENDPOINT=$(aws rds describe-db-cluster-endpoints --db-cluster-identifier $RDS_MYSQL_CLUSTER_IDENTIFIER --region ${{inputs.aws-region}} --query "DBClusterEndpoints[?EndpointType=='WRITER'].Endpoint" --output text)
-          echo RDS_MYSQL_CLUSTER_ENDPOINT="$RDS_MYSQL_CLUSTER_ENDPOINT" >> "$GITHUB_ENV"
-          RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME=$(aws secretsmanager list-secrets --region ${{inputs.aws-region}} --query "SecretList[?Tags[?Value=='arn:aws:rds:${{inputs.aws-region}}:${{env.ACCOUNT_ID}}:cluster:$RDS_MYSQL_CLUSTER_IDENTIFIER']].Name" --output text)
-          echo RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME="$RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME" >> "$GITHUB_ENV"
-
-      - name: Get RDS database credentials from SecretsManager
-        continue-on-error: true
-        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2.0.10
-        env:
-          NODE_OPTIONS: "--network-family-autoselection-attempt-timeout=1000"
-        with:
-          secret-ids:
-            RDS_MYSQL_CLUSTER_SECRETS, ${{env.RDS_MYSQL_CLUSTER_CREDENTIAL_SECRET_NAME}}
-          parse-json-secrets: true
-
-      - name: Convert RDS database credentials to base64
-        continue-on-error: true
-        run: |
-          echo "RDS_MYSQL_CLUSTER_SECRETS_PASSWORD_BASE64=$(echo -n '${{env.RDS_MYSQL_CLUSTER_SECRETS_PASSWORD}}' | base64)" >> "$GITHUB_ENV"
-
       - name: Initiate Terraform
         uses: ./.github/workflows/actions/execute_and_retry
         with:
@@ -256,10 +217,6 @@ jobs:
               -var='service_account_aws_access=service-account-${{ env.TESTING_ID }}' \
               -var='python_app_image=${{ env.MAIN_SAMPLE_APP_IMAGE_ARN }}' \
               -var='python_remote_app_image=${{ env.REMOTE_SAMPLE_APP_IMAGE_ARN }}' \
-              -var='rds_mysql_cluster_endpoint=${{env.RDS_MYSQL_CLUSTER_ENDPOINT}}' \
-              -var='rds_mysql_cluster_username=${{env.RDS_MYSQL_CLUSTER_SECRETS_USERNAME}}' \
-              -var='rds_mysql_cluster_password=${{env.RDS_MYSQL_CLUSTER_SECRETS_PASSWORD_BASE64}}' \
-              -var='rds_mysql_cluster_database=information_schema' \
               -var='account_id=${{ env.ACCOUNT_ID }}' \
             || deployment_failed=$?
           
@@ -404,8 +361,8 @@ jobs:
           --platform-info ${{ env.CLUSTER_NAME }}
           --service-name python-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --remote-resource-identifier "information_schema|${{env.RDS_MYSQL_CLUSTER_ENDPOINT}}|3306"
-          --remote-db-user ${{ env.RDS_MYSQL_CLUSTER_SECRETS_USERNAME }}
+          --remote-resource-identifier "information_schema|mysql-service.${{ env.SAMPLE_APP_NAMESPACE }}.svc.cluster.local|3306"
+          --remote-db-user root
           --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
@@ -424,7 +381,7 @@ jobs:
           --service-name python-application-${{ env.TESTING_ID }}
           --remote-service-name python-remote-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --remote-resource-identifier "information_schema|${{env.RDS_MYSQL_CLUSTER_ENDPOINT}}|3306"
+          --remote-resource-identifier "information_schema|mysql-service.${{ env.SAMPLE_APP_NAMESPACE }}.svc.cluster.local|3306"
           --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 
@@ -441,7 +398,7 @@ jobs:
           --platform-info ${{ env.CLUSTER_NAME }}
           --service-name python-application-${{ env.TESTING_ID }}
           --remote-service-deployment-name ${{ env.REMOTE_SERVICE_DEPLOYMENT_NAME }}
-          --remote-resource-identifier "information_schema|${{env.RDS_MYSQL_CLUSTER_ENDPOINT}}|3306"
+          --remote-resource-identifier "information_schema|mysql-service.${{ env.SAMPLE_APP_NAMESPACE }}.svc.cluster.local|3306"
           --query-string ip=${{ env.REMOTE_SERVICE_POD_IP }}&testingId=${{ env.TESTING_ID }}
           --rollup'
 

--- a/.github/workflows/python-eks-test.yml
+++ b/.github/workflows/python-eks-test.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: 'aws-observability/aws-application-signals-test-framework'
-          ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
+          ref: ${{ inputs.caller-workflow-name == 'main-build' && 'rds-migration' || github.ref }}
           fetch-depth: 0
 
         # We initialize Gradlew Daemon early on during the workflow because sometimes initialization

--- a/sample-apps/java/springboot-main-service/src/main/java/com/amazon/sampleapp/FrontendServiceController.java
+++ b/sample-apps/java/springboot-main-service/src/main/java/com/amazon/sampleapp/FrontendServiceController.java
@@ -32,7 +32,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
-import org.apache.tomcat.util.codec.binary.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -152,7 +151,7 @@ public class FrontendServiceController {
   @ResponseBody
   public String mysql() {
     logger.info("mysql received");
-    final String rdsMySQLClusterPassword = new String(new Base64().decode(System.getenv("RDS_MYSQL_CLUSTER_PASSWORD").getBytes()));
+    final String rdsMySQLClusterPassword = System.getenv("RDS_MYSQL_CLUSTER_PASSWORD");
     try {
       Connection connection = DriverManager.getConnection(
               System.getenv("RDS_MYSQL_CLUSTER_CONNECTION_URL"),

--- a/sample-apps/python/django_frontend_service/frontend_service_app/views.py
+++ b/sample-apps/python/django_frontend_service/frontend_service_app/views.py
@@ -2,7 +2,6 @@
 ## SPDX-License-Identifier: Apache-2.0
 import logging
 import os
-import base64
 import threading
 import time
 import random
@@ -171,13 +170,12 @@ def get_xray_trace_id():
 def mysql(request):
     logger.info("mysql received")
 
-    encoded_password = os.environ["RDS_MYSQL_CLUSTER_PASSWORD"]
-    decoded_password = base64.b64decode(encoded_password).decode('utf-8')
+    password = os.environ["RDS_MYSQL_CLUSTER_PASSWORD"]
 
     try:
         connection = pymysql.connect(host=os.environ["RDS_MYSQL_CLUSTER_ENDPOINT"],
                                      user=os.environ["RDS_MYSQL_CLUSTER_USERNAME"],
-                                     password=decoded_password,
+                                     password=password,
                                      database=os.environ["RDS_MYSQL_CLUSTER_DATABASE"])
         with connection:
             with connection.cursor() as cursor:

--- a/sample-apps/python/django_frontend_service/requirements.txt
+++ b/sample-apps/python/django_frontend_service/requirements.txt
@@ -1,5 +1,6 @@
 Django~=4.2.9
 boto3~=1.34.3
+cryptography>=42.0.0
 opentelemetry-api~=1.22.0
 pymysql==1.1.1
 python-dotenv~=1.0.1

--- a/terraform/java/eks/main.tf
+++ b/terraform/java/eks/main.tf
@@ -113,15 +113,15 @@ resource "kubernetes_deployment" "sample_app_deployment" {
           }
           env {
             name  = "RDS_MYSQL_CLUSTER_CONNECTION_URL"
-            value = "jdbc:mysql://${var.rds_mysql_cluster_endpoint}:3306/information_schema"
+            value = "jdbc:mysql://mysql-service.${var.test_namespace}.svc.cluster.local:3306/information_schema"
           }
           env {
             name  = "RDS_MYSQL_CLUSTER_USERNAME"
-            value = var.rds_mysql_cluster_username
+            value = "root"
           }
           env {
             name  = "RDS_MYSQL_CLUSTER_PASSWORD"
-            value = var.rds_mysql_cluster_password
+            value = "testpassword"
           }
           env {
             name  = "OTEL_INSTRUMENTATION_COMMON_EXPERIMENTAL_CONTROLLER_TELEMETRY_ENABLED"
@@ -261,6 +261,73 @@ resource "kubernetes_deployment" "traffic_generator" {
           }
         }
       }
+    }
+  }
+}
+
+resource "kubernetes_deployment" "mysql" {
+  metadata {
+    name      = "mysql-deployment"
+    namespace = var.test_namespace
+    labels = {
+      app = "mysql"
+    }
+  }
+  spec {
+    replicas = 1
+    selector {
+      match_labels = {
+        app = "mysql"
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          app = "mysql"
+        }
+      }
+      spec {
+        container {
+          name  = "mysql"
+          image = "mysql:8.0"
+          port {
+            container_port = 3306
+          }
+          env {
+            name  = "MYSQL_ROOT_PASSWORD"
+            value = "testpassword"
+          }
+          resources {
+            requests = {
+              cpu    = "100m"
+              memory = "256Mi"
+            }
+            limits = {
+              cpu    = "250m"
+              memory = "512Mi"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "mysql" {
+  depends_on = [kubernetes_deployment.mysql]
+
+  metadata {
+    name      = "mysql-service"
+    namespace = var.test_namespace
+  }
+  spec {
+    selector = {
+      app = "mysql"
+    }
+    port {
+      protocol    = "TCP"
+      port        = 3306
+      target_port = 3306
     }
   }
 }

--- a/terraform/java/eks/main.tf
+++ b/terraform/java/eks/main.tf
@@ -267,7 +267,7 @@ resource "kubernetes_deployment" "traffic_generator" {
 
 resource "kubernetes_deployment" "mysql" {
   metadata {
-    name      = "mysql-deployment"
+    name      = "sql-deployment"
     namespace = var.test_namespace
     labels = {
       app = "mysql"

--- a/terraform/java/eks/variables.tf
+++ b/terraform/java/eks/variables.tf
@@ -49,18 +49,6 @@ variable "sample_remote_app_image" {
   default = "<ECR_IMAGE_LINK>:<TAG>"
 }
 
-variable "rds_mysql_cluster_endpoint" {
-  default = "example.cluster-example.eu-west-1.rds.amazonaws.com"
-}
-
-variable "rds_mysql_cluster_username" {
-  default = "username"
-}
-
-variable "rds_mysql_cluster_password" {
-  default = "password"
-}
-
 variable "account_id" {
   default = "<AWS_ACCOUNT_ID>"
 }

--- a/terraform/node/eks/main.tf
+++ b/terraform/node/eks/main.tf
@@ -120,15 +120,15 @@ resource "kubernetes_deployment" "sample_app_deployment" {
           }
           env {
             name  = "RDS_MYSQL_CLUSTER_CONNECTION_URL"
-            value = "jdbc:mysql://${var.rds_mysql_cluster_endpoint}:3306/information_schema"
+            value = "jdbc:mysql://mysql-service.${var.test_namespace}.svc.cluster.local:3306/information_schema"
           }
           env {
             name  = "RDS_MYSQL_CLUSTER_USERNAME"
-            value = var.rds_mysql_cluster_username
+            value = "root"
           }
           env {
             name  = "RDS_MYSQL_CLUSTER_PASSWORD"
-            value = var.rds_mysql_cluster_password
+            value = "testpassword"
           }
           port {
             container_port = 8000
@@ -264,6 +264,73 @@ resource "kubernetes_deployment" "traffic_generator" {
           }
         }
       }
+    }
+  }
+}
+
+resource "kubernetes_deployment" "mysql" {
+  metadata {
+    name      = "mysql-deployment"
+    namespace = var.test_namespace
+    labels = {
+      app = "mysql"
+    }
+  }
+  spec {
+    replicas = 1
+    selector {
+      match_labels = {
+        app = "mysql"
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          app = "mysql"
+        }
+      }
+      spec {
+        container {
+          name  = "mysql"
+          image = "mysql:8.0"
+          port {
+            container_port = 3306
+          }
+          env {
+            name  = "MYSQL_ROOT_PASSWORD"
+            value = "testpassword"
+          }
+          resources {
+            requests = {
+              cpu    = "100m"
+              memory = "256Mi"
+            }
+            limits = {
+              cpu    = "250m"
+              memory = "512Mi"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "mysql" {
+  depends_on = [kubernetes_deployment.mysql]
+
+  metadata {
+    name      = "mysql-service"
+    namespace = var.test_namespace
+  }
+  spec {
+    selector = {
+      app = "mysql"
+    }
+    port {
+      protocol    = "TCP"
+      port        = 3306
+      target_port = 3306
     }
   }
 }

--- a/terraform/node/eks/main.tf
+++ b/terraform/node/eks/main.tf
@@ -270,7 +270,7 @@ resource "kubernetes_deployment" "traffic_generator" {
 
 resource "kubernetes_deployment" "mysql" {
   metadata {
-    name      = "mysql-deployment"
+    name      = "sql-deployment"
     namespace = var.test_namespace
     labels = {
       app = "mysql"

--- a/terraform/node/eks/variables.tf
+++ b/terraform/node/eks/variables.tf
@@ -49,18 +49,6 @@ variable "sample_remote_app_image" {
   default = "<ECR_IMAGE_LINK>:<TAG>"
 }
 
-variable "rds_mysql_cluster_endpoint" {
-  default = "example.cluster-example.eu-west-1.rds.amazonaws.com"
-}
-
-variable "rds_mysql_cluster_username" {
-  default = "username"
-}
-
-variable "rds_mysql_cluster_password" {
-  default = "password"
-}
-
 variable "account_id" {
   default = "<AWS_ACCOUNT_ID>"
 }

--- a/terraform/python/eks/main.tf
+++ b/terraform/python/eks/main.tf
@@ -273,7 +273,7 @@ resource "kubernetes_deployment_v1" "traffic_generator" {
 
 resource "kubernetes_deployment" "mysql" {
   metadata {
-    name      = "mysql-deployment"
+    name      = "sql-deployment"
     namespace = var.test_namespace
     labels = {
       app = "mysql"

--- a/terraform/python/eks/main.tf
+++ b/terraform/python/eks/main.tf
@@ -121,19 +121,19 @@ resource "kubernetes_deployment_v1" "python_app_deployment" {
           }
           env {
             name  = "RDS_MYSQL_CLUSTER_ENDPOINT"
-            value = var.rds_mysql_cluster_endpoint
+            value = "mysql-service.${var.test_namespace}.svc.cluster.local"
           }
           env {
             name  = "RDS_MYSQL_CLUSTER_DATABASE"
-            value = var.rds_mysql_cluster_database
+            value = "information_schema"
           }
           env {
             name  = "RDS_MYSQL_CLUSTER_USERNAME"
-            value = var.rds_mysql_cluster_username
+            value = "root"
           }
           env {
             name  = "RDS_MYSQL_CLUSTER_PASSWORD"
-            value = var.rds_mysql_cluster_password
+            value = "testpassword"
           }
           port {
             container_port = 8000
@@ -267,6 +267,73 @@ resource "kubernetes_deployment_v1" "traffic_generator" {
           }
         }
       }
+    }
+  }
+}
+
+resource "kubernetes_deployment" "mysql" {
+  metadata {
+    name      = "mysql-deployment"
+    namespace = var.test_namespace
+    labels = {
+      app = "mysql"
+    }
+  }
+  spec {
+    replicas = 1
+    selector {
+      match_labels = {
+        app = "mysql"
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          app = "mysql"
+        }
+      }
+      spec {
+        container {
+          name  = "mysql"
+          image = "mysql:8.0"
+          port {
+            container_port = 3306
+          }
+          env {
+            name  = "MYSQL_ROOT_PASSWORD"
+            value = "testpassword"
+          }
+          resources {
+            requests = {
+              cpu    = "100m"
+              memory = "256Mi"
+            }
+            limits = {
+              cpu    = "250m"
+              memory = "512Mi"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "mysql" {
+  depends_on = [kubernetes_deployment.mysql]
+
+  metadata {
+    name      = "mysql-service"
+    namespace = var.test_namespace
+  }
+  spec {
+    selector = {
+      app = "mysql"
+    }
+    port {
+      protocol    = "TCP"
+      port        = 3306
+      target_port = 3306
     }
   }
 }

--- a/terraform/python/eks/variables.tf
+++ b/terraform/python/eks/variables.tf
@@ -49,22 +49,6 @@ variable "python_remote_app_image" {
   default = "<ECR_IMAGE_LINK>:<TAG>"
 }
 
-variable "rds_mysql_cluster_endpoint" {
-  default = "example.cluster-example.eu-west-1.rds.amazonaws.com"
-}
-
-variable "rds_mysql_cluster_database" {
-  default = "example_database"
-}
-
-variable "rds_mysql_cluster_username" {
-  default = "username"
-}
-
-variable "rds_mysql_cluster_password" {
-  default = "password"
-}
-
 variable "account_id" {
   default = "<AWS_ACCOUNT_ID>"
 }


### PR DESCRIPTION
*Issue description:*
Our EKS E2E tests currently rely on RDS instances with persistent credentials stored in SecretsManager. This has been flagged for security concerns + is costly to host the clusters.

*Description of changes:*
In this PR, the RDS cluster that the sample application connects to is replaced with a MySQL container. There are no changes to the validated telemetry attributes.

Tested in Python by running ADOT main build through a test branch, which uses the MySQL resource to validate the /mysql path and successfully generates all telemetry.

*Rollback procedure:*

This change can be safely reverted.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
