### PR TITLE
Parametrize .NET Linux EKS test across .NET versions

### DIFF
--- a/.github/workflows/dotnet-eks-test.yml
+++ b/.github/workflows/dotnet-eks-test.yml
@@ -435,8 +435,8 @@ jobs:
             -var="eks_cluster_name=${{ inputs.test-cluster-name }}" \
             -var="test_namespace=${{ env.DOTNET_SAMPLE_APP_NAMESPACE }}" \
             -var="service_account_aws_access=service-account-${{ env.TESTING_ID }}" \
-            -var="dotnet_app_image=${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_FE_SA_IMG }}" \
-            -var="dotnet_remote_app_image=${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_RE_SA_IMG }}"
+            -var="dotnet_app_image=${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_FE_SA_IMG }}:v${{ env.DOTNET_VERSION }}" \
+            -var="dotnet_remote_app_image=${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_RE_SA_IMG }}:v${{ env.DOTNET_VERSION }}"
 
       - name: Remove aws access service account
         if: always()

--- a/.github/workflows/dotnet-eks-test.yml
+++ b/.github/workflows/dotnet-eks-test.yml
@@ -23,6 +23,11 @@ on:
       caller-workflow-name:
         required: true
         type: string
+      dotnet-version:
+        description: "Currently support version 8.0, 9.0, 10.0"
+        required: false
+        type: string
+        default: '8.0'
     outputs:
       job-started:
         value: ${{ jobs.dotnet-eks.outputs.job-started }}
@@ -44,6 +49,7 @@ env:
   ADOT_IMAGE_NAME: ${{ inputs.adot-image-name }}
   CW_AGENT_OPERATOR_TAG: ${{ inputs.cw-agent-operator-tag }}
   REPOSITORY_NAME: ${{ github.event.repository.name }}
+  DOTNET_VERSION: ${{ inputs.dotnet-version }}
 
 jobs:
   dotnet-eks:
@@ -181,8 +187,8 @@ jobs:
 
       - name: Set Sample App Image
         run: |
-          echo MAIN_SAMPLE_APP_IMAGE_ARN="${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.DOTNET_MAIN_SAMPLE_APP_IMAGE }}" >> "$GITHUB_ENV"
-          echo REMOTE_SAMPLE_APP_IMAGE_ARN="${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.DOTNET_REMOTE_SAMPLE_APP_IMAGE }}" >> "$GITHUB_ENV"
+          echo MAIN_SAMPLE_APP_IMAGE_ARN="${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.DOTNET_MAIN_SAMPLE_APP_IMAGE }}:v${{ env.DOTNET_VERSION }}" >> "$GITHUB_ENV"
+          echo REMOTE_SAMPLE_APP_IMAGE_ARN="${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.DOTNET_REMOTE_SAMPLE_APP_IMAGE }}:v${{ env.DOTNET_VERSION }}" >> "$GITHUB_ENV"
 
       - name: Deploy sample app via terraform and wait for the endpoint to come online
         id: deploy-dotnet-app

--- a/.github/workflows/dotnet-k8s-test.yml
+++ b/.github/workflows/dotnet-k8s-test.yml
@@ -115,9 +115,9 @@ jobs:
         working-directory: terraform/dotnet/k8s/deploy/resources
         run: |
           sed -i 's#\${TESTING_ID}#${{ env.TESTING_ID }}#' dotnet-frontend-service-depl.yaml
-          sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.DOTNET_MAIN_SAMPLE_APP_IMAGE }}#' dotnet-frontend-service-depl.yaml
+          sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.DOTNET_MAIN_SAMPLE_APP_IMAGE }}:v8.0#' dotnet-frontend-service-depl.yaml
           sed -i 's#\${TESTING_ID}#${{ env.TESTING_ID }}#' dotnet-remote-service-depl.yaml
-          sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.DOTNET_REMOTE_SAMPLE_APP_IMAGE }}#' dotnet-remote-service-depl.yaml
+          sed -i 's#\${IMAGE}#${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.DOTNET_REMOTE_SAMPLE_APP_IMAGE }}:v8.0#' dotnet-remote-service-depl.yaml
           aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key dotnet-frontend-service-depl-${{ env.TESTING_ID }}.yaml --body dotnet-frontend-service-depl.yaml
           aws s3api put-object --bucket aws-appsignals-sample-app-prod-${{ env.E2E_TEST_AWS_REGION }} --key dotnet-remote-service-depl-${{ env.TESTING_ID }}.yaml --body dotnet-remote-service-depl.yaml
 

--- a/.github/workflows/dotnet-sample-app-ecr-deploy.yml
+++ b/.github/workflows/dotnet-sample-app-ecr-deploy.yml
@@ -51,19 +51,15 @@ jobs:
         run: |
           docker compose build
 
-      # Push the default (8.0) canary image both untagged (for backwards compatibility) and
-      # tagged :v8.0 so the version-parametrized EKS test can resolve it by version tag.
+      # Push the default (8.0) canary image tagged :v8.0 to all regions so the version-parametrized
+      # EKS and k8s tests can resolve it by version tag, matching the Java/Python pattern.
       - name: Upload Main Service Image
         run: |
-          docker tag dotnetsampleapp/frontend-service ${{ env.ACCOUNT_ID }}.dkr.ecr.${{ matrix.aws-region }}.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_FE_SA_IMG }}
-          docker push ${{ env.ACCOUNT_ID }}.dkr.ecr.${{ matrix.aws-region }}.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_FE_SA_IMG }}
           docker tag dotnetsampleapp/frontend-service ${{ env.ACCOUNT_ID }}.dkr.ecr.${{ matrix.aws-region }}.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_FE_SA_IMG }}:v8.0
           docker push ${{ env.ACCOUNT_ID }}.dkr.ecr.${{ matrix.aws-region }}.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_FE_SA_IMG }}:v8.0
 
       - name: Upload Remote Service Image
         run: |
-          docker tag dotnetsampleapp/remote-service ${{ env.ACCOUNT_ID }}.dkr.ecr.${{ matrix.aws-region }}.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_RE_SA_IMG }}
-          docker push ${{ env.ACCOUNT_ID }}.dkr.ecr.${{ matrix.aws-region }}.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_RE_SA_IMG }}
           docker tag dotnetsampleapp/remote-service ${{ env.ACCOUNT_ID }}.dkr.ecr.${{ matrix.aws-region }}.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_RE_SA_IMG }}:v8.0
           docker push ${{ env.ACCOUNT_ID }}.dkr.ecr.${{ matrix.aws-region }}.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_RE_SA_IMG }}:v8.0
 

--- a/.github/workflows/dotnet-sample-app-ecr-deploy.yml
+++ b/.github/workflows/dotnet-sample-app-ecr-deploy.yml
@@ -51,12 +51,70 @@ jobs:
         run: |
           docker compose build
 
+      # Push the default (8.0) canary image both untagged (for backwards compatibility) and
+      # tagged :v8.0 so the version-parametrized EKS test can resolve it by version tag.
       - name: Upload Main Service Image
         run: |
           docker tag dotnetsampleapp/frontend-service ${{ env.ACCOUNT_ID }}.dkr.ecr.${{ matrix.aws-region }}.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_FE_SA_IMG }}
           docker push ${{ env.ACCOUNT_ID }}.dkr.ecr.${{ matrix.aws-region }}.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_FE_SA_IMG }}
-      
+          docker tag dotnetsampleapp/frontend-service ${{ env.ACCOUNT_ID }}.dkr.ecr.${{ matrix.aws-region }}.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_FE_SA_IMG }}:v8.0
+          docker push ${{ env.ACCOUNT_ID }}.dkr.ecr.${{ matrix.aws-region }}.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_FE_SA_IMG }}:v8.0
+
       - name: Upload Remote Service Image
         run: |
           docker tag dotnetsampleapp/remote-service ${{ env.ACCOUNT_ID }}.dkr.ecr.${{ matrix.aws-region }}.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_RE_SA_IMG }}
           docker push ${{ env.ACCOUNT_ID }}.dkr.ecr.${{ matrix.aws-region }}.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_RE_SA_IMG }}
+          docker tag dotnetsampleapp/remote-service ${{ env.ACCOUNT_ID }}.dkr.ecr.${{ matrix.aws-region }}.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_RE_SA_IMG }}:v8.0
+          docker push ${{ env.ACCOUNT_ID }}.dkr.ecr.${{ matrix.aws-region }}.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_RE_SA_IMG }}:v8.0
+
+  # Build and push the non-canary .NET versions, tagged :v<version>, to us-east-1 only.
+  # These are used by the ADOT .NET main build to run the EKS test across multiple runtimes.
+  upload-versioned-images:
+    strategy:
+      fail-fast: false
+      matrix:
+        dotnet-version: [ '9.0', '10.0' ]
+    runs-on: ubuntu-latest
+    env:
+      DOTNET_VERSION: ${{ matrix.dotnet-version }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0
+        with:
+          role-to-assume: ${{ secrets.E2E_IAD_TEST_ACCOUNT_ARN }}
+          aws-region: us-east-1
+
+      - name: Retrieve account
+        uses: aws-actions/aws-secretsmanager-get-secrets@a9a7eb4e2f2871d30dc5b892576fde60a2ecc802 # v2.0.10
+        with:
+          secret-ids:
+            ACCOUNT_ID, region-account/us-east-1
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0
+        with:
+          role-to-assume: arn:aws:iam::${{ env.ACCOUNT_ID }}:role/${{ secrets.E2E_TEST_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+
+      - name: Docker compose build
+        working-directory: sample-apps/dotnet
+        run: |
+          docker compose build
+
+      - name: Upload Main Service Image
+        run: |
+          docker tag dotnetsampleapp/frontend-service ${{ env.ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_FE_SA_IMG }}:v${{ env.DOTNET_VERSION }}
+          docker push ${{ env.ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_FE_SA_IMG }}:v${{ env.DOTNET_VERSION }}
+
+      - name: Upload Remote Service Image
+        run: |
+          docker tag dotnetsampleapp/remote-service ${{ env.ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_RE_SA_IMG }}:v${{ env.DOTNET_VERSION }}
+          docker push ${{ env.ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com/${{ secrets.APP_SIGNALS_DOTNET_E2E_RE_SA_IMG }}:v${{ env.DOTNET_VERSION }}

--- a/sample-apps/dotnet/asp_frontend_service/Dockerfile
+++ b/sample-apps/dotnet/asp_frontend_service/Dockerfile
@@ -1,9 +1,10 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+ARG DOTNET_VERSION=8.0
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build-env
 WORKDIR /app
 COPY . ./
 RUN dotnet publish asp_frontend_service/*.csproj -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled
+FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION}-noble-chiseled
 WORKDIR /app
 EXPOSE 8080
 COPY --from=build-env /app/out .

--- a/sample-apps/dotnet/asp_remote_service/Dockerfile
+++ b/sample-apps/dotnet/asp_remote_service/Dockerfile
@@ -1,9 +1,10 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
+ARG DOTNET_VERSION=8.0
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS build-env
 WORKDIR /app
 COPY . ./
 RUN dotnet publish asp_remote_service/*.csproj -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble-chiseled
+FROM mcr.microsoft.com/dotnet/aspnet:${DOTNET_VERSION}-noble-chiseled
 WORKDIR /app
 ENV ASPNETCORE_URLS=http://+:8081
 EXPOSE 8081

--- a/sample-apps/dotnet/docker-compose.yaml
+++ b/sample-apps/dotnet/docker-compose.yaml
@@ -7,6 +7,8 @@ services:
     build:
       context: .
       dockerfile: asp_frontend_service/Dockerfile
+      args:
+        DOTNET_VERSION: ${DOTNET_VERSION:-8.0}
     container_name: asp_frontend_service
     restart: always
     ports:
@@ -17,6 +19,8 @@ services:
     build:
       context: .
       dockerfile: asp_remote_service/Dockerfile
+      args:
+        DOTNET_VERSION: ${DOTNET_VERSION:-8.0}
     container_name: asp_remote_service
     restart: always
     ports:


### PR DESCRIPTION
## Issue description

Unlike Java and Python, the .NET **Linux EKS** E2E test runs against only a single, hardcoded .NET version. Java and Python fan their EKS test out across every supported runtime (via version-tagged sample-app images pulled as `:v<version>`), but .NET's EKS test pulls a single untagged image, so there's no way to exercise the ADOT .NET distro's container instrumentation across .NET 8/9/10.

This aligns the .NET Linux EKS test with the Java/Python pattern. (Windows EKS is intentionally left out — it uses the CodeBuild image path and has no cross-language precedent.)

## Description of changes

- **Parametrize the sample-app Dockerfiles** — introduce a `DOTNET_VERSION` build `ARG` (default `8.0`) in both `asp_frontend_service/Dockerfile` and `asp_remote_service/Dockerfile`, so the SDK and ASP.NET runtime base images are selected by version.
- **Thread the version through docker-compose** — pass `DOTNET_VERSION` (defaulting to `8.0`) as a build arg, so `docker compose build` can target a specific runtime.
- **Publish version-tagged ECR images** (`dotnet-sample-app-ecr-deploy.yml`):
  - The existing all-regions canary build (8.0) is now also pushed with a `:v8.0` tag (in addition to the untagged image, preserving current behavior).
  - A new `upload-versioned-images` job builds `9.0` and `10.0` and pushes them tagged `:v<version>` to us-east-1 (where the main build runs), mirroring the Java deploy pattern.
- **Parametrize the Linux EKS test** (`dotnet-eks-test.yml`) — add an optional `dotnet-version` input (default `8.0`) and resolve the sample-app image ARNs by `:v<version>` tag.

## Backwards compatibility

The `dotnet-version` input defaults to `8.0`, and the `:v8.0` tag is pushed to all regions, so existing callers (including the canary) continue to work unchanged. The .NET main build will only run EKS across multiple versions once the caller in `aws-otel-dotnet-instrumentation`'s `application-signals-e2e-test.yml` is updated to fan out the `dotnet-eks-test.yml` invocation per version (separate change in that repo).

## Testing

Validated `docker compose config` resolves the `DOTNET_VERSION` build arg correctly (default `8.0`, override honored). Confirmed the `mcr.microsoft.com/dotnet/{sdk,aspnet}` base image tags exist for 8.0/9.0/10.0.

## Rollback procedure

Yes, safe to revert. Changes are additive (new ARG with a default, a new deploy job, an optional workflow input defaulting to the prior behavior). Reverting restores the single-version path with no data-loss risk.
