### PR TITLE
fix(validator): add service.instance.id to Python EC2 agent_based custom metrics

### DIFF
--- a/validator/src/main/resources/expected-data-template/python/ec2/default/aws-otel-custom-metrics.mustache
+++ b/validator/src/main/resources/expected-data-template/python/ec2/default/aws-otel-custom-metrics.mustache
@@ -53,6 +53,9 @@
     -
       name: cloud.platform
       value: aws_ec2
+    -
+      name: service.instance.id
+      value: ANY_VALUE
 -
   metricName: agent_based_histogram
   namespace: {{metricNamespace}}
@@ -105,6 +108,9 @@
     -
       name: cloud.platform
       value: aws_ec2
+    -
+      name: service.instance.id
+      value: ANY_VALUE
 -
   metricName: agent_based_gauge
   namespace: {{metricNamespace}}
@@ -157,6 +163,9 @@
     -
       name: cloud.platform
       value: aws_ec2
+    -
+      name: service.instance.id
+      value: ANY_VALUE
       
 # Export pipeline metrics
 -


### PR DESCRIPTION
Follow-up to #667. OTel 1.44.0's `ServiceInstanceIdResourceDetector` adds `service.instance.id` at the resource level, so the `agent_based_*` metrics also gained the dimension (17 dims vs the template's 16) and fail the exact-match validation. #667 only fixed `custom_pipeline_*`. This adds `service.instance.id` (`ANY_VALUE`) to the three `agent_based_*` metrics too.