### PR TITLE
fix: switch dotnet sample app base image to chiseled to resolve AVM CVEs

### DIFF
--- a/sample-apps/dotnet/asp_frontend_service/Dockerfile
+++ b/sample-apps/dotnet/asp_frontend_service/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY . ./
 RUN dotnet publish asp_frontend_service/*.csproj -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled
 WORKDIR /app
 EXPOSE 8080
 COPY --from=build-env /app/out .

--- a/sample-apps/dotnet/asp_remote_service/Dockerfile
+++ b/sample-apps/dotnet/asp_remote_service/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY . ./
 RUN dotnet publish asp_remote_service/*.csproj -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled
 WORKDIR /app
 ENV ASPNETCORE_URLS=http://+:8081
 EXPOSE 8081


### PR DESCRIPTION
*Issue description:*

Sev 2 AVM Container Remediation finding (2026-06-08) — 7 CVEs in OS-level packages (perl, pam) from the Debian 12 base image used by the .NET sample apps. Debian has not released patches and `apt-get upgrade` installs zero updates. Affected images: dotnet-main-service, dotnet-remote-service across 3 accounts.

CVEs: CVE-2026-12087 (CRITICAL), CVE-2026-48962 (HIGH), CVE-2026-48961 (HIGH), CVE-2026-48959 (HIGH), CVE-2026-7010 (MEDIUM), CVE-2025-15649 (MEDIUM), CVE-2026-54411 (MEDIUM).

*Description of changes:*

Switch the .NET sample app runtime base image from `mcr.microsoft.com/dotnet/aspnet:8.0` (Debian 12, 92 packages) to `mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled` (Ubuntu 24.04 chiseled, 18 packages). This eliminates all 7 CVEs, halves image size (~350MB → ~170MB), and requires no terraform or workflow changes since chiseled is glibc-based and the ADOT operator's profiler path works as-is.

Files changed:
- `sample-apps/dotnet/asp_frontend_service/Dockerfile`
- `sample-apps/dotnet/asp_remote_service/Dockerfile`

*Rollback procedure:*

Yes, this commit can be safely reverted. Revert the single commit and re-run `dotnet-sample-app-ecr-deploy.yml` to push Debian-based images back to ECR. 

*Manual Testing Done*
1. **Build & deploy** — Built chiseled images (amd64) via EC2 native builder, pushed to ECR, deployed to EKS with `instrumentation.opentelemetry.io/inject-dotnet: "true"` annotation
2. **ADOT injection** — Confirmed init container `adot-autoinstrumentation-dotnet:v1.12.0` injected successfully, status: ready
3. **Profiler load** — `CORECLR_PROFILER_PATH` correctly set to `linux-x64` (glibc), no override needed. Logs confirm: `AWS Application Signals runtime metrics enabled`
4. **Healthcheck** — Remote service `/healthcheck` returns 200
5. **Service-to-service** — Frontend successfully calls remote service, both return trace IDs
6. **Traces** — Distributed traces generated with correct span attributes (`outgoing-http-call`, `remote-service` endpoints)
7. **Application Signals metrics** — Confirmed `Latency`, `Error`, `Fault` metrics flowing to CloudWatch under namespace `ApplicationSignals` for both `dotnet-frontend-chiseled` and `dotnet-remote-chiseled` services
8. **No shell dependency** — ADOT instrumentation injects via volume mount + env vars only; does not require shell in the target container

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
