### PR TITLE
fix: use rollout status for dotnet k8s operator patch to avoid flaky wait

### DIFF
--- a/terraform/dotnet/k8s/deploy/main.tf
+++ b/terraform/dotnet/k8s/deploy/main.tf
@@ -93,9 +93,8 @@ resource "null_resource" "deploy" {
       elif [ "${var.repository}" = "aws-otel-dotnet-instrumentation" ]; then
         kubectl patch deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager --type='json' \
         -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args/5", "value": "--auto-instrumentation-dotnet-image=${var.patch_image_arn}"}]'
-        kubectl delete pods --all -n amazon-cloudwatch
-        sleep 10
-        kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
+        # Patching the deployment triggers a rollout; wait for it to converge before proceeding.
+        kubectl rollout status deployment/amazon-cloudwatch-observability-controller-manager -n amazon-cloudwatch --timeout=120s
       fi
 
       # Create sample app namespace


### PR DESCRIPTION
## Description

The dotnet k8s deploy script intermittently fails the **Deploy Operator and Sample App** step with:

```
timed out waiting for the condition on pods/amazon-cloudwatch-observability-controller-manager-<old-rs-hash>
timed out waiting for the condition on pods/cloudwatch-agent-...
timed out waiting for the condition on pods/fluent-bit-...
```

### Root cause

After patching the operator deployment's `--auto-instrumentation-dotnet-image` arg, the script ran:

```sh
kubectl delete pods --all -n amazon-cloudwatch
sleep 10
kubectl wait --for=condition=Ready pod --all -n amazon-cloudwatch
```

Patching the deployment's pod template **already triggers a rollout** (old ReplicaSet → new ReplicaSet). The subsequent `delete pods --all` then also needlessly restarts the `cloudwatch-agent` and `fluent-bit` daemonset pods, and `wait --all` races against the **terminating old-generation operator pod**, which never reaches `Ready`. This is timing-dependent, hence the flakiness (the test passed in some runs and failed in others with identical code).

Job logs confirmed the new operator pod reached Ready while the wait timed out on the old-generation pod that was being torn down.

### Fix

Replace the `delete pods --all` + `wait --all` pattern with `kubectl rollout status` on just the operator deployment. This waits for exactly that rollout to converge, without disturbing the daemonsets or racing on transient pods.

## Test plan

- [ ] Run dotnet-k8s test from an ADOT .NET main build and confirm the deploy step passes consistently.