### PR TITLE
test: tighten EKS OCB Environment and PlatformType validation

### DIFF
--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/aws-sdk-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/aws-sdk-call-log.mustache
@@ -2,7 +2,7 @@
   "EC2.AutoScalingGroup": "^eks-.+",
   "EC2.InstanceId": "^i-[A-Za-z0-9]{17}$",
   "Environment": "^eks:(default|{{platformInfo}}/{{appNamespace}})$",
-  "PlatformType": "^(Generic|AWS::EKS)$",
+  "PlatformType": "^AWS::EKS$",
   "Service": "^{{serviceName}}$",
   "Operation": "GET /aws-sdk-call",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"
@@ -11,7 +11,7 @@
   "EC2.AutoScalingGroup": "^eks-.+",
   "EC2.InstanceId": "^i-[A-Za-z0-9]{17}$",
   "Environment": "^eks:(default|{{platformInfo}}/{{appNamespace}})$",
-  "PlatformType": "^(Generic|AWS::EKS)$",
+  "PlatformType": "^AWS::EKS$",
   "Service": "^{{serviceName}}$",
   "Operation": "GET /aws-sdk-call",
   "RemoteService": "AWS::S3",

--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/aws-sdk-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/aws-sdk-call-metric.mustache
@@ -10,7 +10,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Latency
@@ -24,49 +24,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
-    -
-      name: RemoteOperation
-      value: GetBucketLocation
-    -
-      name: RemoteService
-      value: AWS::S3
-
--
-  metricName: Latency
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: Environment
-      value: ANY_VALUE
-
--
-  metricName: Latency
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: Environment
-      value: ANY_VALUE
-    -
-      name: RemoteService
-      value: AWS::S3
-
--
-  metricName: Latency
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteOperation
       value: GetBucketLocation
@@ -83,7 +41,49 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:default
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:default
+    -
+      name: RemoteOperation
+      value: GetBucketLocation
+    -
+      name: RemoteService
+      value: AWS::S3
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:default
     -
       name: RemoteService
       value: AWS::S3
@@ -106,7 +106,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteOperation
       value: GetBucketLocation
@@ -129,7 +129,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteOperation
       value: GetBucketLocation
@@ -155,7 +155,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Error
@@ -169,7 +169,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteOperation
       value: GetBucketLocation
@@ -186,7 +186,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Error
@@ -197,7 +197,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteService
       value: AWS::S3
@@ -211,7 +211,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteOperation
       value: GetBucketLocation
@@ -228,7 +228,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteService
       value: AWS::S3
@@ -251,7 +251,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteOperation
       value: GetBucketLocation
@@ -274,7 +274,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteOperation
       value: GetBucketLocation
@@ -300,7 +300,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Fault
@@ -314,7 +314,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteOperation
       value: GetBucketLocation
@@ -331,7 +331,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Fault
@@ -342,7 +342,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteService
       value: AWS::S3
@@ -356,7 +356,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteOperation
       value: GetBucketLocation
@@ -373,7 +373,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteService
       value: AWS::S3
@@ -396,7 +396,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteOperation
       value: GetBucketLocation
@@ -419,7 +419,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteOperation
       value: GetBucketLocation

--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/aws-sdk-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/aws-sdk-call-trace.mustache
@@ -17,7 +17,7 @@
     "EC2.AutoScalingGroup": "^eks-.+",
     "EKS.Cluster": "^{{platformInfo}}$",
     "K8s.Namespace": "^{{appNamespace}}",
-    "PlatformType": "^(Generic|AWS::EKS)$"
+    "PlatformType": "^AWS::EKS$"
   },
   "subsegments": [
     {
@@ -43,7 +43,7 @@
             "EC2.AutoScalingGroup": "^eks-.+",
             "EKS.Cluster": "^{{platformInfo}}$",
             "K8s.Namespace": "^{{appNamespace}}$",
-            "PlatformType": "^(Generic|AWS::EKS)$"
+            "PlatformType": "^AWS::EKS$"
           },
           "namespace": "^aws$"
         }

--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/client-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/client-call-log.mustache
@@ -2,7 +2,7 @@
   "EC2.AutoScalingGroup": "^eks-.+",
   "EC2.InstanceId": "^i-[A-Za-z0-9]{17}$",
   "Environment": "^eks:(default|{{platformInfo}}/{{appNamespace}})$",
-  "PlatformType": "^(Generic|AWS::EKS)$",
+  "PlatformType": "^AWS::EKS$",
   "Service": "^{{serviceName}}$",
   "Operation": "InternalOperation",
   "RemoteService": "local-root-client-call",

--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/client-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/client-call-metric.mustache
@@ -10,7 +10,7 @@
       value: GET /client-call
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Latency
@@ -21,7 +21,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Latency
@@ -35,7 +35,7 @@
       value: InternalOperation
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteService
       value: local-root-client-call
@@ -52,7 +52,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteService
       value: local-root-client-call
@@ -69,7 +69,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteService
       value: local-root-client-call
@@ -86,7 +86,7 @@
       value: GET /client-call
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Error
@@ -97,7 +97,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Error
@@ -111,7 +111,7 @@
       value: InternalOperation
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteService
       value: local-root-client-call
@@ -128,7 +128,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteService
       value: local-root-client-call
@@ -145,7 +145,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteService
       value: local-root-client-call
@@ -162,7 +162,7 @@
       value: GET /client-call
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Fault
@@ -173,7 +173,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Fault
@@ -187,7 +187,7 @@
       value: InternalOperation
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteService
       value: local-root-client-call
@@ -204,7 +204,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteService
       value: local-root-client-call
@@ -221,7 +221,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteService
       value: local-root-client-call

--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/client-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/client-call-trace.mustache
@@ -28,7 +28,7 @@
         "EC2.AutoScalingGroup": "^eks-.+",
         "EKS.Cluster": "^{{platformInfo}}$",
         "K8s.Namespace": "^{{appNamespace}}$",
-        "PlatformType": "^(Generic|AWS::EKS)$"
+        "PlatformType": "^AWS::EKS$"
       },
       "namespace": "^remote$"
     }

--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/outgoing-http-call-log.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/outgoing-http-call-log.mustache
@@ -2,7 +2,7 @@
   "EC2.AutoScalingGroup": "^eks-.+",
   "EC2.InstanceId": "^i-[A-Za-z0-9]{17}$",
   "Environment": "^eks:(default|{{platformInfo}}/{{appNamespace}})$",
-  "PlatformType": "^(Generic|AWS::EKS)$",
+  "PlatformType": "^AWS::EKS$",
   "Service": "^{{serviceName}}$",
   "Operation": "GET /outgoing-http-call",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"
@@ -11,7 +11,7 @@
   "EC2.AutoScalingGroup": "^eks-.+",
   "EC2.InstanceId": "^i-[A-Za-z0-9]{17}$",
   "Environment": "^eks:(default|{{platformInfo}}/{{appNamespace}})$",
-  "PlatformType": "^(Generic|AWS::EKS)$",
+  "PlatformType": "^AWS::EKS$",
   "Service": "^{{serviceName}}$",
   "Operation": "GET /outgoing-http-call",
   "RemoteService": "www.amazon.com",

--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/outgoing-http-call-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/outgoing-http-call-metric.mustache
@@ -10,7 +10,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Latency
@@ -24,35 +24,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
-    -
-      name: RemoteOperation
-      value: GET /
-    -
-      name: RemoteService
-      value: www.amazon.com
-
--
-  metricName: Latency
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: Environment
-      value: ANY_VALUE
-
--
-  metricName: Latency
-  namespace: {{metricNamespace}}
-  dimensions:
-    -
-      name: Service
-      value: {{serviceName}}
-    -
-      name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteOperation
       value: GET /
@@ -69,7 +41,35 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:default
+    -
+      name: RemoteOperation
+      value: GET /
+    -
+      name: RemoteService
+      value: www.amazon.com
+
+-
+  metricName: Latency
+  namespace: {{metricNamespace}}
+  dimensions:
+    -
+      name: Service
+      value: {{serviceName}}
+    -
+      name: Environment
+      value: eks:default
     -
       name: RemoteService
       value: www.amazon.com
@@ -86,7 +86,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Error
@@ -100,7 +100,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteOperation
       value: GET /
@@ -117,7 +117,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Error
@@ -128,7 +128,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteOperation
       value: GET /
@@ -145,7 +145,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteService
       value: www.amazon.com
@@ -162,7 +162,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Fault
@@ -176,7 +176,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteOperation
       value: GET /
@@ -193,7 +193,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Fault
@@ -204,7 +204,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteOperation
       value: GET /
@@ -221,7 +221,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteService
       value: www.amazon.com

--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/outgoing-http-call-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/outgoing-http-call-trace.mustache
@@ -17,7 +17,7 @@
     "EC2.AutoScalingGroup": "^eks-.+",
     "EKS.Cluster": "^{{platformInfo}}$",
     "K8s.Namespace": "^{{appNamespace}}",
-    "PlatformType": "^(Generic|AWS::EKS)$"
+    "PlatformType": "^AWS::EKS$"
   },
   "subsegments": [
     {
@@ -41,7 +41,7 @@
             "EC2.AutoScalingGroup": "^eks-.+",
             "EKS.Cluster": "^{{platformInfo}}$",
             "K8s.Namespace": "^{{appNamespace}}$",
-            "PlatformType": "^(Generic|AWS::EKS)$"
+            "PlatformType": "^AWS::EKS$"
           },
           "namespace": "^remote$"
         }

--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/remote-service-log.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/remote-service-log.mustache
@@ -2,7 +2,7 @@
   "EC2.AutoScalingGroup": "^eks-.+",
   "EC2.InstanceId": "^i-[A-Za-z0-9]{17}$",
   "Environment": "^eks:(default|{{platformInfo}}/{{appNamespace}})$",
-  "PlatformType": "^(Generic|AWS::EKS)$",
+  "PlatformType": "^AWS::EKS$",
   "Service": "^{{serviceName}}$",
   "Operation": "GET /remote-service",
   "Host": "^ip(-[0-9]{1,3}){4}.*$"
@@ -11,7 +11,7 @@
   "EC2.AutoScalingGroup": "^eks-.+",
   "EC2.InstanceId": "^i-[A-Za-z0-9]{17}$",
   "Environment": "^eks:(default|{{platformInfo}}/{{appNamespace}})$",
-  "PlatformType": "^(Generic|AWS::EKS)$",
+  "PlatformType": "^AWS::EKS$",
   "Service": "^{{serviceName}}$",
   "Operation": "GET /remote-service",
   "RemoteService": "{{remoteServiceDeploymentName}}",

--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/remote-service-metric.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/remote-service-metric.mustache
@@ -10,7 +10,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Latency
@@ -24,7 +24,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteOperation
       value: GET /healthcheck
@@ -38,7 +38,7 @@
   dimensions:
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: Operation
       value: GET /healthcheck
@@ -55,7 +55,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Latency
@@ -66,7 +66,7 @@
       value: {{remoteServiceDeploymentName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Latency
@@ -77,7 +77,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteService
       value: {{remoteServiceDeploymentName}}
@@ -91,7 +91,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteOperation
       value: GET /healthcheck
@@ -119,7 +119,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Error
@@ -133,7 +133,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteOperation
       value: GET /healthcheck
@@ -147,7 +147,7 @@
   dimensions:
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: Operation
       value: GET /healthcheck
@@ -164,7 +164,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Error
@@ -175,7 +175,7 @@
       value: {{remoteServiceDeploymentName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Error
@@ -186,7 +186,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteService
       value: {{remoteServiceDeploymentName}}
@@ -200,7 +200,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteOperation
       value: GET /healthcheck
@@ -228,7 +228,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Fault
@@ -242,7 +242,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteOperation
       value: GET /healthcheck
@@ -256,7 +256,7 @@
   dimensions:
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: Operation
       value: GET /healthcheck
@@ -273,7 +273,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Fault
@@ -284,7 +284,7 @@
       value: {{remoteServiceDeploymentName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
 
 -
   metricName: Fault
@@ -295,7 +295,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteService
       value: {{remoteServiceDeploymentName}}
@@ -309,7 +309,7 @@
       value: {{serviceName}}
     -
       name: Environment
-      value: ANY_VALUE
+      value: eks:default
     -
       name: RemoteOperation
       value: GET /healthcheck

--- a/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/remote-service-trace.mustache
+++ b/validator/src/main/resources/expected-data-template/java/eks-otlp-ocb/remote-service-trace.mustache
@@ -17,7 +17,7 @@
     "EC2.AutoScalingGroup": "^eks-.+",
     "EKS.Cluster": "^{{platformInfo}}$",
     "K8s.Namespace": "^{{appNamespace}}",
-    "PlatformType": "^(Generic|AWS::EKS)$"
+    "PlatformType": "^AWS::EKS$"
   },
   "subsegments": [
     {
@@ -41,7 +41,7 @@
             "EC2.AutoScalingGroup": "^eks-.+",
             "EKS.Cluster": "^{{platformInfo}}$",
             "K8s.Namespace": "^{{appNamespace}}$",
-            "PlatformType": "^(Generic|AWS::EKS)$"
+            "PlatformType": "^AWS::EKS$"
            },
           "namespace": "^remote$"
         }
@@ -65,7 +65,7 @@
     "EC2.AutoScalingGroup": "^eks-.+",
     "EKS.Cluster": "^{{platformInfo}}$",
     "K8s.Namespace": "^{{appNamespace}}",
-    "PlatformType": "^(Generic|AWS::EKS)$",
+    "PlatformType": "^AWS::EKS$",
     "K8s.Workload": "^{{remoteServiceDeploymentName}}$"
   },
   "subsegments": [


### PR DESCRIPTION
*Issue description:*
The `eks-otlp-ocb` expected-data templates still carried backward-compatibility looseness for the EKS `Environment` and `PlatformType` values, so the tests would pass on stale values.

*Description of changes:*
- `PlatformType` (trace/log): `^(Generic|AWS::EKS)$` → `^AWS::EKS$`
- `Environment` (metric): `ANY_VALUE` → `eks:default`

The metric validator matches dimension values exactly rather than by regex, so the literal `eks:default` is used, which is the value these tests observe. Verified that the existing template validation tests pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
