### PR TITLE
fix(java-lambda): raise e2e sample app memory to 1 GB to speed up cold start instead of increasing timeout

### DIFF
--- a/terraform/java/lambda/lambda/main.tf
+++ b/terraform/java/lambda/lambda/main.tf
@@ -23,8 +23,8 @@ module "hello-lambda-function" {
   create_package         = false
   local_existing_package = "${var.layer_artifacts_directory}/java-function.zip"
 
-  memory_size = 512
-  timeout     = 60
+  memory_size = 1024
+  timeout     = 30
 
   layers = [aws_lambda_layer_version.sdk_layer[0].arn]
 


### PR DESCRIPTION
*Issue description:*
Same issue as https://github.com/aws-observability/aws-application-signals-test-framework/pull/683

*Description of changes:*
APIGW timeout is still 30s, so instead increase memory to speed up cold-start.

*Rollback procedure:*

We safely revert this commit if needed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
