### PR TITLE
fix(java-lambda): raise e2e sample app timeout to 60s

### DIFF
--- a/terraform/java/lambda/lambda/main.tf
+++ b/terraform/java/lambda/lambda/main.tf
@@ -24,7 +24,7 @@ module "hello-lambda-function" {
   local_existing_package = "${var.layer_artifacts_directory}/java-function.zip"
 
   memory_size = 512
-  timeout     = 30
+  timeout     = 60
 
   layers = [aws_lambda_layer_version.sdk_layer[0].arn]
 


### PR DESCRIPTION
*Issue description:*
The java11 e2e leg was failing trace validation because the invocation was being killed at the function timeout before spans were exported:
```
  REPORT Duration: 30000.00 ms | Billed Duration: 30000 ms
         Memory Size: 512 MB | Status: timeout
```

*Description of changes:*
Raise timeout 30 -> 60s.

*Rollback procedure:*

We safely revert this commit if needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
