### PR TITLE
test AVM fix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,48 @@
+## Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+
+name: Test Dotnet Chiseled Base Image
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  dotnet-eks-us-east-1:
+    uses: ./.github/workflows/dotnet-eks-test.yml
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      test-cluster-name: e2e-playground
+
+  dotnet-eks-eu-central-2:
+    needs: dotnet-eks-us-east-1
+    uses: ./.github/workflows/dotnet-eks-test.yml
+    secrets: inherit
+    with:
+      aws-region: eu-central-2
+      test-cluster-name: e2e-playground
+
+  dotnet-k8s-us-east-1:
+    needs: dotnet-eks-eu-central-2
+    uses: ./.github/workflows/dotnet-k8s-test.yml
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'main-build'
+
+  dotnet-ec2-default-us-east-1:
+    uses: ./.github/workflows/dotnet-ec2-default-test.yml
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'main-build'
+
+  dotnet-ec2-asg-us-east-1:
+    uses: ./.github/workflows/dotnet-ec2-asg-test.yml
+    secrets: inherit
+    with:
+      aws-region: us-east-1
+      caller-workflow-name: 'main-build'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,14 +21,6 @@ jobs:
       test-cluster-name: e2e-playground
       caller-workflow-name: 'main-build'
 
-  dotnet-eks-eu-central-2:
-    needs: dotnet-eks-us-east-1
-    uses: ./.github/workflows/dotnet-eks-test.yml
-    secrets: inherit
-    with:
-      aws-region: eu-central-2
-      test-cluster-name: e2e-playground
-      caller-workflow-name: 'main-build'
 
   dotnet-k8s-us-east-1:
     needs: dotnet-eks-eu-central-2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@
 name: Test Dotnet Chiseled Base Image
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - TEST_AVM_FIX
 
 permissions:
   id-token: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
     with:
       aws-region: us-east-1
       test-cluster-name: e2e-playground
+      caller-workflow-name: 'main-build'
 
   dotnet-eks-eu-central-2:
     needs: dotnet-eks-us-east-1
@@ -27,6 +28,7 @@ jobs:
     with:
       aws-region: eu-central-2
       test-cluster-name: e2e-playground
+      caller-workflow-name: 'main-build'
 
   dotnet-k8s-us-east-1:
     needs: dotnet-eks-eu-central-2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
 
 
   dotnet-k8s-us-east-1:
-    needs: dotnet-eks-eu-central-2
     uses: ./.github/workflows/dotnet-k8s-test.yml
     secrets: inherit
     with:


### PR DESCRIPTION
Sample app workflows were previously disabled and need to be ran on workflow_call. 

This PR will hold a test.yml file that will call those workflows to ensure no breaking changes.

This will not be merged.

<Can we safely revert this commit if needed? If not, detail what must be done to safely revert and why it is needed.>

*Ensure you've run the following tests on your changes and include the link below:*

To do so, create a `test.yml` file with `name: Test` and workflow description to test your changes, then remove the file for your PR. Link your test run in your PR description. This process is a short term solution while we work on creating a staging environment for testing.

NOTE: TESTS RUNNING ON A SINGLE EKS CLUSTER CANNOT BE RUN IN PARALLEL. See the [needs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds) keyword to run tests in succession.
- Run Java EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run Python EKS on `e2e-playground` in us-east-1 and eu-central-2
- Run metric limiter on EKS cluster `e2e-playground` in us-east-1 and eu-central-2
- Run EC2 tests in all regions
- Run K8s on a separate K8s cluster (check IAD test account for master node endpoints; these will change as we create and destroy clusters for OS patching)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
