### PR TITLE
Migrate .NET sample app AWS SDK clients to V4

### DIFF
--- a/sample-apps/dotnet/asp_frontend_service/asp_frontend_service.csproj
+++ b/sample-apps/dotnet/asp_frontend_service/asp_frontend_service.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.S3" Version="3.7.310.7" />
-    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.300.120" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.101.3" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.100.5" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/sample-apps/dotnet/asp_remote_service/asp_remote_service.csproj
+++ b/sample-apps/dotnet/asp_remote_service/asp_remote_service.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.7.304.31" />
+    <PackageReference Include="AWSSDK.Core" Version="4.0.100.6" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Issue description

The ADOT .NET distro is migrating from AWS SDK v3 to v4. The .NET E2E sample apps in this repo still referenced AWS SDK v3 packages, so main-build E2E runs targeting the migration exercised stale v3 clients.

## Description of changes

Migrate the .NET sample apps (frontend + remote service) from AWS SDK v3 to v4:

- `AWSSDK.Core` 3.7.304.31 → 4.0.100.6
- `AWSSDK.S3` 3.7.310.7 → 4.0.101.3
- `AWSSDK.SecurityToken` 3.7.300.120 → 4.0.100.5

The S3 APIs the sample apps use (`AmazonS3Client`, `GetBucketLocationRequest`, `GetBucketLocationAsync`) are unchanged in v4, so no application code changes were required. Both apps build cleanly against v4.

Related test-infrastructure changes (Windows CodeBuild buildspec, Lambda packaging fix, and parametrizing the single-version EC2 tests) are split into a separate follow-up PR.

## Rollback procedure

Yes, this can be safely reverted. The change only bumps NuGet package versions in two csproj files; reverting the commit restores the prior v3 packages with no data-loss risk.
