### PR TITLE
Drop Python 3.8/3.9 from the Python test framework (OTel floor is now 3.10)

### DIFF
--- a/.github/workflows/python-ec2-adaptive-sampling-test.yml
+++ b/.github/workflows/python-ec2-adaptive-sampling-test.yml
@@ -77,12 +77,12 @@ jobs:
         run: |
           if [ "${{ env.REPOSITORY_NAME }}" = "aws-otel-python-instrumentation" ]; then
             # Reusing the adot-main-build-staging-jar bucket to store the python wheel file
-            echo GET_ADOT_WHEEL_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && sudo python3.9 -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> "$GITHUB_ENV"
+            echo GET_ADOT_WHEEL_COMMAND="aws s3 cp s3://adot-main-build-staging-jar/${{ env.ADOT_WHEEL_NAME }} ./${{ env.ADOT_WHEEL_NAME }} && sudo python3.10 -m pip install ${{ env.ADOT_WHEEL_NAME }}" >> "$GITHUB_ENV"
           else
             latest_release_version=$(curl -sL https://github.com/aws-observability/aws-otel-python-instrumentation/releases/latest | grep -oP '/releases/tag/v\K[0-9]+\.[0-9]+\.[0-9]+' | head -n 1)
             echo "The latest version is $latest_release_version"
             echo GET_ADOT_WHEEL_COMMAND="wget -O aws-opentelemetry-distro https://github.com/aws-observability/aws-otel-python-instrumentation/releases/latest/download/aws_opentelemetry_distro-$latest_release_version-py3-none-any.whl \
-            && sudo python3.9 -m pip install aws-opentelemetry-distro" >> "$GITHUB_ENV"
+            && sudo python3.10 -m pip install aws-opentelemetry-distro" >> "$GITHUB_ENV"
           fi
 
       - name: Set Get CW Agent command environment variable

--- a/.github/workflows/python-ec2-adot-sigv4-test.yml
+++ b/.github/workflows/python-ec2-adot-sigv4-test.yml
@@ -12,10 +12,10 @@ on:
         required: true
         type: string
       python-version:
-        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12, 3.13"
+        description: "Currently support version 3.10, 3.11, 3.12, 3.13, 3.14"
         required: false
         type: string
-        default: '3.9'
+        default: '3.10'
       cpu-architecture:
         description: "Permitted values: x86_64 or arm64"
         required: false

--- a/.github/workflows/python-ec2-asg-test.yml
+++ b/.github/workflows/python-ec2-asg-test.yml
@@ -15,10 +15,10 @@ on:
         required: true
         type: string
       python-version:
-        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12, 3.13"
+        description: "Currently support version 3.10, 3.11, 3.12, 3.13, 3.14"
         required: false
         type: string
-        default: '3.9'
+        default: '3.10'
       cpu-architecture:
         description: "Permitted values: x86_64 or arm64"
         required: false

--- a/.github/workflows/python-ec2-default-test.yml
+++ b/.github/workflows/python-ec2-default-test.yml
@@ -15,10 +15,10 @@ on:
         required: true
         type: string
       python-version:
-        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12, 3.13"
+        description: "Currently support version 3.10, 3.11, 3.12, 3.13, 3.14"
         required: false
         type: string
-        default: '3.9'
+        default: '3.10'
       cpu-architecture:
         description: "Permitted values: x86_64 or arm64"
         required: false

--- a/.github/workflows/python-ecs-test.yml
+++ b/.github/workflows/python-ecs-test.yml
@@ -15,7 +15,7 @@ on:
         required: true
         type: string
       python-version:
-        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12, 3.13"
+        description: "Currently support version 3.10, 3.11, 3.12, 3.13, 3.14"
         required: false
         type: string
         default: '3.10'

--- a/.github/workflows/python-eks-test.yml
+++ b/.github/workflows/python-eks-test.yml
@@ -18,7 +18,7 @@ on:
         required: true
         type: string
       python-version:
-        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14"
+        description: "Currently support version 3.10, 3.11, 3.12, 3.13, 3.14"
         required: false
         type: string
         default: '3.10'

--- a/.github/workflows/python-k8s-test.yml
+++ b/.github/workflows/python-k8s-test.yml
@@ -18,7 +18,7 @@ on:
         required: false
         type: string
       python-version:
-        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12, 3.13"
+        description: "Currently support version 3.10, 3.11, 3.12, 3.13, 3.14"
         required: false
         type: string
         default: '3.10'

--- a/.github/workflows/python-lambda-test.yml
+++ b/.github/workflows/python-lambda-test.yml
@@ -15,10 +15,10 @@ on:
         required: true
         type: string
       python-version:
-        description: "Currently support version 3.8, 3.9, 3.10, 3.11, 3.12, 3.13"
+        description: "Currently support version 3.10, 3.11, 3.12, 3.13, 3.14"
         required: false
         type: string
-        default: '3.9'
+        default: '3.10'
       cpu-architecture:
         description: "Permitted values: x86_64 or arm64"
         required: false

--- a/.github/workflows/python-sample-app-ecr-deploy.yml
+++ b/.github/workflows/python-sample-app-ecr-deploy.yml
@@ -3,7 +3,7 @@
 
 # This workflow is for building and uploading the Python sample application to ECR.
 # Python 3.10 will be built and uploaded to all regions to be used by the canary while
-# other versions (3.8, 3.9, 3.11, 3.12, 3.13, 3.14) will be uploaded to us-east-1 for the purpose of
+# other versions (3.11, 3.12, 3.13, 3.14) will be uploaded to us-east-1 for the purpose of
 # testing ADOT Python
 name: Sample App Deployment - Python ECR
 on:
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.9', '3.11', '3.12', '3.13', '3.14' ]
+        python-version: [ '3.11', '3.12', '3.13', '3.14' ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/terraform/python/ec2/adaptive-sampling/variables.tf
+++ b/terraform/python/ec2/adaptive-sampling/variables.tf
@@ -38,7 +38,7 @@ variable "get_adot_wheel_command" {
 }
 
 variable "language_version" {
-  default = "3.9"
+  default = "3.10"
 }
 
 variable "cpu_architecture" {

--- a/terraform/python/ec2/adot-sigv4/main.tf
+++ b/terraform/python/ec2/adot-sigv4/main.tf
@@ -117,10 +117,10 @@ resource "null_resource" "main_service_setup" {
       sudo yum install wget -y
       sudo yum install unzip -y
 
-      # Dnf does not have the module for python 3.8, 3.10, 3.12, 3.13, therefore we need to manually install it by downloading the package from the python website.
+      # Dnf does not have the module for python 3.10, 3.12, 3.13, therefore we need to manually install it by downloading the package from the python website.
       # Building and installing the package takes longer then installing it through dnf, so a seperate installation process was made.
       # The canary should run on a version without the manual installation process
-      if [ "${var.language_version}" == "3.8" ] || [ "${var.language_version}" = "3.10" ] || [ "${var.language_version}" = "3.12" ] || [ "${var.language_version}" = "3.13" ]; then
+      if [ "${var.language_version}" = "3.10" ] || [ "${var.language_version}" = "3.12" ] || [ "${var.language_version}" = "3.13" ]; then
           # Install modules required to compile Python and also run the sample app
           sudo dnf groupinstall "Development Tools" -y
           sudo dnf install openssl-devel sqlite-devel libffi-devel -y
@@ -145,7 +145,7 @@ resource "null_resource" "main_service_setup" {
       # enable ec2 instance connect for debug
       sudo yum install ec2-instance-connect -y
 
-      # Install modules with specific version so that it doesn't cause errors with Python 3.8
+      # Install modules with specific version so that it doesn't cause errors
       sudo python${var.language_version} -m pip install importlib-metadata==8.4.0 "protobuf>=3.19,<5.0"
       sudo python${var.language_version} -m pip install grpcio --only-binary=:all:
 
@@ -242,10 +242,10 @@ resource "null_resource" "remote_service_setup" {
       sudo yum install wget -y
       sudo yum install unzip -y
 
-      # Dnf does not have the module for python 3.10, 3,10, 3.12, therefore we need to manually install it by downloading the package from the python website.
+      # Dnf does not have the module for python 3.10, 3.12, therefore we need to manually install it by downloading the package from the python website.
       # Building and installing the package takes longer then installing it through dnf, so a seperate installation process was made.
       # The canary should run on a version without the manual installation process
-      if [ "${var.language_version}" == "3.8" ] || [ "${var.language_version}" = "3.10" ] || [ "${var.language_version}" = "3.12" ]; then
+      if [ "${var.language_version}" = "3.10" ] || [ "${var.language_version}" = "3.12" ]; then
           # Install modules required to compile Python and also run the sample app
           sudo dnf groupinstall "Development Tools" -y
           sudo dnf install openssl-devel sqlite-devel libffi-devel -y
@@ -270,7 +270,7 @@ resource "null_resource" "remote_service_setup" {
       # enable ec2 instance connect for debug
       sudo yum install ec2-instance-connect -y
 
-      # Install modules with specific version so that it doesn't cause errors with Python 3.8
+      # Install modules with specific version so that it doesn't cause errors
       sudo python${var.language_version} -m pip install importlib-metadata==8.4.0 "protobuf>=3.19,<5.0"
       sudo python${var.language_version} -m pip install grpcio --only-binary=:all:
 

--- a/terraform/python/ec2/adot-sigv4/variables.tf
+++ b/terraform/python/ec2/adot-sigv4/variables.tf
@@ -38,7 +38,7 @@ variable "canary_type" {
 }
 
 variable "language_version" {
-  default = "3.9"
+  default = "3.10"
 }
 
 variable "cpu_architecture" {

--- a/terraform/python/ec2/asg/main.tf
+++ b/terraform/python/ec2/asg/main.tf
@@ -108,10 +108,10 @@ resource "aws_launch_configuration" "launch_configuration" {
     sudo yum install wget -y
     sudo yum install unzip -y
 
-    # Dnf does not have the module for python 3.8, 3.10, 3.12, 3.13, therefore we need to manually install it by downloading the package from the python website.
+    # Dnf does not have the module for python 3.10, 3.12, 3.13, therefore we need to manually install it by downloading the package from the python website.
     # Building and installing the package takes longer then installing it through dnf, so a seperate installation process was made.
     # The canary should run on a version without the manual installation process
-    if [ "${var.language_version}" == "3.8" ] || [ "${var.language_version}" = "3.10" ] || [ "${var.language_version}" = "3.12" ] || [ "${var.language_version}" = "3.13" ]; then
+    if [ "${var.language_version}" = "3.10" ] || [ "${var.language_version}" = "3.12" ] || [ "${var.language_version}" = "3.13" ]; then
         # Install modules required to compile Python and also run the sample app
         sudo dnf groupinstall "Development Tools" -y
         sudo dnf install openssl-devel sqlite-devel libffi-devel -y
@@ -142,7 +142,7 @@ resource "aws_launch_configuration" "launch_configuration" {
     sudo rpm -U ./cw-agent.rpm
     sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:./amazon-cloudwatch-agent.json
 
-    # Install modules with specific version so that it doesn't cause errors with Python 3.8
+    # Install modules with specific version so that it doesn't cause errors
     sudo python${var.language_version} -m pip install importlib-metadata==8.4.0 "protobuf>=3.19,<5.0"
     sudo python${var.language_version} -m pip install grpcio --only-binary=:all:
 
@@ -246,10 +246,10 @@ resource "null_resource" "remote_service_setup" {
       sudo yum install wget -y
       sudo yum install unzip -y
 
-      # Dnf does not have the module for python 3.10, 3,10, 3.12, therefore we need to manually install it by downloading the package from the python website.
+      # Dnf does not have the module for python 3.10, 3.12, therefore we need to manually install it by downloading the package from the python website.
       # Building and installing the package takes longer then installing it through dnf, so a seperate installation process was made.
       # The canary should run on a version without the manual installation process
-      if [ "${var.language_version}" == "3.8" ] || [ "${var.language_version}" = "3.10" ] || [ "${var.language_version}" = "3.12" ]; then
+      if [ "${var.language_version}" = "3.10" ] || [ "${var.language_version}" = "3.12" ]; then
           # Install modules required to compile Python and also run the sample app
           sudo dnf groupinstall "Development Tools" -y
           sudo dnf install openssl-devel sqlite-devel libffi-devel -y
@@ -280,7 +280,7 @@ resource "null_resource" "remote_service_setup" {
       sudo rpm -U ./cw-agent.rpm
       sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:./amazon-cloudwatch-agent.json
 
-      # Install modules with specific version so that it doesn't cause errors with Python 3.8
+      # Install modules with specific version so that it doesn't cause errors
       sudo python${var.language_version} -m pip install importlib-metadata==8.4.0 "protobuf>=3.19,<5.0"
       sudo python${var.language_version} -m pip install grpcio --only-binary=:all:
 

--- a/terraform/python/ec2/asg/variables.tf
+++ b/terraform/python/ec2/asg/variables.tf
@@ -42,7 +42,7 @@ variable "canary_type" {
 }
 
 variable "language_version" {
-  default = "3.9"
+  default = "3.10"
 }
 
 variable "cpu_architecture" {

--- a/terraform/python/ec2/default/main.tf
+++ b/terraform/python/ec2/default/main.tf
@@ -117,10 +117,10 @@ resource "null_resource" "main_service_setup" {
       sudo yum install wget -y
       sudo yum install unzip -y
 
-      # Dnf does not have the module for python 3.8, 3.10, 3.12, 3.13, therefore we need to manually install it by downloading the package from the python website.
+      # Dnf does not have the module for python 3.10, 3.12, 3.13, therefore we need to manually install it by downloading the package from the python website.
       # Building and installing the package takes longer then installing it through dnf, so a seperate installation process was made.
       # The canary should run on a version without the manual installation process
-      if [ "${var.language_version}" == "3.8" ] || [ "${var.language_version}" = "3.10" ] || [ "${var.language_version}" = "3.12" ] || [ "${var.language_version}" = "3.13" ]; then
+      if [ "${var.language_version}" = "3.10" ] || [ "${var.language_version}" = "3.12" ] || [ "${var.language_version}" = "3.13" ]; then
           # Install modules required to compile Python and also run the sample app
           sudo dnf groupinstall "Development Tools" -y
           sudo dnf install openssl-devel sqlite-devel libffi-devel -y
@@ -154,7 +154,7 @@ resource "null_resource" "main_service_setup" {
       sudo rpm -U ./cw-agent.rpm
       sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:./amazon-cloudwatch-agent.json
 
-      # Install modules with specific version so that it doesn't cause errors with Python 3.8
+      # Install modules with specific version so that it doesn't cause errors
       sudo python${var.language_version} -m pip install importlib-metadata==8.4.0 "protobuf>=3.19,<5.0"
       sudo python${var.language_version} -m pip install grpcio --only-binary=:all:
 
@@ -253,10 +253,10 @@ resource "null_resource" "remote_service_setup" {
       sudo yum install wget -y
       sudo yum install unzip -y
 
-      # Dnf does not have the module for python 3.10, 3,10, 3.12, therefore we need to manually install it by downloading the package from the python website.
+      # Dnf does not have the module for python 3.10, 3.12, 3.13, therefore we need to manually install it by downloading the package from the python website.
       # Building and installing the package takes longer then installing it through dnf, so a seperate installation process was made.
       # The canary should run on a version without the manual installation process
-      if [ "${var.language_version}" == "3.8" ] || [ "${var.language_version}" = "3.10" ] || [ "${var.language_version}" = "3.12" ] || [ "${var.language_version}" = "3.13" ]; then
+      if [ "${var.language_version}" = "3.10" ] || [ "${var.language_version}" = "3.12" ] || [ "${var.language_version}" = "3.13" ]; then
           # Install modules required to compile Python and also run the sample app
           sudo dnf groupinstall "Development Tools" -y
           sudo dnf install openssl-devel sqlite-devel libffi-devel -y
@@ -290,7 +290,7 @@ resource "null_resource" "remote_service_setup" {
       sudo rpm -U ./cw-agent.rpm
       sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:./amazon-cloudwatch-agent.json
 
-      # Install modules with specific version so that it doesn't cause errors with Python 3.8
+      # Install modules with specific version so that it doesn't cause errors
       sudo python${var.language_version} -m pip install importlib-metadata==8.4.0 "protobuf>=3.19,<5.0"
       sudo python${var.language_version} -m pip install grpcio --only-binary=:all:
 

--- a/terraform/python/ec2/default/variables.tf
+++ b/terraform/python/ec2/default/variables.tf
@@ -42,7 +42,7 @@ variable "canary_type" {
 }
 
 variable "language_version" {
-  default = "3.9"
+  default = "3.10"
 }
 
 variable "cpu_architecture" {


### PR DESCRIPTION
## Why

The nightly OpenTelemetry dependency bump in `aws-otel-python-instrumentation` ([PR #762](https://github.com/aws-observability/aws-otel-python-instrumentation/pull/762), OTel `1.42.1` / `0.63b1`) raised the ADOT distro's minimum to **Python ≥ 3.10**:

- `opentelemetry-api`: `1.41.1` was `requires_python >=3.9` → `1.42.1` is **`>=3.10`**
- `opentelemetry-instrumentation-*`: `0.62b1` was `>=3.9` → `0.63b1` is **`>=3.10`**

The `python-ec2-adot-sigv4` and `python-ec2-adaptive-sampling` E2E jobs default to **Python 3.9**, so after the bump pip on the EC2 host could no longer resolve the pinned distro:

```
ERROR: Could not find a version that satisfies the requirement opentelemetry-api==1.42.1 ...
ERROR: No matching distribution found for opentelemetry-instrumentation-celery==0.63b1
nohup: failed to run command 'opentelemetry-instrument': No such file or directory
```

This turned the **Python Instrumentation Main Build** red on every run starting 2026-06-17 01:26 UTC (first failure = the dep-bump commit; the run immediately before it was green). The `default` EC2 matrix (3.10–3.14) and container/layer-based jobs were unaffected because they don't pip-install the pinned distro on a 3.9 interpreter.

> Note: the `k8s-py310-amd64` job also fails intermittently, but that is a **separate, pre-existing** CloudWatch observability controller-manager pod-readiness timeout — unrelated to this change.

## What

Removes **all** Python 3.8/3.9 references from the Python test framework and floors everything at 3.10:

- **Reusable workflows** — `python-version` default `3.9` → `3.10` (`default`, `asg`, `lambda`, `adot-sigv4`); normalized "currently supported" description strings to `3.10, 3.11, 3.12, 3.13, 3.14` across all Python workflows.
- **adaptive-sampling** — hardcoded `python3.9` install command → `python3.10`.
- **Terraform** — `language_version` default `3.9` → `3.10` (`default`, `asg`, `adot-sigv4`, `adaptive-sampling`).
- **EC2 user-data scripts** — dropped the now-dead `== "3.8"` conditional branches and 3.8 comment references; fixed a pre-existing `3,10` comment typo.
- **ECR sample-app deploy** — removed `3.8` and `3.9` from the build matrix.

## Testing

- All 9 modified workflow YAML files validated as well-formed.
- `terraform fmt -check` passes on all four modified EC2 dirs (no diff).
- Repo-wide grep confirms no remaining `3.8`/`3.9`/`python3.8`/`python3.9` references in the Python framework.