### PR TITLE
fix: update OCB outgoing-http-call trace to expect GET / for aws.local.operation

### DIFF
--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/outgoing-http-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/outgoing-http-call-trace.mustache
@@ -32,7 +32,7 @@
           },
           "annotations": {
             "aws.local.service": "^{{serviceName}}$",
-            "aws.local.operation": "^UnmappedOperation$",
+            "aws.local.operation": "^GET /$",
             "aws.remote.service": "^www.amazon.com$",
             "aws.remote.operation": "^GET /$",
             "aws.local.environment": "^eks:(default|{{platformInfo}}/{{appNamespace}})$"


### PR DESCRIPTION
## Summary
- Update `java/eks-otlp-ocb/outgoing-http-call-trace.mustache` to expect `GET /` instead of `UnmappedOperation` for the client span's `aws.local.operation` annotation
- The Java instrumentation behavior has changed — the outgoing HTTP client span to `www.amazon.com` now produces `GET /` instead of `UnmappedOperation`
- This fix addresses consistent canary test failures confirmed across 4 CI runs:
  - https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/27173955795
  - https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/27222713347
  - https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/27217752249
  - https://github.com/aws-observability/aws-application-signals-test-framework/actions/runs/27225146528