### PR TITLE
fix: point lite SDK e2e workflows at main branch for main-build runs

### DIFF
--- a/.github/workflows/node-lambda-lite-sdk-test.yml
+++ b/.github/workflows/node-lambda-lite-sdk-test.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: 'aws-observability/aws-application-signals-test-framework'
-          ref: ${{ env.CALLER_WORKFLOW_NAME == 'main-build' && 'otel-lite-sdk' || github.ref }}
+          ref: ${{ env.CALLER_WORKFLOW_NAME == 'main-build' && 'main' || github.ref }}
           fetch-depth: 0
 
       - name: Initiate Gradlew Daemon

--- a/.github/workflows/python-lambda-lite-sdk-test.yml
+++ b/.github/workflows/python-lambda-lite-sdk-test.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: 'aws-observability/aws-application-signals-test-framework'
-          ref: ${{ env.CALLER_WORKFLOW_NAME == 'main-build' && 'otel-lite-sdk' || github.ref }}
+          ref: ${{ env.CALLER_WORKFLOW_NAME == 'main-build' && 'main' || github.ref }}
           fetch-depth: 0
 
       - name: Initiate Gradlew Daemon


### PR DESCRIPTION
## Description

Updates the Node and Python Lambda Lite SDK E2E workflows to check out the `main`
branch (instead of `otel-lite-sdk`) when invoked from `main-build`.

Now that the lite SDK E2E tests have been merged into `main`, the `main-build`
caller should exercise the code on `main` rather than the temporary `otel-lite-sdk`
development branch.

## Changes

Both reusable workflows change the checkout ref for `main-build` runs:

```diff
- ref: ${{ env.CALLER_WORKFLOW_NAME == 'main-build' && 'otel-lite-sdk' || github.ref }}
+ ref: ${{ env.CALLER_WORKFLOW_NAME == 'main-build' && 'main' || github.ref }}
