### PR TITLE
Add .NET Windows sample-app CodeBuild buildspec and fix Lambda packaging

### DIFF
--- a/.github/workflows/dotnet-ec2-asg-test.yml
+++ b/.github/workflows/dotnet-ec2-asg-test.yml
@@ -32,7 +32,7 @@ env:
   E2E_TEST_AWS_REGION: ${{ inputs.aws-region }}
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
-  SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/dotnet-sample-app.zip
+  SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/dotnet-sample-app-8.0.zip
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: /aws/application-signals/data
   ADOT_DISTRO_NAME: ${{ inputs.staging_distro_name }}

--- a/.github/workflows/dotnet-ec2-nuget-test.yml
+++ b/.github/workflows/dotnet-ec2-nuget-test.yml
@@ -32,7 +32,7 @@ env:
   E2E_TEST_AWS_REGION: ${{ inputs.aws-region }}
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
-  SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/dotnet-sample-app.zip
+  SAMPLE_APP_ZIP: s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/dotnet-sample-app-8.0.zip
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: /aws/application-signals/data
   ADOT_DISTRO_NAME: ${{ inputs.staging_distro_name }}

--- a/.github/workflows/dotnet-ec2-windows-test.yml
+++ b/.github/workflows/dotnet-ec2-windows-test.yml
@@ -32,7 +32,7 @@ env:
   E2E_TEST_AWS_REGION: ${{ inputs.aws-region }}
   E2E_TEST_ACCOUNT_ID: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ACCOUNT_ID }}
   E2E_TEST_ROLE_NAME: ${{ secrets.APPLICATION_SIGNALS_E2E_TEST_ROLE_NAME }}
-  SAMPLE_APP_ZIP: "aws s3 cp s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/dotnet-sample-app.zip ./dotnet-sample-app.zip"
+  SAMPLE_APP_ZIP: "aws s3 cp s3://aws-appsignals-sample-app-prod-${{ inputs.aws-region }}/dotnet-sample-app-8.0.zip ./dotnet-sample-app.zip"
   METRIC_NAMESPACE: ApplicationSignals
   LOG_GROUP_NAME: /aws/application-signals/data
   ADOT_DISTRO_NAME: ${{ inputs.staging_distro_name }}

--- a/.github/workflows/dotnet-sample-app-s3-deploy.yml
+++ b/.github/workflows/dotnet-sample-app-s3-deploy.yml
@@ -148,7 +148,7 @@ jobs:
 
       - name: Build Lambda Sample App
         shell: bash
-        run: dotnet lambda package -pl ./src/SimpleLambdaFunction
+        run: dotnet lambda package -pl ./src/SimpleLambdaFunction --framework net8.0
         working-directory: sample-applications/lambda-test-apps/SimpleLambdaFunction
       
       - name: Upload Lambda Sample App to S3

--- a/sample-apps/dotnet/codebuild/buildspec.yml
+++ b/sample-apps/dotnet/codebuild/buildspec.yml
@@ -1,0 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+version: 0.2
+phases:
+  pre_build:
+    commands:
+      - aws ecr get-login-password --region $env:AWS_DEFAULT_REGION | docker login --username AWS --password-stdin "$env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com"
+  build:
+    commands:
+      - cd sample-apps/dotnet
+      - docker build -f asp_frontend_service/Dockerfile_Windows -t "$env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/appsignals-dotnet-windows-main-service:latest" .
+      - docker build -f asp_remote_service/Dockerfile_Windows -t "$env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/appsignals-dotnet-windows-remote-service:latest" .
+  post_build:
+    commands:
+      - docker push "$env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/appsignals-dotnet-windows-main-service:latest"
+      - docker push "$env:ACCOUNT_ID.dkr.ecr.$env:AWS_DEFAULT_REGION.amazonaws.com/appsignals-dotnet-windows-remote-service:latest"


### PR DESCRIPTION
## Issue description

Several .NET E2E infrastructure issues, independent of the AWS SDK v4 migration (#665):

1. There was no working path to publish the .NET **Windows** sample-app container images to ECR. A CodeBuild project triggered by a GitHub webhook is responsible for this, but it was broken (missing/incorrect buildspec).
2. The .NET Lambda sample-app packaging step fails with `Missing required parameter: --framework`, because newer versions of `Amazon.Lambda.Tools` now require an explicit target framework when packaging a project with `-pl`.
3. The `asg`, `nuget`, and `windows` EC2 tests reference an orphaned, unversioned `dotnet-sample-app.zip` S3 key that no workflow produces anymore. The S3 deploy workflow only publishes versioned keys (`dotnet-sample-app-<version>.zip`), so these three tests pull a stale artifact.

## Description of changes

- **Add `sample-apps/dotnet/codebuild/buildspec.yml`** — buildspec for the CodeBuild project that builds and pushes the .NET Windows sample-app images (main + remote service) to ECR from their `Dockerfile_Windows` definitions. Uses PowerShell (`$env:VAR`) syntax to match the Windows CodeBuild environment.
- **Fix .NET Lambda packaging** — add `--framework net8.0` to the `dotnet lambda package` command in `dotnet-sample-app-s3-deploy.yml`, matching the `net8.0` output path the S3 upload step already reads from.
- **Pin `asg`/`nuget`/`windows` EC2 tests to the versioned zip** — point them at `dotnet-sample-app-8.0.zip` (the key the S3 deploy workflow actually produces) instead of the orphaned unversioned key. These three tests run only on .NET 8.0 and are intentionally not parametrized (their unique surfaces — ASG resource detection, NuGet delivery, Windows — are either not runtime-sensitive or already covered by the parametrized `default` test).

## Rollback procedure

Yes, safe to revert. The buildspec is a new additive file consumed only by the Windows CodeBuild project; the `--framework` change makes an implicit default explicit; and the zip-key change points at an artifact that is actually published. Reverting the commit has no data-loss risk.
