### PR TITLE
Add e2e tests for additional Lambda runtimes

### DIFF
--- a/.github/workflows/dotnet-lambda-test.yml
+++ b/.github/workflows/dotnet-lambda-test.yml
@@ -14,6 +14,11 @@ on:
       caller-workflow-name:
         required: true
         type: string
+      runtime:
+        description: "DotNet Lambda runtime, e.g. dotnet6, dotnet8"
+        required: false
+        type: string
+        default: 'dotnet8'
     outputs:
       job-started:
         value: ${{ jobs.dotnet-lambda-default.outputs.job-started }}
@@ -93,8 +98,13 @@ jobs:
 
       - name: Download Lambda Layer and Function artifacts for E2E Test
         run: |
-          aws s3 cp s3://${{ env.STAGING_S3_BUCKET }}/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip ${{ env.ARTIFACTS_DIR }}/layer.zip |
-          aws s3 cp s3://${{ env.STAGING_S3_BUCKET }}/function-${{ github.run_id }}.zip ${{ env.ARTIFACTS_DIR }}/dotnet-function.zip
+          aws s3 cp s3://${{ env.STAGING_S3_BUCKET }}/aws-distro-opentelemetry-dotnet-instrumentation-linux-glibc-x64.zip ${{ env.ARTIFACTS_DIR }}/layer.zip
+          # Prefer a runtime-specific function artifact (function-<run_id>-<runtime>.zip); fall back to the legacy single artifact.
+          if aws s3 cp s3://${{ env.STAGING_S3_BUCKET }}/function-${{ github.run_id }}-${{ inputs.runtime }}.zip ${{ env.ARTIFACTS_DIR }}/dotnet-function.zip; then
+            echo "Using runtime-specific function artifact for ${{ inputs.runtime }}"
+          else
+            aws s3 cp s3://${{ env.STAGING_S3_BUCKET }}/function-${{ github.run_id }}.zip ${{ env.ARTIFACTS_DIR }}/dotnet-function.zip
+          fi
 
       - name: Set up terraform
         uses: ./.github/workflows/actions/execute_and_retry
@@ -120,10 +130,11 @@ jobs:
       - name: Apply terraform
         uses: ./.github/workflows/actions/execute_and_retry
         with:
-          command: 'cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/dotnet/lambda/lambda && terraform apply -auto-approve 
-          -var="sdk_layer_name=AWSOpenTelemetryDistroDotNet-${{ github.run_id }}" 
-          -var="function_name=${{env.TERRAFORM_LAMBDA_FUNCTION_NAME}}" 
+          command: 'cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/dotnet/lambda/lambda && terraform apply -auto-approve
+          -var="sdk_layer_name=AWSOpenTelemetryDistroDotNet-${{ github.run_id }}"
+          -var="function_name=${{env.TERRAFORM_LAMBDA_FUNCTION_NAME}}"
           -var="layer_artifacts_directory=${{ env.ARTIFACTS_DIR }}"
+          -var="runtime=${{ inputs.runtime }}"
           -var="region=${{ env.E2E_TEST_AWS_REGION }}"'
           max_retry: 6
           sleep_time: 60
@@ -215,4 +226,5 @@ jobs:
           -var="sdk_layer_name=AWSOpenTelemetryDistroDotNet-${{ github.run_id }}" \
           -var="function_name=${{env.TERRAFORM_LAMBDA_FUNCTION_NAME}}" \
           -var="layer_artifacts_directory=${{ env.ARTIFACTS_DIR }}" \
+          -var="runtime=${{ inputs.runtime }}" \
           -var="region=${{ env.E2E_TEST_AWS_REGION }}"

--- a/.github/workflows/java-lambda-test.yml
+++ b/.github/workflows/java-lambda-test.yml
@@ -14,6 +14,11 @@ on:
       caller-workflow-name:
         required: true
         type: string
+      runtime:
+        description: "Java Lambda runtime, e.g. java11, java17, java21, java25"
+        required: false
+        type: string
+        default: 'java17'
     outputs:
       job-started:
         value: ${{ jobs.java-lambda-default.outputs.job-started }}
@@ -123,10 +128,11 @@ jobs:
       - name: Apply terraform
         uses: ./.github/workflows/actions/execute_and_retry
         with:
-          command: 'cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/java/lambda/lambda && terraform apply -auto-approve 
-          -var="sdk_layer_name=AWSOpenTelemetryDistroJava-${{ github.run_id }}" 
+          command: 'cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/java/lambda/lambda && terraform apply -auto-approve
+          -var="sdk_layer_name=AWSOpenTelemetryDistroJava-${{ github.run_id }}"
           -var="function_name=${{env.TERRAFORM_LAMBDA_FUNCTION_NAME}}"
           -var="layer_artifacts_directory=${{ env.ARTIFACTS_DIR }}"
+          -var="runtime=${{ inputs.runtime }}"
           -var="region=${{ env.E2E_TEST_AWS_REGION }}"'
           max_retry: 6
           sleep_time: 60
@@ -229,4 +235,5 @@ jobs:
           -var="sdk_layer_name=AWSOpenTelemetryDistroJava-${{ github.run_id }}" \
           -var="function_name=${{env.TERRAFORM_LAMBDA_FUNCTION_NAME}}" \
           -var="layer_artifacts_directory=${{ env.ARTIFACTS_DIR }}" \
+          -var="runtime=${{ inputs.runtime }}" \
           -var="region=${{ env.E2E_TEST_AWS_REGION }}"

--- a/.github/workflows/node-lambda-test.yml
+++ b/.github/workflows/node-lambda-test.yml
@@ -14,6 +14,11 @@ on:
       caller-workflow-name:
         required: true
         type: string
+      runtime:
+        description: "NodeJS Lambda runtime, e.g. nodejs18.x, nodejs20.x, nodejs22.x, nodejs24.x"
+        required: false
+        type: string
+        default: 'nodejs24.x'
       staging-instrumentation-name:
         required: false
         default: '@aws/aws-distro-opentelemetry-node-autoinstrumentation'
@@ -124,10 +129,11 @@ jobs:
       - name: Apply terraform
         uses: ./.github/workflows/actions/execute_and_retry
         with:
-          command: 'cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/node/lambda/lambda && terraform apply -auto-approve 
-          -var="sdk_layer_name=AWSOpenTelemetryDistroJs-${{ github.run_id }}" 
-          -var="function_name=${{env.TERRAFORM_LAMBDA_FUNCTION_NAME}}" 
+          command: 'cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/node/lambda/lambda && terraform apply -auto-approve
+          -var="sdk_layer_name=AWSOpenTelemetryDistroJs-${{ github.run_id }}"
+          -var="function_name=${{env.TERRAFORM_LAMBDA_FUNCTION_NAME}}"
           -var="layer_artifacts_directory=${{ env.ARTIFACTS_DIR }}"
+          -var="runtime=${{ inputs.runtime }}"
           -var="region=${{ env.E2E_TEST_AWS_REGION }}"'
           max_retry: 6
           sleep_time: 60
@@ -219,4 +225,5 @@ jobs:
           -var="sdk_layer_name=AWSOpenTelemetryDistroJs-${{ github.run_id }}" \
           -var="function_name=${{env.TERRAFORM_LAMBDA_FUNCTION_NAME}}" \
           -var="layer_artifacts_directory=${{ env.ARTIFACTS_DIR }}" \
+          -var="runtime=${{ inputs.runtime }}" \
           -var="region=${{ env.E2E_TEST_AWS_REGION }}"

--- a/.github/workflows/python-lambda-test.yml
+++ b/.github/workflows/python-lambda-test.yml
@@ -18,7 +18,7 @@ on:
         description: "Currently support version 3.10, 3.11, 3.12, 3.13, 3.14"
         required: false
         type: string
-        default: '3.10'
+        default: '3.13'
       cpu-architecture:
         description: "Permitted values: x86_64 or arm64"
         required: false
@@ -140,10 +140,11 @@ jobs:
       - name: Apply terraform
         uses: ./.github/workflows/actions/execute_and_retry
         with:
-          command: 'cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/python/lambda/lambda && terraform apply -auto-approve 
-          -var="sdk_layer_name=AWSOpenTelemetryDistroPython-${{ github.run_id }}" 
+          command: 'cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/python/lambda/lambda && terraform apply -auto-approve
+          -var="sdk_layer_name=AWSOpenTelemetryDistroPython-${{ github.run_id }}"
           -var="function_name=${{env.TERRAFORM_LAMBDA_FUNCTION_NAME}}"
           -var="layer_artifacts_directory=${{ env.ARTIFACTS_DIR }}"
+          -var="runtime=python${{ inputs.python-version }}"
           -var="region=${{ env.E2E_TEST_AWS_REGION }}"'
           max_retry: 6
           sleep_time: 60
@@ -245,4 +246,5 @@ jobs:
           -var="sdk_layer_name=AWSOpenTelemetryDistroPython-${{ github.run_id }}" \
           -var="function_name=${{env.TERRAFORM_LAMBDA_FUNCTION_NAME}}" \
           -var="layer_artifacts_directory=${{ env.ARTIFACTS_DIR }}" \
+          -var="runtime=python${{ inputs.python-version }}" \
           -var="region=${{ env.E2E_TEST_AWS_REGION }}"

--- a/terraform/dotnet/lambda/lambda/main.tf
+++ b/terraform/dotnet/lambda/lambda/main.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_layer_version" "sdk_layer" {
   count               = 1
   layer_name          = var.sdk_layer_name
   filename            = "${var.layer_artifacts_directory}/layer.zip"
-  compatible_runtimes = ["dotnet6", "dotnet8"]
+  compatible_runtimes = ["dotnet8", "dotnet10"]
   license_info        = "Apache-2.0"
   source_code_hash    = filebase64sha256("${var.layer_artifacts_directory}/layer.zip")
   #   filename = "${var.kube_directory_path}/config"

--- a/terraform/java/lambda/lambda/main.tf
+++ b/terraform/java/lambda/lambda/main.tf
@@ -6,7 +6,7 @@ resource "aws_lambda_layer_version" "sdk_layer" {
   count               = 1
   layer_name          = var.sdk_layer_name
   filename            = "${var.layer_artifacts_directory}/layer.zip"
-  compatible_runtimes = ["java17", "java21"]
+  compatible_runtimes = ["java11", "java17", "java21", "java25"]
   license_info        = "Apache-2.0"
   source_code_hash    = filebase64sha256("${var.layer_artifacts_directory}/layer.zip")
 }

--- a/terraform/python/lambda/lambda/main.tf
+++ b/terraform/python/lambda/lambda/main.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_layer_version" "sdk_layer" {
   count               = 1
   layer_name          = var.sdk_layer_name
   filename            = "${var.layer_artifacts_directory}/layer.zip"
-  compatible_runtimes = ["python3.10", "python3.11", "python3.12", "python3.13"]
+  compatible_runtimes = ["python3.10", "python3.11", "python3.12", "python3.13", "python3.14"]
   license_info        = "Apache-2.0"
   source_code_hash    = filebase64sha256("${var.layer_artifacts_directory}/layer.zip")
   #   filename = "${var.kube_directory_path}/config"


### PR DESCRIPTION
Add e2e tests for Python 3.10/3.11/3.12/3.14, Node 18/20/22, Java 11/21/25, and .NET 10 Lambda runtimes.