### PR TITLE
chore: move dotnet build before instrumentation env vars

### DIFF
--- a/sample-apps/dotnet/dotnet-ec2-win-main-setup.ps1
+++ b/sample-apps/dotnet/dotnet-ec2-win-main-setup.ps1
@@ -66,6 +66,9 @@ $current_dir = Get-Location
 Write-Host $current_dir
 
 Set-Location -Path "./asp_frontend_service"
+
+dotnet build | %{ "{0:HH:mm:ss:fff}: {1}" -f (Get-Date), $_ }
+
 $env:CORECLR_ENABLE_PROFILING = "1"
 $env:CORECLR_PROFILER = "{918728DD-259F-4A6A-AC2B-B85E1B658318}"
 $env:CORECLR_PROFILER_PATH = "$current_dir\dotnet-distro\win-x64\OpenTelemetry.AutoInstrumentation.Native.dll"
@@ -83,10 +86,6 @@ $env:OTEL_AWS_APPLICATION_SIGNALS_ENABLED = "true"
 $env:OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED = "false"
 $env:OTEL_TRACES_SAMPLER = "always_on"
 $env:ASPNETCORE_URLS = "http://0.0.0.0:8080"
-
-
-dotnet build | %{ "{0:HH:mm:ss:fff}: {1}" -f (Get-Date), $_ }
-
 
 Start-Process -FilePath "dotnet" -ArgumentList "bin/Debug/netcoreapp8.0/asp_frontend_service.dll"
 

--- a/sample-apps/dotnet/dotnet-ec2-win-remote-setup.ps1
+++ b/sample-apps/dotnet/dotnet-ec2-win-remote-setup.ps1
@@ -60,6 +60,9 @@ Write-Host $current_dir
 
 # Config Env variable for Windows EC2
 Set-Location -Path "./asp_remote_service"
+
+dotnet build | %{ "{0:HH:mm:ss:fff}: {1}" -f (Get-Date), $_ }
+
 $env:CORECLR_ENABLE_PROFILING = "1"
 $env:CORECLR_PROFILER = "{918728DD-259F-4A6A-AC2B-B85E1B658318}"
 $env:CORECLR_PROFILER_PATH = "$current_dir\dotnet-distro\win-x64\OpenTelemetry.AutoInstrumentation.Native.dll"
@@ -77,10 +80,6 @@ $env:OTEL_AWS_APPLICATION_SIGNALS_ENABLED = "true"
 $env:OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED = "false"
 $env:OTEL_TRACES_SAMPLER = "always_on"
 $env:ASPNETCORE_URLS = "http://0.0.0.0:8081"
-
-
-dotnet build | %{ "{0:HH:mm:ss:fff}: {1}" -f (Get-Date), $_ }
-
 
 Start-Process -FilePath "dotnet" -ArgumentList "bin/Debug/netcoreapp8.0/asp_remote_service.dll"
 

--- a/terraform/dotnet/ec2/asg/main.tf
+++ b/terraform/dotnet/ec2/asg/main.tf
@@ -132,8 +132,10 @@ resource "aws_launch_configuration" "launch_configuration" {
     # Get Absolute Path
     current_dir=$(pwd)
 
-    # Export environment variables for instrumentation
     cd ./asp_frontend_service
+    dotnet build
+
+    # Export environment variables for instrumentation
     export INSTALL_DIR=../dotnet-distro
     export CORECLR_ENABLE_PROFILING=1
     export CORECLR_PROFILER={918728DD-259F-4A6A-AC2B-B85E1B658318}
@@ -155,8 +157,7 @@ resource "aws_launch_configuration" "launch_configuration" {
     export OTEL_LOG_LEVEL=debug
     export OTEL_DOTNET_AUTO_LOG_DIRECTORY=/tmp
     export ASPNETCORE_URLS=http://0.0.0.0:8080
-    sudo -E dotnet build
-    sudo -E nohup dotnet bin/Debug/netcoreapp8.0/asp_frontend_service.dll &
+    nohup dotnet bin/Debug/netcoreapp8.0/asp_frontend_service.dll &
 
     # The application needs time to come up and reach a steady state, this should not take longer than 30 seconds
     sleep 30
@@ -249,8 +250,10 @@ resource "null_resource" "remote_service_setup" {
       current_dir=$(pwd)
       echo $current_dir
 
-      # Export environment variables for instrumentation
       cd ./asp_remote_service
+      dotnet build
+
+      # Export environment variables for instrumentation
       export CORECLR_ENABLE_PROFILING=1
       export CORECLR_PROFILER={918728DD-259F-4A6A-AC2B-B85E1B658318}
       export CORECLR_PROFILER_PATH=$current_dir/dotnet-distro/linux-x64/OpenTelemetry.AutoInstrumentation.Native.so
@@ -268,7 +271,6 @@ resource "null_resource" "remote_service_setup" {
       export OTEL_AWS_APPLICATION_SIGNALS_RUNTIME_ENABLED=false
       export OTEL_TRACES_SAMPLER=always_on
       export ASPNETCORE_URLS=http://0.0.0.0:8081
-      dotnet build
       nohup dotnet bin/Debug/netcoreapp8.0/asp_remote_service.dll &
 
       # The application needs time to come up and reach a steady state, this should not take longer than 30 seconds


### PR DESCRIPTION
*Issue description:*

*Description of changes:*
The dotnet-ec2-asg and dotnet-ec2-windows E2E tests fail when running against newer ADOT .NET distros that bundle System.Diagnostics.DiagnosticSource v10.0.0.

The fix moves dotnet build before the instrumentation exports so the build runs in a clean environment. The env vars are only needed at runtime when launching the application DLL, not during compilation.

The default and adot-sigv4 EC2 terraform configs already had the correct ordering; this aligns the asg and windows configs to match.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
