### PR TITLE
fix: align EC2 default trace templates with corrected metric_resource_keys

### DIFF
--- a/validator/src/main/resources/expected-data-template/java/ec2/default/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/java/ec2/default/aws-sdk-call-trace.mustache
@@ -24,7 +24,7 @@
       "otel.resource.Internal_Org": "Financial",
       "otel.resource.Business Unit": "Payments",
       "otel.resource.Region": "us-east-1",
-      "otel.resource.aws.application_signals.metric_resource_keys": "Business Unit&Region&Organization",
+      "otel.resource.aws.application_signals.metric_resource_keys": "Business Unit&Region&Internal_Org",
       "otel.resource.host.image.id": "^{{instanceAmi}}$",
       "otel.resource.host.type": "^([a-z0-9]+\\.[a-z0-9]+)$",
       "aws.span.kind": "^LOCAL_ROOT$"

--- a/validator/src/main/resources/expected-data-template/java/ec2/default/client-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/java/ec2/default/client-call-trace.mustache
@@ -10,7 +10,7 @@
       "otel.resource.Internal_Org": "Financial",
       "otel.resource.Business Unit": "Payments",
       "otel.resource.Region": "us-east-1",
-      "otel.resource.aws.application_signals.metric_resource_keys": "Business Unit&Region&Organization",
+      "otel.resource.aws.application_signals.metric_resource_keys": "Business Unit&Region&Internal_Org",
       "otel.resource.host.image.id": "^{{instanceAmi}}$",
       "otel.resource.host.type": "^([a-z0-9]+\\.[a-z0-9]+)$"
     }

--- a/validator/src/main/resources/expected-data-template/java/ec2/default/outgoing-http-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/java/ec2/default/outgoing-http-call-trace.mustache
@@ -24,7 +24,7 @@
       "otel.resource.Internal_Org": "Financial",
       "otel.resource.Business Unit": "Payments",
       "otel.resource.Region": "us-east-1",
-      "otel.resource.aws.application_signals.metric_resource_keys": "Business Unit&Region&Organization",
+      "otel.resource.aws.application_signals.metric_resource_keys": "Business Unit&Region&Internal_Org",
       "otel.resource.host.image.id": "^{{instanceAmi}}$",
       "otel.resource.host.type": "^([a-z0-9]+\\.[a-z0-9]+)$",
       "aws.span.kind": "^LOCAL_ROOT$"

--- a/validator/src/main/resources/expected-data-template/java/ec2/default/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/java/ec2/default/remote-service-trace.mustache
@@ -24,7 +24,7 @@
       "otel.resource.Internal_Org": "Financial",
       "otel.resource.Business Unit": "Payments",
       "otel.resource.Region": "us-east-1",
-      "otel.resource.aws.application_signals.metric_resource_keys": "Business Unit&Region&Organization",
+      "otel.resource.aws.application_signals.metric_resource_keys": "Business Unit&Region&Internal_Org",
       "otel.resource.host.image.id": "^{{instanceAmi}}$",
       "otel.resource.host.type": "^([a-z0-9]+\\.[a-z0-9]+)$",
       "aws.span.kind": "^LOCAL_ROOT$"


### PR DESCRIPTION
## Summary
Follow-up to #641, which corrected the `metric_resource_keys` typo in `terraform/java/ec2/default/main.tf` (`Organization` → `Internal_Org`). After that change, `Validate generated EMF logs` and `Validate generated metrics` started passing on `default-v11/v17/v21/arm64`, but `Validate generated traces` started failing with:

```
ERROR Data model validation failed
Mismatched data for key: [0].metadata.default["otel.resource.aws.application_signals.metric_resource_keys"]
Value of stored trace map: Business Unit&Region&Organization      ← the four trace templates (still old typo)
Value of retrieved map:    Business Unit&Region&Internal_Org      ← actual trace value (now correct)
```

The four EC2-default Java trace templates also hard-coded the typo. This PR aligns them with the corrected value:
- [aws-sdk-call-trace.mustache](validator/src/main/resources/expected-data-template/java/ec2/default/aws-sdk-call-trace.mustache)
- [client-call-trace.mustache](validator/src/main/resources/expected-data-template/java/ec2/default/client-call-trace.mustache)
- [outgoing-http-call-trace.mustache](validator/src/main/resources/expected-data-template/java/ec2/default/outgoing-http-call-trace.mustache)
- [remote-service-trace.mustache](validator/src/main/resources/expected-data-template/java/ec2/default/remote-service-trace.mustache)

### Reference failure
- https://github.com/aws-observability/aws-otel-java-instrumentation/actions/runs/27649590816/job/81775857261 — `default-v11-amd64 / java-ec2-default` `Validate generated traces` step.

### Out of scope
`default-v8-amd64` and `default-v25-amd64` are still failing with EMF logs entirely empty (independent regression first appearing on the java-instrumentation `main-build` after [aws-observability/aws-otel-java-instrumentation#1386 feat(serviceevents)](https://github.com/aws-observability/aws-otel-java-instrumentation/pull/1386), 2026-06-11). To be tracked separately on the java-instrumentation repo.

## Test plan
- [ ] Re-run `Application Signals E2E Test / default-v11-amd64 / java-ec2-default` and confirm `Validate generated traces` passes.
- [ ] Confirm `default-v17-amd64`, `default-v21-amd64`, `default-v11-arm64` trace validations also pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)