### PR TITLE
fix: correct operator arg index for dotnet k8s image patch

### DIFF
--- a/terraform/dotnet/k8s/deploy/main.tf
+++ b/terraform/dotnet/k8s/deploy/main.tf
@@ -92,7 +92,7 @@ resource "null_resource" "deploy" {
         kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
       elif [ "${var.repository}" = "aws-otel-dotnet-instrumentation" ]; then
         kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' \
-        -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/4", "value": "--auto-instrumentation-dotnet-image=${var.patch_image_arn}"}]'
+        -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/5", "value": "--auto-instrumentation-dotnet-image=${var.patch_image_arn}"}]'
         kubectl delete pods --all -n amazon-cloudwatch
         sleep 10
         kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch


### PR DESCRIPTION
*Issue description:*

*Description of changes:*
The dotnet k8s deploy script patched args/4, which is the python image slot in the current operator helm chart (6.3.0). The dotnet image is at args/5. Patching the wrong index corrupted the operator deployment causing all pods in the namespace to fail to reach ready state.

*Rollback procedure:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
