### PR TITLE
fix(adaptive-sampling): build Python from source when dnf lacks the version

### DIFF
--- a/terraform/python/ec2/adaptive-sampling/main.tf
+++ b/terraform/python/ec2/adaptive-sampling/main.tf
@@ -120,9 +120,30 @@ resource "null_resource" "main_service_setup" {
       sudo yum install wget -y
       sudo yum install unzip -y
 
-      # Install Python
-      sudo dnf install -y python${var.language_version}
-      sudo dnf install -y python${var.language_version}-pip
+      # Dnf does not have the module for python 3.10, 3.12, 3.13, therefore we need to manually install it by downloading the package from the python website.
+      # Building and installing the package takes longer then installing it through dnf, so a seperate installation process was made.
+      # The canary should run on a version without the manual installation process
+      if [ "${var.language_version}" = "3.10" ] || [ "${var.language_version}" = "3.12" ] || [ "${var.language_version}" = "3.13" ]; then
+          # Install modules required to compile Python and also run the sample app
+          sudo dnf groupinstall "Development Tools" -y
+          sudo dnf install openssl-devel sqlite-devel libffi-devel -y
+
+          # Download the Python package
+          cd /usr/src
+          sudo wget https://www.python.org/ftp/python/${var.language_version}.0/Python-${var.language_version}.0.tgz
+          sudo tar xzf Python-${var.language_version}.0.tgz
+
+          # Compile and install Python using c++
+          cd Python-${var.language_version}.0
+          sudo ./configure
+          sudo make install
+
+          # Return back to ec2-user directory
+          cd ~
+      else
+        sudo dnf install -y python${var.language_version}
+        sudo dnf install -y python${var.language_version}-pip
+      fi
 
       # enable ec2 instance connect for debug
       sudo yum install ec2-instance-connect -y
@@ -233,9 +254,30 @@ resource "null_resource" "remote_service_setup" {
       sudo yum install wget -y
       sudo yum install unzip -y
 
-      # Install Python
-      sudo dnf install -y python${var.language_version}
-      sudo dnf install -y python${var.language_version}-pip
+      # Dnf does not have the module for python 3.10, 3.12, 3.13, therefore we need to manually install it by downloading the package from the python website.
+      # Building and installing the package takes longer then installing it through dnf, so a seperate installation process was made.
+      # The canary should run on a version without the manual installation process
+      if [ "${var.language_version}" = "3.10" ] || [ "${var.language_version}" = "3.12" ] || [ "${var.language_version}" = "3.13" ]; then
+          # Install modules required to compile Python and also run the sample app
+          sudo dnf groupinstall "Development Tools" -y
+          sudo dnf install openssl-devel sqlite-devel libffi-devel -y
+
+          # Download the Python package
+          cd /usr/src
+          sudo wget https://www.python.org/ftp/python/${var.language_version}.0/Python-${var.language_version}.0.tgz
+          sudo tar xzf Python-${var.language_version}.0.tgz
+
+          # Compile and install Python using c++
+          cd Python-${var.language_version}.0
+          sudo ./configure
+          sudo make install
+
+          # Return back to ec2-user directory
+          cd ~
+      else
+        sudo dnf install -y python${var.language_version}
+        sudo dnf install -y python${var.language_version}-pip
+      fi
 
       # enable ec2 instance connect for debug
       sudo yum install ec2-instance-connect -y


### PR DESCRIPTION
## Why

Follow-up to #643. After flooring the `python-ec2-adaptive-sampling` test at Python 3.10, the EC2 deploy failed at a **different** step:

```
+ sudo dnf install -y python3.10
No match for argument: python3.10
Error: Unable to find a match: python3.10
...
Max retry reached, failed to deploy terraform and connect to the endpoint. Exiting code
```

Amazon Linux's dnf repos don't carry `python3.10` (they had `python3.9`, which is why the test passed before the OTel ≥3.10 bump). The `default`, `adot-sigv4`, and `asg` EC2 configs already handle this by **compiling Python from source** for versions dnf lacks (3.10 / 3.12 / 3.13), falling back to `dnf` otherwise. `adaptive-sampling` was the only Python EC2 config still doing a plain `dnf install`, so it kept failing after the bump.

Verified against the main build run after #643 merged: `adot-sigv4` and `k8s-py310` now pass; `adaptive-sampling` is the lone remaining failure with the `dnf` error above.

## What

Replicate the existing conditional source-build-with-dnf-fallback (byte-for-byte identical to the already-passing `default` config) in both `null_resource.main_service_setup` and `null_resource.remote_service_setup` user-data scripts. `cd ~` at the end returns to the home dir so the subsequent `aws s3 cp` / `unzip` / app-launch flow is unchanged.

## Testing

- `terraform fmt -check` passes on `terraform/python/ec2/adaptive-sampling` (no diff).
- Diff is limited to the two install blocks; the pattern is byte-for-byte the same as the already-passing `default` config.