### PR TITLE
Delete intermediate per-mode artifacts from lambda perf tests

### DIFF
--- a/.github/workflows/node-lambda-layer-perf-test.yml
+++ b/.github/workflows/node-lambda-layer-perf-test.yml
@@ -206,7 +206,7 @@ jobs:
       run: |
         artifacts=$(gh api --paginate \
           "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
-          --jq '.artifacts[] | select(.name | test("^node-(full|lite|baseline)-results$")) | .id')
+          --jq '.artifacts[] | select(.name | test("^node-(full|lite|baseline)-results$|^node-lambda-build-artifacts$")) | .id')
         for id in $artifacts; do
           echo "Deleting artifact $id"
           gh api --method DELETE "/repos/${{ github.repository }}/actions/artifacts/$id"

--- a/.github/workflows/node-lambda-layer-perf-test.yml
+++ b/.github/workflows/node-lambda-layer-perf-test.yml
@@ -182,7 +182,8 @@ jobs:
     needs: [test]
     if: always()
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      actions: write
 
     steps:
     - name: Download all test results
@@ -198,3 +199,15 @@ jobs:
         name: js-performance-test-results
         path: results/
         retention-days: 90
+
+    - name: Delete intermediate artifacts
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        artifacts=$(gh api --paginate \
+          "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+          --jq '.artifacts[] | select(.name | test("^node-(full|lite|baseline)-results$")) | .id')
+        for id in $artifacts; do
+          echo "Deleting artifact $id"
+          gh api --method DELETE "/repos/${{ github.repository }}/actions/artifacts/$id"
+        done

--- a/.github/workflows/python-lambda-layer-perf-test.yml
+++ b/.github/workflows/python-lambda-layer-perf-test.yml
@@ -207,7 +207,7 @@ jobs:
       run: |
         artifacts=$(gh api --paginate \
           "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
-          --jq '.artifacts[] | select(.name | test("^python-(full|lite|baseline)-results$")) | .id')
+          --jq '.artifacts[] | select(.name | test("^python-(full|lite|baseline)-results$|^python-lambda-build-artifacts$")) | .id')
         for id in $artifacts; do
           echo "Deleting artifact $id"
           gh api --method DELETE "/repos/${{ github.repository }}/actions/artifacts/$id"

--- a/.github/workflows/python-lambda-layer-perf-test.yml
+++ b/.github/workflows/python-lambda-layer-perf-test.yml
@@ -183,7 +183,8 @@ jobs:
     needs: [test]
     if: always()
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      actions: write
 
     steps:
     - name: Download all test results
@@ -199,3 +200,15 @@ jobs:
         name: python-performance-test-results
         path: results/
         retention-days: 90
+
+    - name: Delete intermediate artifacts
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        artifacts=$(gh api --paginate \
+          "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+          --jq '.artifacts[] | select(.name | test("^python-(full|lite|baseline)-results$")) | .id')
+        for id in $artifacts; do
+          echo "Deleting artifact $id"
+          gh api --method DELETE "/repos/${{ github.repository }}/actions/artifacts/$id"
+        done


### PR DESCRIPTION
*Issue description:*
After parallelizing the python/node lambda layer performance tests (#662), each run uploads one artifact per test mode (`*-full-results`, `*-lite-results`, `*-baseline-results`) in addition to the combined `*-performance-test-results` artifact. This makes it ambiguous which artifact to download to get the full results.

*Description of changes:*
The `collect-results` job now deletes the intermediate per-mode artifacts after producing the combined artifact, so only the single combined results artifact remains for download. Deletion uses `gh api` (no new action dependency); the job's permissions are scoped to the minimal `actions: write` required to delete artifacts.

*Rollback procedure:*
Revert this commit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.