### PR TITLE
fix: correct metric_resource_keys typo in EC2 default Java test

### DIFF
--- a/terraform/java/ec2/default/main.tf
+++ b/terraform/java/ec2/default/main.tf
@@ -145,7 +145,7 @@ resource "null_resource" "main_service_setup" {
       OTEL_AWS_APPLICATION_SIGNALS_EXPORTER_ENDPOINT=http://localhost:4316/v1/metrics \
       OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
       OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4316/v1/traces \
-      OTEL_RESOURCE_ATTRIBUTES="service.name=sample-application-${var.test_id},Internal_Org=Financial,Business Unit=Payments,Region=us-east-1,aws.application_signals.metric_resource_keys=Business Unit&Region&Organization" \
+      OTEL_RESOURCE_ATTRIBUTES="service.name=sample-application-${var.test_id},Internal_Org=Financial,Business Unit=Payments,Region=us-east-1,aws.application_signals.metric_resource_keys=Business Unit&Region&Internal_Org" \
       OTEL_INSTRUMENTATION_COMMON_EXPERIMENTAL_CONTROLLER_TELEMETRY_ENABLED=true \
       nohup java -XX:+UseG1GC -jar main-service.jar &> nohup.out &
 


### PR DESCRIPTION
## Summary
Two related fixes that together unblock the `Application Signals E2E Test / default-v?-amd64 / java-ec2-default` validations on the Java instrumentation `main-build`.

### 1. terraform — fix `metric_resource_keys` typo
The EC2-default Java sample app sets `Internal_Org=Financial` in `OTEL_RESOURCE_ATTRIBUTES`, but `aws.application_signals.metric_resource_keys` referenced `Organization`, which is not a defined attribute. Application Signals processor silently drops EMF logs and metrics for resources whose `metric_resource_keys` references a non-existent attribute, while traces (which do not consume `metric_resource_keys`) keep flowing — explaining the original symptom of `Validate generated EMF logs`/`Validate generated metrics` retries exhausting on empty results while traces succeeded.

Change `Organization` → `Internal_Org` in [terraform/java/ec2/default/main.tf](terraform/java/ec2/default/main.tf).

### 2. validator templates — align trace templates with the corrected attr
Four trace mustache templates also hard-coded the `Organization` typo. After terraform is fixed, traces now carry `Internal_Org`, so the trace validator starts reporting `Data model validation failed: Mismatched data for key: otel.resource.aws.application_signals.metric_resource_keys`. Updating the four templates restores trace validation:

- [aws-sdk-call-trace.mustache](validator/src/main/resources/expected-data-template/java/ec2/default/aws-sdk-call-trace.mustache)
- [client-call-trace.mustache](validator/src/main/resources/expected-data-template/java/ec2/default/client-call-trace.mustache)
- [outgoing-http-call-trace.mustache](validator/src/main/resources/expected-data-template/java/ec2/default/outgoing-http-call-trace.mustache)
- [remote-service-trace.mustache](validator/src/main/resources/expected-data-template/java/ec2/default/remote-service-trace.mustache)

### Reference failures (against current `main`)
- https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/27638414372/job/81750035249 (initial `Organization` typo, EMF logs/metrics empty)
- https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/27649590816 (after fixing terraform without templates: EMF/metrics pass on v11/v17/v21/arm64; traces fail with the mismatch addressed by the second commit)

### Out of scope
- `default-v8-amd64` and `default-v25-amd64` are still failing with EMF logs entirely empty even with this fix applied. The 2026-06-03 main-build (`e2e859b`) shows v8/v25 producing EMF normally; the regression appears to start with [aws-observability/aws-otel-java-instrumentation#1386 feat(serviceevents)](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1386) added on 2026-06-11, which auto-registers a new instrumentation module via SPI and may break agent autoconfiguration on Java 8 and Java 25. To be tracked separately on the java-instrumentation repo.

## Test plan
- [ ] Re-run `Application Signals E2E Test / default-v11-amd64 / java-ec2-default` and confirm Validate EMF logs / metrics / traces all pass.
- [ ] Re-run `default-v17-amd64`, `default-v21-amd64`, `default-v11-arm64` and confirm trace validation now passes too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)