### PR TITLE
fix(validator): add service.instance.id to Python EC2 custom pipeline metrics

### DIFF
--- a/validator/src/main/resources/expected-data-template/python/ec2/default/aws-otel-custom-metrics.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/default/aws-otel-custom-metrics.mustache
@@ -181,6 +181,9 @@
     -
       name: telemetry.sdk.version
       value: ANY_VALUE
+    -
+      name: service.instance.id
+      value: ANY_VALUE
 -
   metricName: custom_pipeline_histogram
   namespace: {{metricNamespace}}
@@ -203,6 +206,9 @@
     -
       name: telemetry.sdk.version
       value: ANY_VALUE
+    -
+      name: service.instance.id
+      value: ANY_VALUE
 -
   metricName: custom_pipeline_gauge
   namespace: {{metricNamespace}}
@@ -224,4 +230,7 @@
       value: python
     -
       name: telemetry.sdk.version
+      value: ANY_VALUE
+    -
+      name: service.instance.id
       value: ANY_VALUE


### PR DESCRIPTION
## Problem
The "Validate custom metrics" step in the Python EC2 default E2E test is failing on the OTel 1.44.0 dependency bump.

## Cause
OTel SDK 1.44.0 enables `ServiceInstanceIdResourceDetector` by default, adding a `service.instance.id` resource attribute. This flows into the `custom_pipeline_*` EMF metric dimensions. The validator does an exact dimension-set match, so the metrics no longer match the expected template.

## Fix
Add `service.instance.id` (`ANY_VALUE`) to the three `custom_pipeline_*` metrics in the Python EC2 template. `agent_based_*` metrics go through the CloudWatch agent path and are unaffected.