### PR TITLE
Revert "fix: update OCB outgoing-http-call trace to expect GET / for aws.local.operation (#637)"

### DIFF
--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/outgoing-http-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/outgoing-http-call-trace.mustache
@@ -32,7 +32,7 @@
           },
           "annotations": {
             "aws.local.service": "^{{serviceName}}$",
-            "aws.local.operation": "^GET /$",
+            "aws.local.operation": "^UnmappedOperation$",
             "aws.remote.service": "^www.amazon.com$",
             "aws.remote.operation": "^GET /$",
             "aws.local.environment": "^eks:(default|{{platformInfo}}/{{appNamespace}})$"


### PR DESCRIPTION
## Summary
Reverts #637.

The original failure was caused by an X-Ray gamma service-side change, not a real behavior change in the SDK or collector. The expected value should remain `UnmappedOperation` per the design (SDK has Application Signals disabled in this OCB test, so `aws.local.operation` for client spans should be `UnmappedOperation`).

The X-Ray service issue should be fixed at the service level rather than masked here.