### PR TITLE
fix(ci): point python-eks-test main-build ref to main

### DIFF
--- a/.github/workflows/python-eks-test.yml
+++ b/.github/workflows/python-eks-test.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: 'aws-observability/aws-application-signals-test-framework'
-          ref: ${{ inputs.caller-workflow-name == 'main-build' && 'rds-migration' || github.ref }}
+          ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
           fetch-depth: 0
 
         # We initialize Gradlew Daemon early on during the workflow because sometimes initialization


### PR DESCRIPTION
## Summary

- Fix `.github/workflows/python-eks-test.yml:75` — checkout was pinned to the temporary `rds-migration` branch, which has been deleted.
- Restores the convention used by every other `python-*-test.yml` workflow (`main-build` → ref `main`).

## Context

PR #634 (merged 2026-06-03) flipped this single line from `'main'` → `'rds-migration'` — looks like leftover test scaffolding that was never reverted before merge.

Since the branch was later deleted, every push-triggered run of the [aws-otel-python-instrumentation main-build](https://github.com/aws-observability/aws-otel-python-instrumentation/actions/workflows/main-build.yml) since 2026-06-10 has failed all 5 EKS shards (py310/311/312/313/314) at the checkout step:

```
##[error]A branch or tag with the name 'rds-migration' could not be found
```

Non-EKS jobs (build, EC2, ECS, K8s, Lambda) are unaffected.

## Test plan

- [ ] CI on this PR passes
- [ ] Next push to `aws-otel-python-instrumentation` main → confirm EKS jobs reach the actual deploy/validate steps instead of failing on checkout