### PR TITLE
feat(node-sample-app): make frontend-service Service Events-capable

### DIFF
--- a/sample-apps/node/frontend-service/helpers.js
+++ b/sample-apps/node/frontend-service/helpers.js
@@ -1,0 +1,61 @@
+'use strict';
+
+/**
+ * Helper functions for the Service Events FunctionCall signal.
+ *
+ * Service Events function instrumentation (OTEL_AWS_SERVICE_EVENTS_PACKAGES_INCLUDE) is matched
+ * (minimatch, matchBase) against the full file path of every require()'d module, so the functions
+ * that should emit the `service.function.duration` metric must live in a separate required module
+ * — the entry script (index.js) is never transformed. The Service Events EC2 cell sets
+ * PACKAGES_INCLUDE to `**\/helpers.js` so the functions below are instrumented.
+ *
+ * The functions call each other so the captured call_path has more than one frame:
+ *   processData -> validateInput, computeResult, formatResponse.
+ */
+
+/**
+ * Error class mirroring Python's ValueError so the exception-triggered IncidentSnapshot and the
+ * EndpointErrorMetric `count` data point carry a meaningful `exception_type` across SDKs.
+ */
+class ValueError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'ValueError';
+  }
+}
+
+// Throws ValueError on a falsy value; this is the function the /exception route trips so the
+// exception incident records exception_type=ValueError, function_name=helpers.validateInput.
+function validateInput(value) {
+  if (!value) {
+    throw new ValueError('Invalid input');
+  }
+  return true;
+}
+
+function computeResult(x) {
+  return x * 2;
+}
+
+function formatResponse(data) {
+  return {
+    formatted: true,
+    payload: data,
+  };
+}
+
+// Happy-path entry point exercised by /success: drives the success-status FunctionCall data point
+// for service.function.duration (status=success) by calling the other instrumented helpers.
+function processData(input) {
+  validateInput(input);
+  const result = computeResult((input && input.length) || 0);
+  return formatResponse({ processed: true, result });
+}
+
+module.exports = {
+  ValueError,
+  validateInput,
+  computeResult,
+  formatResponse,
+  processData,
+};

--- a/sample-apps/node/frontend-service/index.js
+++ b/sample-apps/node/frontend-service/index.js
@@ -8,6 +8,10 @@ const { S3Client, GetBucketLocationCommand } = require('@aws-sdk/client-s3');
 const opentelemetry = require('@opentelemetry/sdk-node');
 const { metrics } = require('@opentelemetry/api');
 const { randomInt } = require('crypto');
+// Named functions instrumented for the Service Events FunctionCall signal (see helpers.js). Kept
+// in a separate module because Service Events function instrumentation only transforms require()'d
+// modules, not this entry script.
+const { processData, validateInput } = require('./helpers');
 
 const PORT = parseInt(process.env.SAMPLE_APP_PORT || '8000', 10);
 
@@ -221,6 +225,37 @@ app.get('/mysql', (req, res) => {
       res.send(msg);
     });
   });
+});
+
+// --- Service Events: success-path FunctionCall driver ---
+// Exercises the instrumented helpers (processData -> validateInput/computeResult/formatResponse)
+// so the `service.function.duration` metric emits a status=success data point. Returns HTTP 200.
+app.get('/success', (req, res) => {
+  const result = processData('service-events');
+  logger.info('/success called successfully');
+  res.json({ status: 'ok', result });
+});
+
+// --- Service Events: exception-incident driver ---
+// Calls the instrumented helpers.validateInput(null), which throws ValueError. The error
+// propagates to the error-handling middleware below, returning HTTP 500 with a captured
+// exception. This is the gate for the EndpointErrorMetric `count` data point and the
+// exception-triggered IncidentSnapshot (mirrors Python /mysql and Java /mysql in those cells).
+app.get('/exception', (req, res, next) => {
+  try {
+    validateInput(null);
+    res.json({ status: 'ok' });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Error-handling middleware: turns a thrown/forwarded error into an HTTP 500 so Service Events
+// captures it. Express identifies an error handler by its four-argument signature.
+// eslint-disable-next-line no-unused-vars
+app.use((err, req, res, next) => {
+  logger.error(`Unhandled error: ${err.message}`);
+  res.status(500).json({ error: err.message });
 });
 
 app.listen(PORT, () => {


### PR DESCRIPTION
## What

Makes the standard Node `frontend-service` sample app able to drive all five **Service Events** telemetry signals from a single app, so the Node EC2 Service Events test cell can deploy the *same* app the other Node EC2 cells (default/asg/sigv4) already use — instead of a separate vendored app.

Two files, additive only:

- **`helpers.js`** (new): `ValueError` class + `validateInput` / `computeResult` / `formatResponse` / `processData`. These live in a separate `require()`'d module because Service Events function instrumentation only transforms required modules, not the `index.js` entry script (the SE cell scopes `PACKAGES_INCLUDE=**/helpers.js`).
- **`index.js`**: adds `GET /success` (drives the success-path `FunctionCall` metric via `processData`), `GET /exception` (calls `validateInput(null)` → `ValueError` → 500, driving `EndpointErrorMetric count` + the exception-triggered `IncidentSnapshot`), and a 4-arg Express error-handling middleware that turns the forwarded error into an HTTP 500.

`DeploymentEvent` (startup) and the latency `IncidentSnapshot` (existing `/aws-sdk-call`, threshold 1ms) need no app change.

## Why additive / no impact on existing cells

- Every existing route (`/mysql`, `/aws-sdk-call`, `/healthcheck`, …) is **unchanged**.
- No existing route throws synchronously or calls `next(err)`, so the new error middleware is inert for the default/asg/sigv4/k8s/ecs/eks/lambda cells.
- Those cells drive traffic from a separate `traffic-generator.zip` that never curls `/success` or `/exception`, so the new routes are never exercised outside the Service Events cell.
- The Node metric validator is containment-only (asserts expected ⊆ actual), so extra operations cannot fail an existing cell.
- `helpers.js` ships in every deployment (Dockerfile `COPY . ./`; the S3 deploy zips the whole `sample-apps/node` tree), so the new `require('./helpers')` resolves everywhere.

## Validation

Validated end to end — **5/5 Service Events signals PASS** against live CloudWatch on an EC2 instance running this exact app (DeploymentEvent, exception IncidentSnapshot, latency IncidentSnapshot, EndpointErrorMetric, FunctionCall).

## Follow-up

The Node EC2 Service Events **test cell** (terraform + validator templates that consume these routes) and a republish of the prod `node-sample-app.zip` follow in a separate PR. This sample-app change is split out first so the prod zip can be republished from `main`.