### PR TITLE
Revert "fixed a commenting issue that was breaking EKS tests (#673)"

### DIFF
--- a/.github/workflows/python-eks-test.yml
+++ b/.github/workflows/python-eks-test.yml
@@ -273,7 +273,7 @@ jobs:
               #
               # Every python version job injects the SAME adot-image-name (the single staging image 
               # under test; the version differences live in the sample-app image, not the instrumentation image).
-              # So the shared operator arg is a value all jobs agree on. We only patch + roll out if the arg is not
+               So the shared operator arg is a value all jobs agree on. We only patch + roll out if the arg is not
               # already the target value, so the first job patches and the rest no-op. We restart ONLY
               # the operator deployment — never the shared cloudwatch-agent, whose restart would drop
               # other parallel jobs' in-flight telemetry.


### PR DESCRIPTION
This reverts commit 92cf4dcc03d7c900467f50180182b61b82979b9f.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
