### PR TITLE
Make Lambda e2e resource names unique per runtime

### DIFF
--- a/.github/workflows/dotnet-lambda-test.yml
+++ b/.github/workflows/dotnet-lambda-test.yml
@@ -124,14 +124,20 @@ jobs:
 
       - name: Get terraform Lambda function name
         shell: bash
+        # Suffix resource names with the matrix runtime so parallel runtime jobs sharing a run_id
+        # don't collide on the same IAM role / log group / layer. Strip dots since Lambda function,
+        # IAM role, and layer names disallow them.
         run: |
-          echo TERRAFORM_LAMBDA_FUNCTION_NAME="AdotLambdaDotNetSampleApp-${{ github.run_id }}"|
+          RUNTIME_TAG=$(echo "${{ inputs.runtime }}" | tr -cd '[:alnum:]')
+          echo TERRAFORM_LAMBDA_FUNCTION_NAME="AdotLambdaDotNetSampleApp-${{ github.run_id }}-${RUNTIME_TAG}" |
+          tee --append "$GITHUB_ENV"
+          echo TERRAFORM_LAMBDA_LAYER_NAME="AWSOpenTelemetryDistroDotNet-${{ github.run_id }}-${RUNTIME_TAG}" |
           tee --append "$GITHUB_ENV"
       - name: Apply terraform
         uses: ./.github/workflows/actions/execute_and_retry
         with:
           command: 'cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/dotnet/lambda/lambda && terraform apply -auto-approve
-          -var="sdk_layer_name=AWSOpenTelemetryDistroDotNet-${{ github.run_id }}"
+          -var="sdk_layer_name=${{ env.TERRAFORM_LAMBDA_LAYER_NAME }}"
           -var="function_name=${{env.TERRAFORM_LAMBDA_FUNCTION_NAME}}"
           -var="layer_artifacts_directory=${{ env.ARTIFACTS_DIR }}"
           -var="runtime=${{ inputs.runtime }}"
@@ -223,7 +229,7 @@ jobs:
         continue-on-error: true
         run: |
           cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/dotnet/lambda/lambda && terraform destroy -auto-approve \
-          -var="sdk_layer_name=AWSOpenTelemetryDistroDotNet-${{ github.run_id }}" \
+          -var="sdk_layer_name=${{ env.TERRAFORM_LAMBDA_LAYER_NAME }}" \
           -var="function_name=${{env.TERRAFORM_LAMBDA_FUNCTION_NAME}}" \
           -var="layer_artifacts_directory=${{ env.ARTIFACTS_DIR }}" \
           -var="runtime=${{ inputs.runtime }}" \

--- a/.github/workflows/dotnet-lambda-test.yml
+++ b/.github/workflows/dotnet-lambda-test.yml
@@ -124,9 +124,6 @@ jobs:
 
       - name: Get terraform Lambda function name
         shell: bash
-        # Suffix resource names with the matrix runtime so parallel runtime jobs sharing a run_id
-        # don't collide on the same IAM role / log group / layer. Strip dots since Lambda function,
-        # IAM role, and layer names disallow them.
         run: |
           RUNTIME_TAG=$(echo "${{ inputs.runtime }}" | tr -cd '[:alnum:]')
           echo TERRAFORM_LAMBDA_FUNCTION_NAME="AdotLambdaDotNetSampleApp-${{ github.run_id }}-${RUNTIME_TAG}" |

--- a/.github/workflows/java-lambda-test.yml
+++ b/.github/workflows/java-lambda-test.yml
@@ -121,15 +121,21 @@ jobs:
 
       - name: Get terraform Lambda function name
         shell: bash
+        # Suffix resource names with the matrix runtime so parallel runtime jobs sharing a run_id
+        # don't collide on the same IAM role / log group / layer. Strip dots since Lambda function,
+        # IAM role, and layer names disallow them.
         run: |
-          echo TERRAFORM_LAMBDA_FUNCTION_NAME="AdotLambdaJavaSampleApp-${{ github.run_id }}"|
+          RUNTIME_TAG=$(echo "${{ inputs.runtime }}" | tr -cd '[:alnum:]')
+          echo TERRAFORM_LAMBDA_FUNCTION_NAME="AdotLambdaJavaSampleApp-${{ github.run_id }}-${RUNTIME_TAG}" |
+          tee --append "$GITHUB_ENV"
+          echo TERRAFORM_LAMBDA_LAYER_NAME="AWSOpenTelemetryDistroJava-${{ github.run_id }}-${RUNTIME_TAG}" |
           tee --append "$GITHUB_ENV"
           
       - name: Apply terraform
         uses: ./.github/workflows/actions/execute_and_retry
         with:
           command: 'cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/java/lambda/lambda && terraform apply -auto-approve
-          -var="sdk_layer_name=AWSOpenTelemetryDistroJava-${{ github.run_id }}"
+          -var="sdk_layer_name=${{ env.TERRAFORM_LAMBDA_LAYER_NAME }}"
           -var="function_name=${{env.TERRAFORM_LAMBDA_FUNCTION_NAME}}"
           -var="layer_artifacts_directory=${{ env.ARTIFACTS_DIR }}"
           -var="runtime=${{ inputs.runtime }}"
@@ -232,7 +238,7 @@ jobs:
         continue-on-error: true
         run: |
           cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/java/lambda/lambda && terraform destroy -auto-approve \
-          -var="sdk_layer_name=AWSOpenTelemetryDistroJava-${{ github.run_id }}" \
+          -var="sdk_layer_name=${{ env.TERRAFORM_LAMBDA_LAYER_NAME }}" \
           -var="function_name=${{env.TERRAFORM_LAMBDA_FUNCTION_NAME}}" \
           -var="layer_artifacts_directory=${{ env.ARTIFACTS_DIR }}" \
           -var="runtime=${{ inputs.runtime }}" \

--- a/.github/workflows/java-lambda-test.yml
+++ b/.github/workflows/java-lambda-test.yml
@@ -121,9 +121,6 @@ jobs:
 
       - name: Get terraform Lambda function name
         shell: bash
-        # Suffix resource names with the matrix runtime so parallel runtime jobs sharing a run_id
-        # don't collide on the same IAM role / log group / layer. Strip dots since Lambda function,
-        # IAM role, and layer names disallow them.
         run: |
           RUNTIME_TAG=$(echo "${{ inputs.runtime }}" | tr -cd '[:alnum:]')
           echo TERRAFORM_LAMBDA_FUNCTION_NAME="AdotLambdaJavaSampleApp-${{ github.run_id }}-${RUNTIME_TAG}" |

--- a/.github/workflows/node-lambda-test.yml
+++ b/.github/workflows/node-lambda-test.yml
@@ -123,9 +123,6 @@ jobs:
 
       - name: Get terraform Lambda function name
         shell: bash
-        # Suffix resource names with the matrix runtime so parallel runtime jobs sharing a run_id
-        # don't collide on the same IAM role / log group / layer. Strip dots ('nodejs22.x' ->
-        # 'nodejs22x') since Lambda function, IAM role, and layer names disallow them.
         run: |
           RUNTIME_TAG=$(echo "${{ inputs.runtime }}" | tr -cd '[:alnum:]')
           echo TERRAFORM_LAMBDA_FUNCTION_NAME="AdotLambdaNodeJsSampleApp-${{ github.run_id }}-${RUNTIME_TAG}" |

--- a/.github/workflows/node-lambda-test.yml
+++ b/.github/workflows/node-lambda-test.yml
@@ -123,14 +123,20 @@ jobs:
 
       - name: Get terraform Lambda function name
         shell: bash
+        # Suffix resource names with the matrix runtime so parallel runtime jobs sharing a run_id
+        # don't collide on the same IAM role / log group / layer. Strip dots ('nodejs22.x' ->
+        # 'nodejs22x') since Lambda function, IAM role, and layer names disallow them.
         run: |
-          echo TERRAFORM_LAMBDA_FUNCTION_NAME="AdotLambdaNodeJsSampleApp-${{ github.run_id }}"|
+          RUNTIME_TAG=$(echo "${{ inputs.runtime }}" | tr -cd '[:alnum:]')
+          echo TERRAFORM_LAMBDA_FUNCTION_NAME="AdotLambdaNodeJsSampleApp-${{ github.run_id }}-${RUNTIME_TAG}" |
+          tee --append "$GITHUB_ENV"
+          echo TERRAFORM_LAMBDA_LAYER_NAME="AWSOpenTelemetryDistroJs-${{ github.run_id }}-${RUNTIME_TAG}" |
           tee --append "$GITHUB_ENV"
       - name: Apply terraform
         uses: ./.github/workflows/actions/execute_and_retry
         with:
           command: 'cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/node/lambda/lambda && terraform apply -auto-approve
-          -var="sdk_layer_name=AWSOpenTelemetryDistroJs-${{ github.run_id }}"
+          -var="sdk_layer_name=${{ env.TERRAFORM_LAMBDA_LAYER_NAME }}"
           -var="function_name=${{env.TERRAFORM_LAMBDA_FUNCTION_NAME}}"
           -var="layer_artifacts_directory=${{ env.ARTIFACTS_DIR }}"
           -var="runtime=${{ inputs.runtime }}"
@@ -222,7 +228,7 @@ jobs:
         continue-on-error: true
         run: |
           cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/node/lambda/lambda && terraform destroy -auto-approve \
-          -var="sdk_layer_name=AWSOpenTelemetryDistroJs-${{ github.run_id }}" \
+          -var="sdk_layer_name=${{ env.TERRAFORM_LAMBDA_LAYER_NAME }}" \
           -var="function_name=${{env.TERRAFORM_LAMBDA_FUNCTION_NAME}}" \
           -var="layer_artifacts_directory=${{ env.ARTIFACTS_DIR }}" \
           -var="runtime=${{ inputs.runtime }}" \

--- a/.github/workflows/python-lambda-lite-sdk-test.yml
+++ b/.github/workflows/python-lambda-lite-sdk-test.yml
@@ -130,9 +130,6 @@ jobs:
 
       - name: Get terraform Lambda function name
         shell: bash
-        # Suffix resource names with the matrix runtime so parallel python-version jobs sharing a
-        # run_id don't collide on the same IAM role / log group / layer. Strip dots ('3.12' -> '312')
-        # since Lambda function, IAM role, and layer names disallow them.
         run: |
           RUNTIME_TAG=$(echo "${{ inputs.python-version }}" | tr -cd '[:alnum:]')
           echo TERRAFORM_LAMBDA_FUNCTION_NAME="AdotLambdaPythonLiteSdk-${{ github.run_id }}-py${RUNTIME_TAG}" |

--- a/.github/workflows/python-lambda-lite-sdk-test.yml
+++ b/.github/workflows/python-lambda-lite-sdk-test.yml
@@ -130,8 +130,14 @@ jobs:
 
       - name: Get terraform Lambda function name
         shell: bash
+        # Suffix resource names with the matrix runtime so parallel python-version jobs sharing a
+        # run_id don't collide on the same IAM role / log group / layer. Strip dots ('3.12' -> '312')
+        # since Lambda function, IAM role, and layer names disallow them.
         run: |
-          echo TERRAFORM_LAMBDA_FUNCTION_NAME="AdotLambdaPythonLiteSdk-${{ github.run_id }}" |
+          RUNTIME_TAG=$(echo "${{ inputs.python-version }}" | tr -cd '[:alnum:]')
+          echo TERRAFORM_LAMBDA_FUNCTION_NAME="AdotLambdaPythonLiteSdk-${{ github.run_id }}-py${RUNTIME_TAG}" |
+          tee --append "$GITHUB_ENV"
+          echo TERRAFORM_LAMBDA_LAYER_NAME="AWSOpenTelemetryDistroPythonLiteSdk-${{ github.run_id }}-py${RUNTIME_TAG}" |
           tee --append "$GITHUB_ENV"
 
       - name: Apply terraform
@@ -139,7 +145,7 @@ jobs:
         with:
           command: 'cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/python/lambda/lambda && terraform apply -auto-approve
           -var="lite_sdk=true"
-          -var="sdk_layer_name=AWSOpenTelemetryDistroPythonLiteSdk-${{ github.run_id }}"
+          -var="sdk_layer_name=${{ env.TERRAFORM_LAMBDA_LAYER_NAME }}"
           -var="function_name=${{env.TERRAFORM_LAMBDA_FUNCTION_NAME}}"
           -var="layer_artifacts_directory=${{ env.ARTIFACTS_DIR }}"
           -var="region=${{ env.E2E_TEST_AWS_REGION }}"'
@@ -205,7 +211,7 @@ jobs:
         with:
           command: 'cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/python/lambda/lambda && terraform destroy -auto-approve
           -var="lite_sdk=true"
-          -var="sdk_layer_name=AWSOpenTelemetryDistroPythonLiteSdk-${{ github.run_id }}"
+          -var="sdk_layer_name=${{ env.TERRAFORM_LAMBDA_LAYER_NAME }}"
           -var="function_name=${{env.TERRAFORM_LAMBDA_FUNCTION_NAME}}"
           -var="layer_artifacts_directory=${{ env.ARTIFACTS_DIR }}"
           -var="region=${{ env.E2E_TEST_AWS_REGION }}"'

--- a/.github/workflows/python-lambda-test.yml
+++ b/.github/workflows/python-lambda-test.yml
@@ -133,15 +133,21 @@ jobs:
 
       - name: Get terraform Lambda function name
         shell: bash
+        # Suffix resource names with the matrix runtime so parallel python-version jobs sharing a
+        # run_id don't collide on the same IAM role / log group / layer. Strip dots ('3.12' -> '312')
+        # since Lambda function, IAM role, and layer names disallow them.
         run: |
-          echo TERRAFORM_LAMBDA_FUNCTION_NAME="AdotLambdaPythonSampleApp-${{ github.run_id }}"|
+          RUNTIME_TAG=$(echo "${{ inputs.python-version }}" | tr -cd '[:alnum:]')
+          echo TERRAFORM_LAMBDA_FUNCTION_NAME="AdotLambdaPythonSampleApp-${{ github.run_id }}-py${RUNTIME_TAG}" |
+          tee --append "$GITHUB_ENV"
+          echo TERRAFORM_LAMBDA_LAYER_NAME="AWSOpenTelemetryDistroPython-${{ github.run_id }}-py${RUNTIME_TAG}" |
           tee --append "$GITHUB_ENV"
 
       - name: Apply terraform
         uses: ./.github/workflows/actions/execute_and_retry
         with:
           command: 'cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/python/lambda/lambda && terraform apply -auto-approve
-          -var="sdk_layer_name=AWSOpenTelemetryDistroPython-${{ github.run_id }}"
+          -var="sdk_layer_name=${{ env.TERRAFORM_LAMBDA_LAYER_NAME }}"
           -var="function_name=${{env.TERRAFORM_LAMBDA_FUNCTION_NAME}}"
           -var="layer_artifacts_directory=${{ env.ARTIFACTS_DIR }}"
           -var="runtime=python${{ inputs.python-version }}"
@@ -243,7 +249,7 @@ jobs:
         continue-on-error: true
         run: |
           cd ${{ env.TEST_RESOURCES_FOLDER }}/terraform/python/lambda/lambda && terraform destroy -auto-approve \
-          -var="sdk_layer_name=AWSOpenTelemetryDistroPython-${{ github.run_id }}" \
+          -var="sdk_layer_name=${{ env.TERRAFORM_LAMBDA_LAYER_NAME }}" \
           -var="function_name=${{env.TERRAFORM_LAMBDA_FUNCTION_NAME}}" \
           -var="layer_artifacts_directory=${{ env.ARTIFACTS_DIR }}" \
           -var="runtime=python${{ inputs.python-version }}" \

--- a/.github/workflows/python-lambda-test.yml
+++ b/.github/workflows/python-lambda-test.yml
@@ -133,9 +133,6 @@ jobs:
 
       - name: Get terraform Lambda function name
         shell: bash
-        # Suffix resource names with the matrix runtime so parallel python-version jobs sharing a
-        # run_id don't collide on the same IAM role / log group / layer. Strip dots ('3.12' -> '312')
-        # since Lambda function, IAM role, and layer names disallow them.
         run: |
           RUNTIME_TAG=$(echo "${{ inputs.python-version }}" | tr -cd '[:alnum:]')
           echo TERRAFORM_LAMBDA_FUNCTION_NAME="AdotLambdaPythonSampleApp-${{ github.run_id }}-py${RUNTIME_TAG}" |


### PR DESCRIPTION
Suffix the Lambda function, IAM role, log group, and layer names with the per-job runtime so parallel matrix jobs sharing a github.run_id no longer collide on the same resources (previously they raced and failed with EntityAlreadyExists / ResourceAlreadyExistsException). Applies to the python, python-lite-sdk, java, node, and dotnet lambda test workflows.