### PR TITLE
fix(testing): parallelize EKS tests for python

### DIFF
--- a/.github/workflows/python-eks-service-events-test.yml
+++ b/.github/workflows/python-eks-service-events-test.yml
@@ -299,29 +299,32 @@ jobs:
             echo PATCH_IMAGE_ARN="${{ env.ADOT_IMAGE_NAME }}" >> "$GITHUB_ENV"
           fi
 
-      # For the python repo, idempotently patch the operator's ADOT python image instead of using
-      # patch_image_and_check_diff. service-events-eks runs after the parallel eks-py* jobs, which
-      # already patched the shared operator to this same staging image; the shared action asserts the
-      # image *changed* and exits 1 when it is already correct. It also must NOT delete/reinstall the
-      # shared addon (doing so breaks the cloudwatch-agent's IRSA role binding, causing agent
-      # logs:PutLogEvents AccessDenied and dropping ALL App Signals telemetry cluster-wide). So we only
-      # patch the operator arg if it differs and restart THIS namespace's pods to pick it up. Other
-      # repos (operator) keep the shared action below.
+      # Patch the operator's ADOT python image only if it differs, then restart this namespace's pods.
       - name: Patch operator python image (idempotent) and restart sample app
         id: patch-image
         if: ${{ env.ADOT_IMAGE_NAME != '' && env.REPOSITORY_NAME == 'aws-otel-python-instrumentation' }}
         run: |
           . ${{ env.TEST_RESOURCES_FOLDER }}/.github/workflows/util/execute_and_retry.sh
+
+           # --- Patch the shared operator's python image (retry: siblings may write it concurrently) ---
           patched=0
           for patch_attempt in 1 2 3 4 5 6; do
+            # Read the operator's currently-configured python image from its container args
+
             CURRENT_PY_IMAGE=$(kubectl get deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager \
               -o jsonpath='{range .spec.template.spec.containers[0].args[*]}{.}{"\n"}{end}' \
               | sed -n 's/^--auto-instrumentation-python-image=//p')
+
+            # Already the target image (e.g. an eks-py* job set it) -> nothing to do
+
             if [ "$CURRENT_PY_IMAGE" = "${{ env.PATCH_IMAGE_ARN }}" ]; then
               echo "Operator python image already at target (${{ env.PATCH_IMAGE_ARN }})."
               patched=1
               break
             fi
+            
+            # Rewrite just the --auto-instrumentation-python-image arg and apply
+
             echo "Attempt $patch_attempt: patching '$CURRENT_PY_IMAGE' -> '${{ env.PATCH_IMAGE_ARN }}'"
             if kubectl get deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager -o json \
                 | jq '.spec.template.spec.containers[0].args |= map(if test("^--auto-instrumentation-python-image=") then "--auto-instrumentation-python-image=${{ env.PATCH_IMAGE_ARN }}" else . end)' \
@@ -334,11 +337,15 @@ jobs:
             sleep 10
           done
           if [ "$patched" -ne 1 ]; then echo "Failed to set operator python image."; exit 1; fi
-
+          
+          # Wait for the operator to roll out with the new arg before restarting app pods
           kubectl -n amazon-cloudwatch rollout status \
             deployment/amazon-cloudwatch-observability-controller-manager --timeout=180s \
             || echo "Operator rollout wait timed out; continuing (injection is verified below)."
-
+          
+          # --- Restart this namespace's pods and confirm the target image was actually injected ---
+          # A pod can come up Ready but uninjected if the webhook wasn't serving yet, so verify + retry.
+          
           inject_verified=0
           for inject_attempt in 1 2 3 4 5; do
             execute_and_retry 2 "kubectl delete pods --all -n ${{ env.SAMPLE_APP_NAMESPACE }}" "" 60

--- a/.github/workflows/python-eks-service-events-test.yml
+++ b/.github/workflows/python-eks-service-events-test.yml
@@ -214,6 +214,31 @@ jobs:
           max_retry: 6
           sleep_time: 60
 
+      # service-events runs LAST, after all parallel eks-py* jobs (see caller `needs:`), which leave
+      # the shared amazon-cloudwatch-observability addon installed with the operator's ADOT python
+      # image patched to the staging build. enable-app-signals.sh is idempotent and will NOT reset an
+      # already-installed addon, so the operator would stay on the staging image and the downstream
+      # patch_image_and_check_diff step would fail ("ADOT image did not change"). Since this job runs
+      # exclusively (no parallel job is alive), fully delete the addon here and wait for it to be gone;
+      # the Deploy step's enable-app-signals.sh then performs a clean install with the operator back on
+      # its default image, restoring the default -> staging transition the diff check expects. Safe only
+      # because this job is gated on all eks-py* jobs.
+      - name: Rebuild Application Signals addon from scratch (operator back to default image)
+        if: ${{ env.ADOT_IMAGE_NAME != '' }}
+        continue-on-error: true
+        run: |
+          if aws eks describe-addon --cluster-name ${{ env.CLUSTER_NAME }} \
+               --addon-name amazon-cloudwatch-observability --region ${{ env.E2E_TEST_AWS_REGION }} >/dev/null 2>&1; then
+            echo "Deleting existing amazon-cloudwatch-observability addon so it reinstalls at the default image."
+            aws eks delete-addon --cluster-name ${{ env.CLUSTER_NAME }} \
+              --addon-name amazon-cloudwatch-observability --region ${{ env.E2E_TEST_AWS_REGION }} || true
+            echo "Waiting for addon deletion to complete..."
+            aws eks wait addon-deleted --cluster-name ${{ env.CLUSTER_NAME }} \
+              --addon-name amazon-cloudwatch-observability --region ${{ env.E2E_TEST_AWS_REGION }} || true
+          else
+            echo "Addon not present; enable-app-signals.sh will install it fresh."
+          fi
+
       - name: Deploy sample app via terraform and install Application Signals
         id: deploy-python-app
         working-directory: terraform/python/eks/service-events

--- a/.github/workflows/python-eks-service-events-test.yml
+++ b/.github/workflows/python-eks-service-events-test.yml
@@ -214,31 +214,6 @@ jobs:
           max_retry: 6
           sleep_time: 60
 
-      # service-events runs LAST, after all parallel eks-py* jobs (see caller `needs:`), which leave
-      # the shared amazon-cloudwatch-observability addon installed with the operator's ADOT python
-      # image patched to the staging build. enable-app-signals.sh is idempotent and will NOT reset an
-      # already-installed addon, so the operator would stay on the staging image and the downstream
-      # patch_image_and_check_diff step would fail ("ADOT image did not change"). Since this job runs
-      # exclusively (no parallel job is alive), fully delete the addon here and wait for it to be gone;
-      # the Deploy step's enable-app-signals.sh then performs a clean install with the operator back on
-      # its default image, restoring the default -> staging transition the diff check expects. Safe only
-      # because this job is gated on all eks-py* jobs.
-      - name: Rebuild Application Signals addon from scratch (operator back to default image)
-        if: ${{ env.ADOT_IMAGE_NAME != '' }}
-        continue-on-error: true
-        run: |
-          if aws eks describe-addon --cluster-name ${{ env.CLUSTER_NAME }} \
-               --addon-name amazon-cloudwatch-observability --region ${{ env.E2E_TEST_AWS_REGION }} >/dev/null 2>&1; then
-            echo "Deleting existing amazon-cloudwatch-observability addon so it reinstalls at the default image."
-            aws eks delete-addon --cluster-name ${{ env.CLUSTER_NAME }} \
-              --addon-name amazon-cloudwatch-observability --region ${{ env.E2E_TEST_AWS_REGION }} || true
-            echo "Waiting for addon deletion to complete..."
-            aws eks wait addon-deleted --cluster-name ${{ env.CLUSTER_NAME }} \
-              --addon-name amazon-cloudwatch-observability --region ${{ env.E2E_TEST_AWS_REGION }} || true
-          else
-            echo "Addon not present; enable-app-signals.sh will install it fresh."
-          fi
-
       - name: Deploy sample app via terraform and install Application Signals
         id: deploy-python-app
         working-directory: terraform/python/eks/service-events
@@ -324,9 +299,66 @@ jobs:
             echo PATCH_IMAGE_ARN="${{ env.ADOT_IMAGE_NAME }}" >> "$GITHUB_ENV"
           fi
 
-      - name: Patch Image and Check Diff
+      # For the python repo, idempotently patch the operator's ADOT python image instead of using
+      # patch_image_and_check_diff. service-events-eks runs after the parallel eks-py* jobs, which
+      # already patched the shared operator to this same staging image; the shared action asserts the
+      # image *changed* and exits 1 when it is already correct. It also must NOT delete/reinstall the
+      # shared addon (doing so breaks the cloudwatch-agent's IRSA role binding, causing agent
+      # logs:PutLogEvents AccessDenied and dropping ALL App Signals telemetry cluster-wide). So we only
+      # patch the operator arg if it differs and restart THIS namespace's pods to pick it up. Other
+      # repos (operator) keep the shared action below.
+      - name: Patch operator python image (idempotent) and restart sample app
         id: patch-image
-        if: ${{ env.ADOT_IMAGE_NAME != '' || env.CW_AGENT_OPERATOR_TAG != '' }}
+        if: ${{ env.ADOT_IMAGE_NAME != '' && env.REPOSITORY_NAME == 'aws-otel-python-instrumentation' }}
+        run: |
+          . ${{ env.TEST_RESOURCES_FOLDER }}/.github/workflows/util/execute_and_retry.sh
+          patched=0
+          for patch_attempt in 1 2 3 4 5 6; do
+            CURRENT_PY_IMAGE=$(kubectl get deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager \
+              -o jsonpath='{range .spec.template.spec.containers[0].args[*]}{.}{"\n"}{end}' \
+              | sed -n 's/^--auto-instrumentation-python-image=//p')
+            if [ "$CURRENT_PY_IMAGE" = "${{ env.PATCH_IMAGE_ARN }}" ]; then
+              echo "Operator python image already at target (${{ env.PATCH_IMAGE_ARN }})."
+              patched=1
+              break
+            fi
+            echo "Attempt $patch_attempt: patching '$CURRENT_PY_IMAGE' -> '${{ env.PATCH_IMAGE_ARN }}'"
+            if kubectl get deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager -o json \
+                | jq '.spec.template.spec.containers[0].args |= map(if test("^--auto-instrumentation-python-image=") then "--auto-instrumentation-python-image=${{ env.PATCH_IMAGE_ARN }}" else . end)' \
+                | kubectl apply -f - ; then
+              echo "Patch applied on attempt $patch_attempt."
+              patched=1
+              break
+            fi
+            echo "Patch attempt $patch_attempt lost a concurrent write; retrying..."
+            sleep 10
+          done
+          if [ "$patched" -ne 1 ]; then echo "Failed to set operator python image."; exit 1; fi
+
+          kubectl -n amazon-cloudwatch rollout status \
+            deployment/amazon-cloudwatch-observability-controller-manager --timeout=180s \
+            || echo "Operator rollout wait timed out; continuing (injection is verified below)."
+
+          inject_verified=0
+          for inject_attempt in 1 2 3 4 5; do
+            execute_and_retry 2 "kubectl delete pods --all -n ${{ env.SAMPLE_APP_NAMESPACE }}" "" 60
+            execute_and_retry 2 "kubectl wait --for=condition=Ready --request-timeout '5m' pod --all -n ${{ env.SAMPLE_APP_NAMESPACE }}" "" 10
+            INJECTED_IMAGE=$(kubectl get pod -n ${{ env.SAMPLE_APP_NAMESPACE }} --selector=app=python-app \
+              -o jsonpath='{.items[0].spec.initContainers[?(@.name=="opentelemetry-auto-instrumentation-python")].image}' 2>/dev/null || true)
+            if [ "$INJECTED_IMAGE" = "${{ env.PATCH_IMAGE_ARN }}" ]; then
+              echo "Instrumentation injected with target image on attempt $inject_attempt: $INJECTED_IMAGE"
+              inject_verified=1
+              break
+            fi
+            echo "Not injected with target image yet on attempt $inject_attempt (got: '${INJECTED_IMAGE:-none}'); retrying..."
+            sleep 20
+          done
+          if [ "$inject_verified" -ne 1 ]; then echo "Instrumentation never injected with target image."; exit 1; fi
+
+      # Other repos (e.g. amazon-cloudwatch-agent-operator) keep the shared patch+diff action.
+      - name: Patch Image and Check Diff
+        id: patch-image-operator
+        if: ${{ env.CW_AGENT_OPERATOR_TAG != '' && env.REPOSITORY_NAME != 'aws-otel-python-instrumentation' }}
         uses: ./.github/workflows/actions/patch_image_and_check_diff
         with:
           repository: ${{ env.REPOSITORY_NAME }}

--- a/.github/workflows/python-eks-test.yml
+++ b/.github/workflows/python-eks-test.yml
@@ -66,13 +66,21 @@ jobs:
 
       - name: Generate testing id and python sample app namespace
         run: |
-          echo TESTING_ID="${{ github.job }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}" >> "$GITHUB_ENV"
-          echo SAMPLE_APP_NAMESPACE="ns-${{ github.run_id }}-${{ github.run_number }}" >> "$GITHUB_ENV"
+          # Sanitize the python version for a DNS-1123 namespace label (no dots).
+          PY_VERSION_SLUG="py$(echo '${{ env.PYTHON_VERSION }}' | tr -d '.')"
+          echo TESTING_ID="${{ github.job }}-${PY_VERSION_SLUG}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}" >> "$GITHUB_ENV"
+          # Namespace is unique per parallel version job. The reusable workflow's github.job is
+          # identical ("python-eks") across all version callers, so the version slug disambiguates
+          # concurrent runs sharing the cluster.
+          echo SAMPLE_APP_NAMESPACE="ns-${PY_VERSION_SLUG}-${{ github.run_id }}-${{ github.run_number }}" >> "$GITHUB_ENV"
           
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: 'aws-observability/aws-application-signals-test-framework'
-          ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
+          # TESTING: pin the checked-out terraform/scripts to the feature branch instead of 'main'
+          # so the python_version variable and other EKS-test-fix changes are present. REVERT to
+          # the original `... && 'main' || github.ref` line before merge.
+          ref: ${{ inputs.caller-workflow-name == 'main-build' && 'EKS-test-fix' || github.ref }}
           fetch-depth: 0
 
         # We initialize Gradlew Daemon early on during the workflow because sometimes initialization
@@ -148,11 +156,13 @@ jobs:
         run: |
           echo "${{ github.workspace }}/eksctl" >> "$GITHUB_PATH"
 
-      # This step deletes lingering resources from previous test runs
-      - name: Delete all sample app namespaces
+      # Delete only THIS version's namespace from a prior run. Do NOT bulk-delete all ns-* namespaces:
+      # parallel version jobs share the cluster, and deleting all ns-* would destroy other running
+      # jobs' namespaces mid-test.
+      - name: Delete this version's sample app namespace if it lingers
         continue-on-error: true
         timeout-minutes: 5
-        run: kubectl get namespace | awk '/^ns-[0-9]+-[0-9]+/{print $1}' | xargs kubectl delete namespace
+        run: kubectl delete namespace "${{ env.SAMPLE_APP_NAMESPACE }}" --ignore-not-found
 
       - name: Create role for AWS access from the sample app
         id: create_service_account
@@ -194,6 +204,18 @@ jobs:
             echo MAIN_SAMPLE_APP_IMAGE_ARN="${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.PYTHON_MAIN_SAMPLE_APP_IMAGE }}:v${{ env.PYTHON_VERSION }}" >> "$GITHUB_ENV"
             echo REMOTE_SAMPLE_APP_IMAGE_ARN="${{ env.ACCOUNT_ID }}.dkr.ecr.${{ env.E2E_TEST_AWS_REGION }}.amazonaws.com/${{ env.PYTHON_REMOTE_SAMPLE_APP_IMAGE }}:v${{ env.PYTHON_VERSION }}" >> "$GITHUB_ENV"
 
+      # The ADOT image this test injects. Set BEFORE deploy so the Instrumentation CR created in the
+      # deploy step can reference it. For the python repo this is the staging image under test.
+      - name: Determine ADOT image to inject
+        run: |
+          if [ "${{ env.REPOSITORY_NAME }}" = "amazon-cloudwatch-agent" ]; then
+            echo PATCH_IMAGE_ARN="${{ secrets.AWS_ECR_PRIVATE_REGISTRY }}/cwagent-integration-test:${{ github.sha }}" >> "$GITHUB_ENV"
+          elif [ "${{ env.REPOSITORY_NAME }}" = "amazon-cloudwatch-agent-operator" ]; then
+            echo PATCH_IMAGE_ARN="${{ vars.ECR_OPERATOR_STAGING_REPO }}:${{ env.CW_AGENT_OPERATOR_TAG }}" >> "$GITHUB_ENV"
+          elif [ "${{ env.REPOSITORY_NAME }}" = "aws-otel-python-instrumentation" ]; then
+            echo PATCH_IMAGE_ARN="${{ env.ADOT_IMAGE_NAME }}" >> "$GITHUB_ENV"
+          fi
+
       - name: Deploy sample app via terraform and wait for the endpoint to come online
         id: deploy-python-app
         working-directory: terraform/python/eks
@@ -208,6 +230,7 @@ jobs:
             echo "Attempt $retry_counter"
             deployment_failed=0
             terraform apply -auto-approve \
+              -var='python_version=${{ env.PYTHON_VERSION }}'\
               -var='test_id=${{ env.TESTING_ID }}' \
               -var='aws_region=${{ env.E2E_TEST_AWS_REGION }}' \
               -var='kube_directory_path=${{ github.workspace }}/.kube' \
@@ -226,41 +249,119 @@ jobs:
 
             # If the deployment_failed is still 0, then the terraform deployment succeeded and now try to connect to the endpoint 
             # after installing Application Signals. Attempts to connect will be made for up to 10 minutes
-            if [ $deployment_failed -eq 0 ]; then          
-              echo "Installing application signals to the sample app"
+            if [ $deployment_failed -eq 0 ]; then
+              echo "Ensuring Application Signals is enabled on the cluster"
               . ${{ env.TEST_RESOURCES_FOLDER }}/.github/workflows/util/execute_and_retry.sh
+              # Install the cluster-wide Application Signals addon. This is idempotent: the first
+              # parallel version job installs it, the rest see it already present. We intentionally do
+              # NOT pass a per-job clean-up command here — deleting the shared addon would break other
+              # parallel jobs. The addon persists on the (long-lived) test cluster.
               execute_and_retry 3 \
               "${{ env.TEST_RESOURCES_FOLDER }}/enablement-script/enable-app-signals.sh \
               ${{ inputs.test-cluster-name }} \
               ${{ env.E2E_TEST_AWS_REGION }} \
               ${{ env.SAMPLE_APP_NAMESPACE }}" \
-              "${{ env.TEST_RESOURCES_FOLDER }}/enablement-script/clean-app-signals.sh \
-              ${{ inputs.test-cluster-name }} \
-              ${{ env.E2E_TEST_AWS_REGION }} \
-              ${{ env.SAMPLE_APP_NAMESPACE }} && \
-              aws eks update-kubeconfig --name ${{ inputs.test-cluster-name }} --region ${{ env.E2E_TEST_AWS_REGION }}" \
+              "" \
               60
-          
+
               aws eks update-kubeconfig --region ${{ env.E2E_TEST_AWS_REGION }} --name ${{ env.CLUSTER_NAME }}
-                  
-              execute_and_retry 2 "kubectl delete pods --all -n ${{ env.SAMPLE_APP_NAMESPACE }}" "" 60
-              execute_and_retry 2 "kubectl wait --for=condition=Ready --request-timeout '5m' pod --all -n ${{ env.SAMPLE_APP_NAMESPACE }}" "" 10
+
+              # enable-app-signals.sh returns as soon as the addon is *requested*, while the addon is
+              # still CREATING. The operator (which performs injection) is deployed by the addon, so it
+              # is not serving until the addon reaches ACTIVE (typically 2-5 min). Wait for ACTIVE
+              # before touching the operator — otherwise the patch/rollout below races the install.
+              execute_and_retry 30 \
+                "[ \"\$(aws eks describe-addon --cluster-name ${{ env.CLUSTER_NAME }} --addon-name amazon-cloudwatch-observability --region ${{ env.E2E_TEST_AWS_REGION }} --query 'addon.status' --output text)\" = ACTIVE ]" \
+                "" 20
+
+              # Inject THIS test's ADOT image the same way the sequential (main) flow does: patch the
+              # operator's cluster-wide --auto-instrumentation-python-image arg. App Signals telemetry
+              # (Latency/Error/Fault metrics + EMF logs) comes from the operator's auto-monitor
+              # applying App Signals mode to injected pods — NOT from a per-namespace Instrumentation
+              # CR. A hand-built CR with empty env bypasses that and yields plain OTel tracing with no
+              # App Signals data, which is why custom CRs produced empty validator results.
+              #
+              # This is parallel-safe: every python version job injects the SAME adot-image-name
+              # (the single staging image under test; the version differences live in the sample-app
+              # image, not the instrumentation image). So the shared operator arg is a value all jobs
+              # agree on, exactly like the shared addon. We only patch + roll out if the arg is not
+              # already the target value, so the first job patches and the rest no-op. We restart ONLY
+              # the operator deployment — never the shared cloudwatch-agent, whose restart would drop
+              # other parallel jobs' in-flight telemetry.
+              # Concurrency: multiple version jobs may reach this at once. A `get | jq | apply` pipeline
+              # carries the read resourceVersion and loses to a sibling job's concurrent write with
+              # "Operation cannot be fulfilled ... the object has been modified". Since every job writes
+              # the SAME target image, we retry: re-read each attempt, treat "already target" as done,
+              # and only patch when it differs. This converges regardless of who wins the race.
+              patched=0
+              for patch_attempt in 1 2 3 4 5 6; do
+                CURRENT_PY_IMAGE=$(kubectl get deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager \
+                  -o jsonpath='{range .spec.template.spec.containers[0].args[*]}{.}{"\n"}{end}' \
+                  | sed -n 's/^--auto-instrumentation-python-image=//p')
+                if [ "$CURRENT_PY_IMAGE" = "${{ env.PATCH_IMAGE_ARN }}" ]; then
+                  echo "Operator python image is set to target (${{ env.PATCH_IMAGE_ARN }})."
+                  patched=1
+                  break
+                fi
+                echo "Attempt $patch_attempt: patching operator python image '$CURRENT_PY_IMAGE' -> '${{ env.PATCH_IMAGE_ARN }}'"
+                if kubectl get deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager -o json \
+                    | jq '.spec.template.spec.containers[0].args |= map(if test("^--auto-instrumentation-python-image=") then "--auto-instrumentation-python-image=${{ env.PATCH_IMAGE_ARN }}" else . end)' \
+                    | kubectl apply -f - ; then
+                  echo "Patch applied on attempt $patch_attempt."
+                  patched=1
+                  break
+                fi
+                echo "Patch attempt $patch_attempt lost a concurrent write; re-reading and retrying..."
+                sleep 10
+              done
+              if [ "$patched" -ne 1 ]; then
+                echo "Failed to set operator python image after retries."
+                exit 1
+              fi
+
+              # Wait for the operator to be rolled out and serving before restarting pods. Otherwise
+              # pods can come up Ready but WITHOUT instrumentation injected (uninstrumented app -> zero
+              # telemetry -> empty validator results). The injection-verification loop below is the
+              # authoritative gate if the rollout status is slow.
+              kubectl -n amazon-cloudwatch rollout status \
+                deployment/amazon-cloudwatch-observability-controller-manager --timeout=180s \
+                || echo "Operator rollout wait timed out; continuing (injection is verified below)."
+
+              # Restart this namespace's pods so the operator injects instrumentation, then VERIFY
+              # injection took effect with the CORRECT (patched) image. A pod can become Ready WITHOUT
+              # being injected if the webhook was not serving when the pod was admitted. Under parallel
+              # load (jobs share the single operator/webhook) this race is real. If the auto-
+              # instrumentation init container is missing, or still carries a non-target image, we
+              # restart again until it appears with the patched image.
+              inject_verified=0
+              for inject_attempt in 1 2 3 4 5; do
+                execute_and_retry 2 "kubectl delete pods --all -n ${{ env.SAMPLE_APP_NAMESPACE }}" "" 60
+                execute_and_retry 2 "kubectl wait --for=condition=Ready --request-timeout '5m' pod --all -n ${{ env.SAMPLE_APP_NAMESPACE }}" "" 10
+                INJECTED_IMAGE=$(kubectl get pod -n ${{ env.SAMPLE_APP_NAMESPACE }} --selector=app=python-app \
+                  -o jsonpath='{.items[0].spec.initContainers[?(@.name=="opentelemetry-auto-instrumentation-python")].image}' 2>/dev/null || true)
+                if [ "$INJECTED_IMAGE" = "${{ env.PATCH_IMAGE_ARN }}" ]; then
+                  echo "Instrumentation injected with target image on attempt $inject_attempt: $INJECTED_IMAGE"
+                  inject_verified=1
+                  break
+                fi
+                echo "Instrumentation not yet injected with target image on attempt $inject_attempt (got: '${INJECTED_IMAGE:-none}', want: '${{ env.PATCH_IMAGE_ARN }}'); retrying restart..."
+                sleep 20
+              done
+              if [ "$inject_verified" -ne 1 ]; then
+                echo "Instrumentation was never injected with the target image after retries; failing so this is not a silent empty-telemetry pass."
+                exit 1
+              fi
             fi
           
             # If the deployment_failed is 1 then either the terraform deployment or the endpoint connection failed, so first destroy the
             # resources created from terraform and try again.
             if [ $deployment_failed -eq 1 ]; then
-              echo "Cleaning up Application Signal"
-              ${{ env.TEST_RESOURCES_FOLDER }}/enablement-script/clean-app-signals.sh \
-              ${{ env.CLUSTER_NAME }} \
-              ${{ env.E2E_TEST_AWS_REGION }} \
-              ${{ env.SAMPLE_APP_NAMESPACE }}
-
-              # Running clean-app-signal.sh removes the current cluster from the config. Update the cluster again for subsequent runs.
-              aws eks update-kubeconfig --name ${{ inputs.test-cluster-name }} --region ${{ env.E2E_TEST_AWS_REGION }}
-
+              # Do NOT run clean-app-signals.sh here: the Application Signals addon is cluster-wide and
+              # shared by the other parallel version jobs — deleting it would break them. Only tear down
+              # this version's own terraform resources.
               echo "Destroying terraform"
               terraform destroy -auto-approve \
+                -var='python_version=${{ env.PYTHON_VERSION }}'\
                 -var='test_id=${{ env.TESTING_ID }}' \
                 -var='aws_region=${{ env.E2E_TEST_AWS_REGION }}' \
                 -var='kube_directory_path=${{ github.workspace }}/.kube' \
@@ -283,30 +384,6 @@ jobs:
             fi
           done
 
-      - name: Get ECR to Patch
-        run: |
-          if [ "${{ env.REPOSITORY_NAME }}" = "amazon-cloudwatch-agent" ]; then
-            echo PATCH_IMAGE_ARN="${{ secrets.AWS_ECR_PRIVATE_REGISTRY }}/cwagent-integration-test:${{ github.sha }}" >> "$GITHUB_ENV"
-          elif [ "${{ env.REPOSITORY_NAME }}" = "amazon-cloudwatch-agent-operator" ]; then
-            echo PATCH_IMAGE_ARN="${{ vars.ECR_OPERATOR_STAGING_REPO }}:${{ env.CW_AGENT_OPERATOR_TAG }}" >> "$GITHUB_ENV"
-          elif [ "${{ env.REPOSITORY_NAME }}" = "aws-otel-python-instrumentation" ]; then
-            echo PATCH_IMAGE_ARN="${{ env.ADOT_IMAGE_NAME }}" >> "$GITHUB_ENV"
-          fi
-
-      - name: Patch Image and Check Diff
-        id: patch-image
-        uses: ./.github/workflows/actions/patch_image_and_check_diff
-        with:
-          repository: ${{ env.REPOSITORY_NAME }}
-          patch-image-arn: ${{ env.PATCH_IMAGE_ARN }}
-          sample-app-namespace: ${{ env.SAMPLE_APP_NAMESPACE }}
-
-      - name: Log Artifact Versions
-        run: |
-          echo "ADOT Image: Previous Version is: ${{ steps.patch-image.outputs.default-adot-image }}, Updated Version is: ${{ steps.patch-image.outputs.latest-adot-image }}";
-          echo "CW Agent Image: Previous Version is: ${{ steps.patch-image.outputs.default-cw-agent-image }}, Updated Version is: ${{ steps.patch-image.outputs.latest-cw-agent-image }}";
-          echo "CW Agent Operator Image: Previous Version is: ${{ steps.patch-image.outputs.default-cw-agent-operator-image }}, Updated Version is: ${{ steps.patch-image.outputs.latest-cw-agent-operator-image }}";
-          echo "Fluent Bit Image: Version is: ${{ steps.patch-image.outputs.fluent-bit-image }}";
 
       - name: Get Remote Service Deployment Name
         uses: ./.github/workflows/actions/execute_and_retry
@@ -420,22 +497,14 @@ jobs:
           fi
 
       # Clean up Procedures
+      # NOTE: the cluster-wide Application Signals addon is intentionally NOT removed here — it is
+      # shared by the other parallel version jobs and persists on the long-lived test cluster.
+      # This job cleans up only its own namespace (which also deletes its Instrumentation CR).
 
-      - name: Clean Up Application Signals
+      - name: Delete this version's sample app namespace
         if: always()
         continue-on-error: true
-        working-directory: enablement-script
-        run: |
-          ./clean-app-signals.sh \
-          ${{ inputs.test-cluster-name }} \
-          ${{ env.E2E_TEST_AWS_REGION }} \
-          ${{ env.SAMPLE_APP_NAMESPACE }}
-
-      # This step also deletes lingering resources from previous test runs
-      - name: Delete all sample app resources
-        if: always()
-        continue-on-error: true
-        run: kubectl delete namespace ${{ env.SAMPLE_APP_NAMESPACE }}
+        run: kubectl delete namespace ${{ env.SAMPLE_APP_NAMESPACE }} --ignore-not-found
 
       - name: Terraform destroy
         if: always()
@@ -444,6 +513,7 @@ jobs:
         working-directory: terraform/python/eks
         run: |
           terraform destroy -auto-approve \
+            -var='python_version=${{ env.PYTHON_VERSION }}'\
             -var='test_id=${{ env.TESTING_ID }}' \
             -var='aws_region=${{ env.E2E_TEST_AWS_REGION }}' \
             -var='kube_directory_path=${{ github.workspace }}/.kube' \

--- a/.github/workflows/python-eks-test.yml
+++ b/.github/workflows/python-eks-test.yml
@@ -77,10 +77,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: 'aws-observability/aws-application-signals-test-framework'
-          # TESTING: pin the checked-out terraform/scripts to the feature branch instead of 'main'
-          # so the python_version variable and other EKS-test-fix changes are present. REVERT to
-          # the original `... && 'main' || github.ref` line before merge.
-          ref: ${{ inputs.caller-workflow-name == 'main-build' && 'EKS-test-fix' || github.ref }}
+          ref: ${{ inputs.caller-workflow-name == 'main-build' && 'main' || github.ref }}
           fetch-depth: 0
 
         # We initialize Gradlew Daemon early on during the workflow because sometimes initialization
@@ -156,9 +153,7 @@ jobs:
         run: |
           echo "${{ github.workspace }}/eksctl" >> "$GITHUB_PATH"
 
-      # Delete only THIS version's namespace from a prior run. Do NOT bulk-delete all ns-* namespaces:
-      # parallel version jobs share the cluster, and deleting all ns-* would destroy other running
-      # jobs' namespaces mid-test.
+      # Delete only THIS version's namespace from a prior run. Do NOT bulk-delete all ns-* namespaces
       - name: Delete this version's sample app namespace if it lingers
         continue-on-error: true
         timeout-minutes: 5
@@ -266,33 +261,28 @@ jobs:
 
               aws eks update-kubeconfig --region ${{ env.E2E_TEST_AWS_REGION }} --name ${{ env.CLUSTER_NAME }}
 
-              # enable-app-signals.sh returns as soon as the addon is *requested*, while the addon is
-              # still CREATING. The operator (which performs injection) is deployed by the addon, so it
-              # is not serving until the addon reaches ACTIVE (typically 2-5 min). Wait for ACTIVE
-              # before touching the operator — otherwise the patch/rollout below races the install.
+              # enable-app-signals.sh returns as soon as the addon is requested, while the addon is still
+              # being created. The operator is not serving until the addon becomes active, so we need to 
+              #wait for the addon to become ACTIVE.
               execute_and_retry 30 \
                 "[ \"\$(aws eks describe-addon --cluster-name ${{ env.CLUSTER_NAME }} --addon-name amazon-cloudwatch-observability --region ${{ env.E2E_TEST_AWS_REGION }} --query 'addon.status' --output text)\" = ACTIVE ]" \
                 "" 20
 
               # Inject THIS test's ADOT image the same way the sequential (main) flow does: patch the
-              # operator's cluster-wide --auto-instrumentation-python-image arg. App Signals telemetry
-              # (Latency/Error/Fault metrics + EMF logs) comes from the operator's auto-monitor
-              # applying App Signals mode to injected pods — NOT from a per-namespace Instrumentation
-              # CR. A hand-built CR with empty env bypasses that and yields plain OTel tracing with no
-              # App Signals data, which is why custom CRs produced empty validator results.
+              # operator's cluster-wide --auto-instrumentation-python-image arg. 
               #
-              # This is parallel-safe: every python version job injects the SAME adot-image-name
-              # (the single staging image under test; the version differences live in the sample-app
-              # image, not the instrumentation image). So the shared operator arg is a value all jobs
-              # agree on, exactly like the shared addon. We only patch + roll out if the arg is not
+              # Every python version job injects the SAME adot-image-name (the single staging image 
+              # under test; the version differences live in the sample-app image, not the instrumentation image).
+               So the shared operator arg is a value all jobs agree on. We only patch + roll out if the arg is not
               # already the target value, so the first job patches and the rest no-op. We restart ONLY
               # the operator deployment — never the shared cloudwatch-agent, whose restart would drop
               # other parallel jobs' in-flight telemetry.
+              #
               # Concurrency: multiple version jobs may reach this at once. A `get | jq | apply` pipeline
               # carries the read resourceVersion and loses to a sibling job's concurrent write with
               # "Operation cannot be fulfilled ... the object has been modified". Since every job writes
               # the SAME target image, we retry: re-read each attempt, treat "already target" as done,
-              # and only patch when it differs. This converges regardless of who wins the race.
+              # and only patch when it differs. 
               patched=0
               for patch_attempt in 1 2 3 4 5 6; do
                 CURRENT_PY_IMAGE=$(kubectl get deploy -n amazon-cloudwatch amazon-cloudwatch-observability-controller-manager \
@@ -328,9 +318,7 @@ jobs:
                 || echo "Operator rollout wait timed out; continuing (injection is verified below)."
 
               # Restart this namespace's pods so the operator injects instrumentation, then VERIFY
-              # injection took effect with the CORRECT (patched) image. A pod can become Ready WITHOUT
-              # being injected if the webhook was not serving when the pod was admitted. Under parallel
-              # load (jobs share the single operator/webhook) this race is real. If the auto-
+              # injection took effect with the CORRECT (patched) image. If the auto-
               # instrumentation init container is missing, or still carries a non-target image, we
               # restart again until it appears with the patched image.
               inject_verified=0
@@ -356,9 +344,6 @@ jobs:
             # If the deployment_failed is 1 then either the terraform deployment or the endpoint connection failed, so first destroy the
             # resources created from terraform and try again.
             if [ $deployment_failed -eq 1 ]; then
-              # Do NOT run clean-app-signals.sh here: the Application Signals addon is cluster-wide and
-              # shared by the other parallel version jobs — deleting it would break them. Only tear down
-              # this version's own terraform resources.
               echo "Destroying terraform"
               terraform destroy -auto-approve \
                 -var='python_version=${{ env.PYTHON_VERSION }}'\

--- a/terraform/python/eks/main.tf
+++ b/terraform/python/eks/main.tf
@@ -113,12 +113,7 @@ resource "kubernetes_deployment_v1" "python_app_deployment" {
           app = "python-app"
         }
         annotations = {
-          # Opt into the CloudWatch Observability operator's auto-monitor injection. This applies
-          # Application Signals mode (OTEL_AWS_APPLICATION_SIGNALS_ENABLED etc.), which is what
-          # produces Latency/Error/Fault metrics and App Signals EMF logs. The specific ADOT image
-          # under test is selected cluster-wide by the workflow patching the operator's
-          # --auto-instrumentation-python-image arg. Parallel per-version isolation comes from unique
-          # namespaces + service names + NodePorts, not from a per-namespace Instrumentation CR.
+          # these annotations allow for OTel Python instrumentation
           "instrumentation.opentelemetry.io/inject-python" = "true"
         }
       }
@@ -209,12 +204,7 @@ resource "kubernetes_deployment_v1" "python_r_app_deployment" {
           app = "remote-app"
         }
         annotations = {
-          # Opt into the CloudWatch Observability operator's auto-monitor injection. This applies
-          # Application Signals mode (OTEL_AWS_APPLICATION_SIGNALS_ENABLED etc.), which is what
-          # produces Latency/Error/Fault metrics and App Signals EMF logs. The specific ADOT image
-          # under test is selected cluster-wide by the workflow patching the operator's
-          # --auto-instrumentation-python-image arg. Parallel per-version isolation comes from unique
-          # namespaces + service names + NodePorts, not from a per-namespace Instrumentation CR.
+          # these annotations allow for OTel Python instrumentation
           "instrumentation.opentelemetry.io/inject-python" = "true"
         }
       }
@@ -243,14 +233,7 @@ resource "kubernetes_service" "python_r_app_service" {
 
   metadata {
     # Name the remote Service after the remote DEPLOYMENT (python-remote-${test_id}) instead of a
-    # shared constant ("python-r-app-service"). Under parallel version jobs, multiple identically
-    # named Services made the cluster-wide CloudWatch agent resolve the caller's RemoteService to
-    # the ambiguous Service name ("python-r-app-service") instead of the deployment name the
-    # validator expects ({{remoteServiceDeploymentName}} = python-remote-${test_id}). Matching the
-    # Service name to the deployment name makes RemoteService resolve to python-remote-${test_id}
-    # regardless of whether the agent reports the Service or the workload -- both are now identical,
-    # and unique per version. The app reaches the remote by pod IP, so this rename does not affect
-    # the call path.
+    # shared constant ("python-r-app-service").
     name      = "python-remote-${var.test_id}"
     namespace = var.test_namespace
   }

--- a/terraform/python/eks/main.tf
+++ b/terraform/python/eks/main.tf
@@ -59,6 +59,20 @@ provider "kubectl" {
   load_config_file       = false
 }
 
+# Compute unique NodePorts per Python version so EKS test jobs can run in parallel
+# on the same cluster without "port is already allocated" collisions.
+locals {
+  version_offset = {
+    "3.10" = 0
+    "3.11" = 1
+    "3.12" = 2
+    "3.13" = 3
+    "3.14" = 4
+  }
+  main_node_port   = 30100 + lookup(local.version_offset, var.python_version, 1) * 2
+  remote_node_port = 30101 + lookup(local.version_offset, var.python_version, 1) * 2
+}
+
 data "template_file" "kubeconfig_file" {
   template = file("./kubeconfig.tpl")
   vars = {
@@ -99,7 +113,12 @@ resource "kubernetes_deployment_v1" "python_app_deployment" {
           app = "python-app"
         }
         annotations = {
-          # these annotations allow for OTel Python instrumentation
+          # Opt into the CloudWatch Observability operator's auto-monitor injection. This applies
+          # Application Signals mode (OTEL_AWS_APPLICATION_SIGNALS_ENABLED etc.), which is what
+          # produces Latency/Error/Fault metrics and App Signals EMF logs. The specific ADOT image
+          # under test is selected cluster-wide by the workflow patching the operator's
+          # --auto-instrumentation-python-image arg. Parallel per-version isolation comes from unique
+          # namespaces + service names + NodePorts, not from a per-namespace Instrumentation CR.
           "instrumentation.opentelemetry.io/inject-python" = "true"
         }
       }
@@ -160,7 +179,7 @@ resource "kubernetes_service" "python_app_service" {
       protocol    = "TCP"
       port        = 8080
       target_port = 8000
-      node_port   = 30100
+      node_port   = local.main_node_port
     }
   }
 }
@@ -190,7 +209,12 @@ resource "kubernetes_deployment_v1" "python_r_app_deployment" {
           app = "remote-app"
         }
         annotations = {
-          # these annotations allow for OTel Python instrumentation
+          # Opt into the CloudWatch Observability operator's auto-monitor injection. This applies
+          # Application Signals mode (OTEL_AWS_APPLICATION_SIGNALS_ENABLED etc.), which is what
+          # produces Latency/Error/Fault metrics and App Signals EMF logs. The specific ADOT image
+          # under test is selected cluster-wide by the workflow patching the operator's
+          # --auto-instrumentation-python-image arg. Parallel per-version isolation comes from unique
+          # namespaces + service names + NodePorts, not from a per-namespace Instrumentation CR.
           "instrumentation.opentelemetry.io/inject-python" = "true"
         }
       }
@@ -218,7 +242,16 @@ resource "kubernetes_service" "python_r_app_service" {
   depends_on = [kubernetes_deployment_v1.python_r_app_deployment]
 
   metadata {
-    name      = "python-r-app-service"
+    # Name the remote Service after the remote DEPLOYMENT (python-remote-${test_id}) instead of a
+    # shared constant ("python-r-app-service"). Under parallel version jobs, multiple identically
+    # named Services made the cluster-wide CloudWatch agent resolve the caller's RemoteService to
+    # the ambiguous Service name ("python-r-app-service") instead of the deployment name the
+    # validator expects ({{remoteServiceDeploymentName}} = python-remote-${test_id}). Matching the
+    # Service name to the deployment name makes RemoteService resolve to python-remote-${test_id}
+    # regardless of whether the agent reports the Service or the workload -- both are now identical,
+    # and unique per version. The app reaches the remote by pod IP, so this rename does not affect
+    # the call path.
+    name      = "python-remote-${var.test_id}"
     namespace = var.test_namespace
   }
   spec {
@@ -230,7 +263,7 @@ resource "kubernetes_service" "python_r_app_service" {
       protocol    = "TCP"
       port        = 8001
       target_port = 8001
-      node_port   = 30101
+      node_port   = local.remote_node_port
     }
   }
 }

--- a/terraform/python/eks/variables.tf
+++ b/terraform/python/eks/variables.tf
@@ -49,6 +49,10 @@ variable "python_remote_app_image" {
   default = "<ECR_IMAGE_LINK>:<TAG>"
 }
 
+variable "python_version" {
+  default = "3.10"
+}
+
 variable "account_id" {
   default = "<AWS_ACCOUNT_ID>"
 }


### PR DESCRIPTION
*Issue description:*
EKS tests run sequentially because we reuse the same cluster for all language versions supported for ADOT Python. Unfortunately the test suite is designed to run sequentially and many resources such as namespace, nodeport, and Application Signals addon are designed into the test suites to be used in a sequential manner. 

Refactoring of the EKS test pipeline and the related service-events test are necessary to parallelize the EKS tests.

*Description of changes:*
**Per-version resource isolation:** The most obvious immediate change needed to be made (NodePort thrashing was a known issue that forced sequentialization of EKS tests)

 - added python_version variable and a version_offset map to assign each version unique NodePorts (30100 + offset)
 - Namespace and TESTING_ID now include a per-version slug (py310, py311, …) so each job gets its own namespace
 - Renamed the remote k8s Service to match its deployment (python-remote-${test_id}) instead of a shared constant, so the CloudWatch agent resolves the RemoteService dimension to the expected per-version name 

**Changed how the test ADOT image is injected:**: Necessary to reduce redundant work as previously each test would inject its own  ADOT image, and to orchestrate an environment which allows for parallel EKS testing 
 - modified workflow away from patch_image_and_check_diff to patch the operator's cluster-wide --auto-instrumentation-python-image arg directly:
 -  Only applies the patch if the current value differs from the target, and retries if encountering a race condition (two jobs try to write at same time) to avoid erroring out.
 - Restarts only the operator deployment and the job's own namespace — never the shared CloudWatch agent.

**Added readiness/verification gates to remove race conditions on the shared operator:**:
 - Individual teardown of each job's own namespace (kubectl delete namespace <this-ns>) instead of the previous bulk delete of all ns-* namespaces, which would destroy sibling jobs' resources mid-run. 
 
 - Wait for the amazon-cloudwatch-observability addon to reach ACTIVE before use.
 - After restarting pods, verify the auto-instrumentation init container was injected with the target image before validating (fail loudly instead of silently validating an uninstrumented app).
- python-eks-service-events-test.yml: apply the same operator-image patch + injection verification, and never delete/reinstall the shared addon (deleting it breaks the CloudWatch agent and drops App Signals telemetry cluster-wide).



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
